### PR TITLE
Add unindex web service

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
@@ -515,27 +515,47 @@ public class PluginController{
     }
 
     
-    
     public void unindex(URI path) {
-    	logger.info("Starting Indexing procedure for "+path.toString());
+    	logger.info("Starting unindexing procedure for "+path.toString());
+        this.doUnindex(path, this.getIndexingPlugins(true));
+    }
+
+    /** Issue the removal of indexed entries in a path from the given indexers.
+     * 
+     * @param path the URI of the directory or file to unindex
+     * @param indexProviders a collection of providers
+     */
+    public void unindex(URI path, Collection<String> indexProviders) {
+    	logger.info("Starting unindexing procedure for "+path.toString());
+        
+        if (indexProviders != null) {
+            List<IndexerInterface> indexers = new ArrayList<>();
+            for (String provider : indexProviders) {
+                indexers.add(this.getIndexerByName(provider, true));
+            }
+            this.doUnindex(path, indexers);
+        } else {
+            this.doUnindex(path, this.getIndexingPlugins(true));
+        }
+    }
+    
+    /** Issue an unindexation procedure to the given indexers.
+     * 
+     * @param path the URI of the directory or file to unindex
+     * @param indexProviders a collection of providers
+     */
+    private void doUnindex(URI path, Collection<IndexerInterface> indexers) {
         StorageInterface store = getStorageForSchema(path);
 
         if(store==null){ 
         	logger.error("No storage plugin detected");
         }
         
-        Collection<IndexerInterface> indexers = getIndexingPlugins(true);
-        ArrayList<Task<Report>> rettasks = new ArrayList<>();
-        
         for(IndexerInterface indexer : indexers){            
-        	
-        	boolean result = indexer.unindex(path);
-            
+        	indexer.unindex(path);
         }
-        logger.info("Finised firing all undexing plugins for "+path.toString());
-        
-    }       
-    
+        logger.info("Finished unindexing "+path.toString());
+    }    
     
     /*
      * Convinience method that calls index(URI) and runs the returned

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/DicoogleWeb.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/DicoogleWeb.java
@@ -51,6 +51,7 @@ import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlets.GzipFilter;
 
 import pt.ua.dicoogle.server.web.servlets.accounts.LogoutServlet;
+import pt.ua.dicoogle.server.web.servlets.management.UnindexServlet;
 import pt.ua.dicoogle.server.web.servlets.search.DumpServlet;
 import pt.ua.dicoogle.server.web.utils.LocalImageCache;
 
@@ -186,6 +187,7 @@ public class DicoogleWeb {
             createServletHandler(new ProvidersServlet(), "/providers"),
             createServletHandler(new DicomSettingsServlet(), "/management/settings/dicom/query"),
             createServletHandler(new ForceIndexing(), "/management/tasks/index"),
+            createServletHandler(new UnindexServlet(), "/management/tasks/unindex"),
             createServletHandler(new ServicesServlet(ServicesServlet.STORAGE), "/management/dicom/storage"),
             createServletHandler(new ServicesServlet(ServicesServlet.QUERY), "/management/dicom/query"),
             createServletHandler(new ServicesServlet(ServicesServlet.PLUGIN), "/management/plugins/"),

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/management/UnindexServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/management/UnindexServlet.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (C) 2014  Universidade de Aveiro, DETI/IEETA, Bioinformatics Group - http://bioinformatics.ua.pt/
+ *
+ * This file is part of Dicoogle/dicoogle.
+ *
+ * Dicoogle/dicoogle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Dicoogle/dicoogle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Dicoogle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pt.ua.dicoogle.server.web.servlets.management;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import pt.ua.dicoogle.plugins.PluginController;
+
+/** Unindexer servlet.
+ * 
+ * @author Eduardo Pinho <eduardopinho@ua.pt>
+ */
+public class UnindexServlet extends HttpServlet {
+
+    private static final Logger logger = Logger.getLogger(UnindexServlet.class.getName());
+    
+    /**
+     */
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+
+        // Getting Parameters.
+        String[] uris = req.getParameterValues("uri");
+        String[] providerArr = req.getParameterValues("provider");
+
+        List<String> providers = providerArr != null ? Arrays.asList(providerArr) : null;
+
+        if (uris == null) {
+            resp.sendError(400, "No uri provided");
+            return;
+        }
+
+        URI[] effUris = new URI[uris.length];
+        try {
+            for (int i = 0 ; i < effUris.length ; i++) {
+                effUris[i] = new URI(uris[i]);
+            }
+        } catch (URISyntaxException ex) {
+            logger.log(Level.INFO, "Received bad URI", ex);
+            resp.sendError(400, "Bad URI: " + ex.getInput());
+            return;
+        }
+
+        // unindex
+        for (URI uri : effUris) {
+            try {
+                PluginController.getInstance().unindex(uri, providers);
+            } catch (RuntimeException ex) {
+                logger.log(Level.SEVERE, ex.getMessage(), ex);
+            }
+        }
+
+        logger.log(Level.INFO, "Finished unindexing {0}", Arrays.asList(uris));
+        resp.setStatus(200);
+    }
+}


### PR DESCRIPTION
Fixes #38 - Added an unindex operation:

**POST** `/management/task/unindex`
  - _uri_ : one of many URI path(s) to unindex
  - _provider_ : optional, the indexer providers to be issued (all by default)