### PR TITLE
Query provider selection in Information services

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/ImageServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/ImageServlet.java
@@ -30,6 +30,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 import javax.servlet.ServletOutputStream;
 
@@ -80,6 +82,8 @@ public class ImageServlet extends HttpServlet
 			response.sendError(400, "Invalid SOP Instance UID!");
 			return;
 		}
+		String[] providerArray = request.getParameterValues("provider");
+        List<String> providers = providerArray == null ? null : Arrays.asList(providerArray);
 		String sFrame = request.getParameter("frame");
 		if (sFrame == null)
 			sFrame = "0";
@@ -87,7 +91,7 @@ public class ImageServlet extends HttpServlet
 
 		// get the .dcm file for that SOP Instance UID
 		//File dcmFile = Information.getFileFromSOPInstanceUID(sopInstanceUID);
-		StorageInputStream dcmFile = Information.getFileFromSOPInstanceUID(sopInstanceUID);
+		StorageInputStream dcmFile = Information.getFileFromSOPInstanceUID(sopInstanceUID, providers);
 		
 		// if no .dcm file was found tell the client
 		if ((dcmFile == null))

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/TagsServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/TagsServlet.java
@@ -23,6 +23,8 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import javax.servlet.ServletOutputStream;
 import pt.ua.dicoogle.server.web.dicom.Information;
 
@@ -42,9 +44,12 @@ public class TagsServlet extends HttpServlet
 			response.sendError(400, "Invalid SOP Instance UID!");
 			return;
 		}
+        
+        String[] providerArray = request.getParameterValues("provider");
+        List<String> providers = providerArray == null ? null : Arrays.asList(providerArray);
 
 		// get the XML document containing the tags for that SOP Instance UID file
-		String xml = Information.getXMLTagListFromFile(sopInstanceUID);
+		String xml = Information.getXMLTagListFromFile(sopInstanceUID, providers);
 
 		// if no xml was retrieved, tell the client
 		if (xml == null)

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/jspf/studybrowser.jspf
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/jspf/studybrowser.jspf
@@ -63,7 +63,13 @@
 		var loading = Ladda.create(ca);
 		loading.start();
 		
-		var resp = $.get( "dictags?SOPInstanceUID="+image.uid, function( data ) {
+                var providerqs = '';
+                for (var i = 0 ; i < providers.length ; i++) {
+                    if (providers[i].selected) {
+                        providerqs += '&provider=' + providers[i].name;
+                    }
+                }
+		var resp = $.get( "dictags?SOPInstanceUID="+image.uid + providerqs, function( data ) {
 			//console.log("Executed");
 			
 			$("tag", data).each(function(){				


### PR DESCRIPTION
Resolves Issue bioinformatics-ua/dicoogle-pvt#11 and integrates the feature to the existing servlets and the web application.

* The services in `Information` now allow selective querying by passing a list of query plugin names.
* The `TagsServlet` and `ImageServlet` were updated to support them as well, by accepting "provider" query strings.
* In the web application, performing a data dump on an image will now only query the selected providers.