### PR TITLE
Add Raven for Sentry support

### DIFF
--- a/dicoogle/pom.xml
+++ b/dicoogle/pom.xml
@@ -329,5 +329,10 @@
                     <version>2.2</version>
                 </dependency>
 
-	</dependencies>
+                <dependency>
+                    <groupId>net.kencochrane.raven</groupId>
+                    <artifactId>raven-log4j2</artifactId>
+                    <version>5.0.2</version>
+                </dependency>
+        </dependencies>
 </project>

--- a/dicoogle/src/main/resources/log4j2_sentry.xml
+++ b/dicoogle/src/main/resources/log4j2_sentry.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration packages="org.apache.logging.log4j.core,net.kencochrane.raven.log4j2">
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout pattern="%-5p %C{2} (%F:%L) - %m%n"/>
+        </Console>
+        <File name="File" fileName="dicoogle.log" bufferedIO="true">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} | %-5p [%t] %C{2} (%F:%L) - %m%n"/>
+        </File>
+        <Raven name="Sentry">
+            <dsn>
+                <!-- fill in the address before using -->
+                https://publicKey:secretKey@host:port/1?options
+            </dsn>
+            <tags>
+            </tags>
+            <!--
+                Optional, allows to select the ravenFactory
+            -->
+            <!--
+            <ravenFactory>
+                net.kencochrane.raven.DefaultRavenFactory
+            </ravenFactory>
+            -->
+        </Raven>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="STDOUT" />
+            <AppenderRef ref="File" />
+            <AppenderRef ref="Sentry" level="error" />
+        </Root>
+        <Logger level="debug" name="pt.ua.dicoogle.*" additivity="false">
+            <AppenderRef ref="STDOUT" level="info" />
+            <AppenderRef ref="File" level="debug" />
+        </Logger>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
I added Raven v5 to Dicoogle, which will provide support for Sentry v6.4.x. Since we are already using log4j2 as the backend, configuring the client is as simple as adding a new `<Raven>` appender (there is an example in "dicoogle/src/main/resources/log4j2_sentry.xml").

Solves #40 