### PR TITLE
Fix corrupted license header in MainWindow.java

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/rGUI/client/windows/MainWindow.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/rGUI/client/windows/MainWindow.java
@@ -16,23 +16,6 @@
  * You should have received a copy of the GNU General Public License
  * along with Dicoogle.  If not, see <http://www.gnu.org/licenses/>.
  */
-                2008 João Pereira, Miguel Fonseca
- *              2007 Marco Pereira, Filipe Freitas
- *  This file is part of Dicoogle.
- *
- *  Dicoogle is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  Dicoogle is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with Dicoogle.  If not, see <http://www.gnu.org/licenses/>.
- */
 
 /*
  * MainWindow.java


### PR DESCRIPTION
Somehow, an outdated piece of a license header without proper comment delimitation was in this file.