### PR TITLE
Settings access from SDK

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/core/QueryResultRecord.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/core/QueryResultRecord.java
@@ -22,6 +22,7 @@ package pt.ua.dicoogle.core;
 /**
  *
  * @author carloscosta
+ * @MarkedForDeath currently unused
  */
 public class QueryResultRecord {
     private String patientName;

--- a/dicoogle/src/main/java/pt/ua/dicoogle/core/ServerSettings.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/core/ServerSettings.java
@@ -18,6 +18,7 @@
  */
 package pt.ua.dicoogle.core;
 
+import pt.ua.dicoogle.sdk.datastructs.MoveDestination;
 import java.net.*;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -27,18 +28,20 @@ import java.util.HashSet;
 import java.util.concurrent.ConcurrentHashMap;
 import org.dcm4che2.data.UID;
 import org.slf4j.LoggerFactory;
+import pt.ua.dicoogle.sdk.core.ServerSettingsReader;
+import pt.ua.dicoogle.sdk.core.WebSettingsReader;
 
 import pt.ua.dicoogle.server.web.utils.types.DataTable;
 
-/**
+/** Singleton class of all server settings.
  *
  * @author Marco Pereira
  * @author Luís A. Bastião Silva <bastiao@ua.pt>
  * @author António Novo <antonio.novo@ua.pt>
+ * @author Eduardo Pinho <eduardopinho@ua.pt>
  * @see XMLSupport
- * 
  */
-public class ServerSettings
+public class ServerSettings implements ServerSettingsReader
 {
     private String AETitle;
 
@@ -153,29 +156,26 @@ public class ServerSettings
     /* DEFAULT Connection timeout (in sec) */
     private int connectionTimeout ;
     
-    
     private int maxMessages = 2000;
     private String SOPClass  ; 
     private String transfCAP ; 
     
      /* DEFAULT Max Client Associations */
-    private int MAX_CLIENT_ASSOCS  ; 
+    private int maxClientAssocs  ; 
    
-    private int MAX_PDU_LENGTH_RECEIVE ;
-    private int MAX_PDU_LENGTH_SEND ;
+    private int maxPDULengthReceive ;
+    private int maxPDULengthSend ;
 
 
-    HashMap<String, String> modalityFind = new HashMap<String, String>();
+    HashMap<String, String> modalityFind = new HashMap<>();
 
-    ArrayList<MoveDestination> dest = new ArrayList<MoveDestination>();
+    ArrayList<MoveDestination> dest = new ArrayList<>();
 
     private boolean indexAnonymous = false;
 
     private boolean indexZIPFiles = true;
     
     private boolean monitorWatcher = false;
-    
-
 
     /**
      * P2P
@@ -190,7 +190,7 @@ public class ServerSettings
     /** Indexer */
     private String indexer = "lucene2.2";
     private int indexerEffort = 0 ;
-    private HashSet<String> extensionsAllowed = new HashSet();
+    private HashSet<String> extensionsAllowed = new HashSet<>();
 
     private boolean gzipStorage = false;
     private final String aclxmlFileName = "aetitleFilter.xml";
@@ -198,6 +198,7 @@ public class ServerSettings
     /**
      * @return the web
      */
+    @Override
     public Web getWeb()
     {
         return web;
@@ -228,6 +229,7 @@ public class ServerSettings
     /**
      * @return the indexer
      */
+    @Override
     public String getIndexer() {
         return indexer;
     }
@@ -242,6 +244,7 @@ public class ServerSettings
     /**
      * @return the nodeName
      */
+    @Override
     public String getNodeName() {
         return nodeName;
     }
@@ -256,6 +259,7 @@ public class ServerSettings
     /**
      * @return the nodeNameDefined
      */
+    @Override
     public boolean isNodeNameDefined() {
         return nodeNameDefined;
     }
@@ -267,6 +271,7 @@ public class ServerSettings
         this.nodeNameDefined = nodeNameDefined;
     }
 
+    @Override
     public String getNetworkInterfaceName()
     {
         return networkInterfaceName;
@@ -281,6 +286,7 @@ public class ServerSettings
     /**
      * @return the indexerEffort
      */
+    @Override
     public int getIndexerEffort() {
         return indexerEffort;
     }
@@ -295,6 +301,7 @@ public class ServerSettings
     /**
      * @return the encryptUsersFile
      */
+    @Override
     public boolean isEncryptUsersFile() {
         return encryptUsersFile;
     }
@@ -309,6 +316,7 @@ public class ServerSettings
     /**
      * @return the indexZIPFiles
      */
+    @Override
     public boolean isIndexZIPFiles() {
         return indexZIPFiles;
     }
@@ -339,6 +347,7 @@ public class ServerSettings
     /**
      * @return the monitorWatcher
      */
+    @Override
     public boolean isMonitorWatcher() {
         return monitorWatcher;
     }
@@ -353,6 +362,7 @@ public class ServerSettings
     /**
      * @return the indexAnonymous
      */
+    @Override
     public boolean isIndexAnonymous() {
         return indexAnonymous;
     }
@@ -367,6 +377,7 @@ public class ServerSettings
     /**
      * @return the gzipStorage
      */
+    @Override
     public boolean isGzipStorage() {
         return gzipStorage;
     }
@@ -378,6 +389,7 @@ public class ServerSettings
         this.gzipStorage = gzipStorage;
     }
 
+    @Override
     public String getAccessListFileName() {
         return this.aclxmlFileName;
     }
@@ -385,13 +397,15 @@ public class ServerSettings
     /**
      * Web (including web server, webservices, etc)
      */
-    public class Web
+    public class Web implements WebSettingsReader
     {
-
         private boolean webServer = true;
-        private boolean webServices = false;
+        private int serverPort = 8080;
+        private String accessControlAllowOrigins = null;
 
-        private int serverPort = 8080 ;
+        @Deprecated
+        private boolean webServices = false;
+        @Deprecated
         private int servicePort = 6060;
 
         public Web()
@@ -401,6 +415,7 @@ public class ServerSettings
         /**
          * @return the webServer
          */
+        @Override
         public boolean isWebServer() {
             return webServer;
         }
@@ -415,6 +430,7 @@ public class ServerSettings
         /**
          * @return the webServices
          */
+        @Deprecated
         public boolean isWebServices() {
             return webServices;
         }
@@ -422,6 +438,7 @@ public class ServerSettings
         /**
          * @param webServices the webServices to set
          */
+        @Deprecated
         public void setWebServices(boolean webServices) {
             this.webServices = webServices;
         }
@@ -429,6 +446,7 @@ public class ServerSettings
         /**
          * @return the serverPort
          */
+        @Override
         public int getServerPort() {
             return serverPort;
         }
@@ -443,6 +461,7 @@ public class ServerSettings
         /**
          * @return the servicePort
          */
+        @Deprecated
         public int getServicePort() {
             return servicePort;
         }
@@ -450,13 +469,23 @@ public class ServerSettings
         /**
          * @param servicePort the servicePort to set
          */
+        @Deprecated
         public void setServicePort(int servicePort) {
             this.servicePort = servicePort;
+        }
+        
+        @Override
+        public String getAccessControlAllowOrigins() {
+            return this.accessControlAllowOrigins;
+        }
+
+        public void setAccessControlAllowOrigins(String accessControlAllowOrigins) {
+            this.accessControlAllowOrigins = accessControlAllowOrigins;
         }
 
     }
 
-    private Web web = new Web() ;
+    private Web web = new Web();
 
 	private boolean wanmode;
 
@@ -506,12 +535,12 @@ public class ServerSettings
         + "|" + UID.PatientRootQueryRetrieveInformationModelFIND;
                
         fillModalityFindDefault();
-        this.MAX_CLIENT_ASSOCS = 20 ; 
-        this.MAX_PDU_LENGTH_RECEIVE = 16364 ; 
-        this.MAX_PDU_LENGTH_SEND = 16364 ;
+        this.maxClientAssocs = 20 ; 
+        this.maxPDULengthReceive = 16364 ; 
+        this.maxPDULengthSend = 16364 ;
         System.setProperty("java.net.preferIPv4Stack", "true");
 
-	autoStartPlugin = new ConcurrentHashMap<String, Boolean>();
+        autoStartPlugin = new ConcurrentHashMap<>();
     }
 
     // Nasty bug fix; no thumbnails references here = null pointers
@@ -538,6 +567,7 @@ public class ServerSettings
         AETitle = AE;
     }
 
+    @Override
     public String getAE()
     {
         return AETitle;
@@ -548,6 +578,7 @@ public class ServerSettings
         ID = I;
     }
 
+    @Override
     public String getID()
     {
         return ID;
@@ -558,6 +589,7 @@ public class ServerSettings
         CAETitle = CAET;            
     }
 
+    @Override
     public String[] getCAET()
     {
         return CAETitle;
@@ -567,6 +599,7 @@ public class ServerSettings
         permitAllAETitles = value;
     }
 
+    @Override
     public boolean getPermitAllAETitles(){
         return permitAllAETitles;
     }
@@ -581,11 +614,13 @@ public class ServerSettings
         Path = p;
     }
 
+    @Override
     public String getPath()
     {
         return Path;
     }
 
+    @Override
     public int getStoragePort()
     {
         return storagePort;
@@ -601,6 +636,7 @@ public class ServerSettings
         return rGUIPort;
     }
 
+    @Override
     public String getDicoogleDir() {
         return dicoogleDir;
     }
@@ -610,6 +646,7 @@ public class ServerSettings
     }
 
 
+    @Override
     public boolean getFullContentIndex() {
         return fullContentIndex;
     }
@@ -618,6 +655,7 @@ public class ServerSettings
         this.fullContentIndex = fullContentIndex;
     }
 
+    @Override
     public boolean getSaveThumbnails() {
         return saveThumbnails;
     }
@@ -626,6 +664,7 @@ public class ServerSettings
         this.saveThumbnails = saveThumbnails;
     }
     
+    @Override
     public String getThumbnailsMatrix() {
         return thumbnailsMatrix;
     }
@@ -634,7 +673,7 @@ public class ServerSettings
         this.thumbnailsMatrix = thumbnailsMatrix;
     }
 
-    /**
+    /*
      * Query Retrieve Server
      */
 
@@ -643,6 +682,7 @@ public class ServerSettings
         this.wlsPort = port ;
     }
 
+    @Override
     public int getWlsPort()
     {
         return this.wlsPort ;
@@ -653,6 +693,7 @@ public class ServerSettings
         this.idleTimeout = timeout ;
     }
 
+    @Override
     public int getIdleTimeout()
     {
         return this.idleTimeout ;
@@ -663,6 +704,7 @@ public class ServerSettings
         this.rspDelay = delay ;
     }
 
+    @Override
     public int getRspDelay()
     {
         return this.rspDelay  ;
@@ -672,6 +714,7 @@ public class ServerSettings
     {
         this.acceptTimeout = timeout ;
     }
+    @Override
     public int getAcceptTimeout()
     {
         return this.acceptTimeout;
@@ -681,6 +724,7 @@ public class ServerSettings
     {
         this.connectionTimeout = timeout; 
     }
+    @Override
     public int getConnectionTimeout()
     {
         return this.connectionTimeout ;
@@ -691,6 +735,7 @@ public class ServerSettings
         this.SOPClass = SOPClass ;
     }
     
+    @Override
     public String[] getSOPClasses()
     {
         String []tmp = {
@@ -700,6 +745,7 @@ public class ServerSettings
         return tmp ; 
     }
 
+    @Override
     public String getSOPClass()
     {
         return this.SOPClass ; 
@@ -708,6 +754,7 @@ public class ServerSettings
     {
         this.DIMSERspTimeout = timeout ; 
     }
+    @Override
     public int getDIMSERspTimeout()
     {
         return this.DIMSERspTimeout ; 
@@ -717,6 +764,7 @@ public class ServerSettings
         this.deviceDescription = desc ; 
     }
     
+    @Override
     public String getDeviceDescription()
     {
         return this.deviceDescription;
@@ -727,62 +775,70 @@ public class ServerSettings
         this.transfCAP = transfCap;
     }
         
+    @Override
     public String getTransfCap()
     {
-        return this.transfCAP ; 
+        return this.transfCAP; 
     }
     
     public void setMaxClientAssoc(int maxClients)
     {
-        this.MAX_CLIENT_ASSOCS = maxClients ; 
+        this.maxClientAssocs = maxClients; 
     }
     
+    @Override
     public int getMaxClientAssoc()
     {
-        return this.MAX_CLIENT_ASSOCS ; 
+        return this.maxClientAssocs; 
     }
     
     public void setMaxPDULengthReceive(int len)
     {
-        this.MAX_PDU_LENGTH_RECEIVE = len ;
+        this.maxPDULengthReceive = len;
     }
     
+    @Override
     public int getMaxPDULengthReceive()
     {
-        return this.MAX_PDU_LENGTH_RECEIVE ; 
+        return this.maxPDULengthReceive; 
     }
     public void setMaxPDULengthSend(int len)
     {
-        this.MAX_PDU_LENGTH_SEND = len ;
+        this.maxPDULengthSend = len;
     }
-    public int getMaxPDULenghtSend()
+    @Override
+    public int getMaxPDULenghtSend() // FIXME typo
     {
-        return this.MAX_PDU_LENGTH_SEND; 
+        return this.maxPDULengthSend; 
     }
     
     public void setLocalAETName(String name)
     {
-        this.localAETName = name ; 
+        this.localAETName = name; 
     }
+    @Override
     public String getLocalAETName()
     {
-        return this.localAETName ; 
+        return this.localAETName; 
     }
     
     public void setPermitedLocalInterfaces(String localInterfaces)
     {
-        this.permitedLocalInterfaces  = localInterfaces ; 
+        this.permitedLocalInterfaces  = localInterfaces; 
     }
     
+    @Override
     public String getPermitedLocalInterfaces()
     {
-        return this.permitedLocalInterfaces ; 
+        return this.permitedLocalInterfaces; 
     }
     
     public void setPermitedRemoteHostnames(String remoteHostnames)
     {
-        this.permitedRemoteHostnames = remoteHostnames ; 
+        this.permitedRemoteHostnames = remoteHostnames; 
     }
+    
+    @Override
     public String getPermitedRemoteHostnames()
     {
         return this.permitedRemoteHostnames;
@@ -794,9 +850,11 @@ public class ServerSettings
    /* public boolean isP2P() {
         return P2P;
     }*/
+    @Override
     public boolean isStorage() {
         return storage;
     }
+    @Override
     public boolean isQueryRetrive() {
         return queryRetrieve;
     }
@@ -828,6 +886,7 @@ public class ServerSettings
     public boolean contains(MoveDestination m){
         return this.dest.contains(m);
     }
+    @Override
     public ArrayList<MoveDestination> getMoves()
     {
         return this.dest ;
@@ -873,7 +932,8 @@ public class ServerSettings
      *
      * @return HashMap with Modalitys FIND
      */
-    public HashMap getModalityFind()
+    @Override
+    public HashMap<String, String> getModalityFind()
     {
         return this.modalityFind;
     }
@@ -903,6 +963,7 @@ public class ServerSettings
      * @param name the name of the plugin.
      * @return true if the plugin is to be auto started on server init or false if it is not.
      */
+    @Override
     public boolean getAutoStartPlugin(String name)
     {
     	Boolean result = autoStartPlugin.get(name);
@@ -917,6 +978,7 @@ public class ServerSettings
 	 *
 	 * @return the current settings for plugin auto start on server init.
 	 */
+    @Override
 	public ConcurrentHashMap<String, Boolean> getAutoStartPluginsSettings()
 	{
 		return autoStartPlugin;
@@ -983,6 +1045,7 @@ public class ServerSettings
 	 *
 	 * @return and HashMap containing the Query Retrieve list of settings (name, value/type pairs).
 	 */
+    @Override
 	public HashMap<String, Object> getQueryRetrieveSettings()
 	{
 		HashMap<String, Object> result = new HashMap<String, Object>();
@@ -1047,6 +1110,7 @@ public class ServerSettings
 	 *
 	 * @return and HashMap containing the Storage list of settings (name, value/type pairs).
 	 */
+    @Override
 	public HashMap<String, Object> getStorageSettings()
 	{
 		HashMap<String, Object> result = new HashMap<>();
@@ -1128,6 +1192,7 @@ public class ServerSettings
         this.queryRetrieve = queryRetrieve;
     }
 
+    @Override
     public ArrayList<String> getNetworkInterfacesNames()
     {
         ArrayList<String> interfaces = new ArrayList<String>();
@@ -1164,6 +1229,7 @@ public class ServerSettings
         return interfaces;
     }
 
+    @Override
     public String getNetworkInterfaceAddress()
     {
         Enumeration<NetworkInterface> nets = null;
@@ -1210,6 +1276,7 @@ public class ServerSettings
 
 
 
+    @Override
     public HashSet<String> getExtensionsAllowed()
     {
         return extensionsAllowed;
@@ -1218,6 +1285,7 @@ public class ServerSettings
     /**
      * @return the maxMessages
      */
+    @Override
     public int getMaxMessages() {
         return maxMessages;
     }
@@ -1229,6 +1297,7 @@ public class ServerSettings
         this.maxMessages = maxMessages;
     }
 
+    @Override
 	public boolean isWANModeEnabled() {
 		// TODO Auto-generated method stub
 		return wanmode;

--- a/dicoogle/src/main/java/pt/ua/dicoogle/core/XMLSupport.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/core/XMLSupport.java
@@ -27,6 +27,7 @@ package pt.ua.dicoogle.core;
  */
 
 
+import pt.ua.dicoogle.sdk.datastructs.MoveDestination;
 import pt.ua.dicoogle.server.*;
 
 import java.io.*;

--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/DicooglePlatformProxy.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/DicooglePlatformProxy.java
@@ -21,12 +21,14 @@ package pt.ua.dicoogle.plugins;
 import java.net.URI;
 import java.util.Collection;
 import java.util.List;
+import pt.ua.dicoogle.core.ServerSettings;
 
 import pt.ua.dicoogle.sdk.IndexerInterface;
 import pt.ua.dicoogle.sdk.QueryInterface;
 import pt.ua.dicoogle.sdk.StorageInputStream;
 import pt.ua.dicoogle.sdk.StorageInterface;
 import pt.ua.dicoogle.sdk.core.DicooglePlatformInterface;
+import pt.ua.dicoogle.sdk.core.ServerSettingsReader;
 import pt.ua.dicoogle.sdk.datastructs.Report;
 import pt.ua.dicoogle.sdk.datastructs.SearchResult;
 import pt.ua.dicoogle.sdk.task.JointQueryTask;
@@ -40,7 +42,7 @@ import pt.ua.dicoogle.sdk.task.Task;
  */
 public class DicooglePlatformProxy implements DicooglePlatformInterface {
 
-    private PluginController pluginController;
+    private final PluginController pluginController;
     
     public DicooglePlatformProxy(PluginController pluginController){
         this.pluginController = pluginController;
@@ -90,48 +92,63 @@ public class DicooglePlatformProxy implements DicooglePlatformInterface {
         return pluginController.resolveURI(location);
     }
 
+    @Override
 	public Collection<StorageInterface> getStoragePlugins(boolean onlyEnabled) {
 		return pluginController.getStoragePlugins(onlyEnabled);
 	}
 
+    @Override
 	public StorageInterface getStorageForSchema(String schema) {
 		return pluginController.getStorageForSchema(schema);
 	}
 
+    @Override
 	public Collection<QueryInterface> getQueryPlugins(boolean onlyEnabled) {
 		return pluginController.getQueryPlugins(onlyEnabled);
 	}
 
+    @Override
 	public List<String> getQueryProvidersName(boolean enabled) {
 		return pluginController.getQueryProvidersName(enabled);
 	}
 
+    @Override
 	public QueryInterface getQueryProviderByName(String name,
 			boolean onlyEnabled) {
 		return pluginController.getQueryProviderByName(name, onlyEnabled);
 	}
 
+    @Override
 	public JointQueryTask queryAll(JointQueryTask holder, String query,
 			Object... parameters) {
 		return pluginController.queryAll(holder, query, parameters);
 	}
 
+    @Override
 	public Task<Iterable<SearchResult>> query(String querySource, String query,
 			Object... parameters) {
 		return pluginController.query(querySource, query, parameters);
 	}
 
+    @Override
 	public JointQueryTask query(JointQueryTask holder,
 			List<String> querySources, String query, Object... parameters) {
 		return pluginController.query(holder, querySources, query, parameters);
 	}
 
+    @Override
 	public List<Task<Report>> index(URI path) {
 		return pluginController.index(path);
 	}
 
+    @Override
 	public List<Report> indexBlocking(URI path) {
 		return pluginController.indexBlocking(path);
 	}
+
+    @Override
+    public ServerSettingsReader getSettings() {
+        return ServerSettings.getInstance();
+    }
     
 }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/rGUI/client/windows/DicomSend.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/rGUI/client/windows/DicomSend.java
@@ -35,7 +35,7 @@ import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.TreePath;
 
 import pt.ua.dicoogle.Main;
-import pt.ua.dicoogle.core.MoveDestination;
+import pt.ua.dicoogle.sdk.datastructs.MoveDestination;
 import pt.ua.dicoogle.rGUI.client.UserRefs;
 import pt.ua.dicoogle.rGUI.interfaces.controllers.IDicomSend;
 

--- a/dicoogle/src/main/java/pt/ua/dicoogle/rGUI/client/windows/QRServers.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/rGUI/client/windows/QRServers.java
@@ -44,7 +44,7 @@ import javax.swing.JTextField;
 
 import pt.ua.dicoogle.rGUI.interfaces.controllers.IQRServers;
 import pt.ua.dicoogle.Main;
-import pt.ua.dicoogle.core.MoveDestination;
+import pt.ua.dicoogle.sdk.datastructs.MoveDestination;
 import pt.ua.dicoogle.rGUI.client.AdminRefs;
 import pt.ua.dicoogle.rGUI.client.UIHelper.AllowBlankMaskFormatter;
 

--- a/dicoogle/src/main/java/pt/ua/dicoogle/rGUI/interfaces/controllers/IDicomSend.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/rGUI/interfaces/controllers/IDicomSend.java
@@ -21,7 +21,7 @@ package pt.ua.dicoogle.rGUI.interfaces.controllers;
 import java.rmi.Remote;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
-import pt.ua.dicoogle.core.MoveDestination;
+import pt.ua.dicoogle.sdk.datastructs.MoveDestination;
 
 /**
  *

--- a/dicoogle/src/main/java/pt/ua/dicoogle/rGUI/interfaces/controllers/IQRServers.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/rGUI/interfaces/controllers/IQRServers.java
@@ -19,7 +19,7 @@
 package pt.ua.dicoogle.rGUI.interfaces.controllers;
 
 import java.util.ArrayList;
-import pt.ua.dicoogle.core.MoveDestination;
+import pt.ua.dicoogle.sdk.datastructs.MoveDestination;
 import java.rmi.Remote;
 import java.rmi.RemoteException;
 

--- a/dicoogle/src/main/java/pt/ua/dicoogle/rGUI/server/controllers/DicomSend.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/rGUI/server/controllers/DicomSend.java
@@ -27,7 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import pt.ua.dicoogle.core.MoveDestination;
+import pt.ua.dicoogle.sdk.datastructs.MoveDestination;
 import pt.ua.dicoogle.core.ServerSettings;
 import pt.ua.dicoogle.rGUI.interfaces.controllers.IDicomSend;
 import pt.ua.dicoogle.server.queryretrieve.CallDCMSend;

--- a/dicoogle/src/main/java/pt/ua/dicoogle/rGUI/server/controllers/QRServers.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/rGUI/server/controllers/QRServers.java
@@ -25,7 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import pt.ua.dicoogle.core.MoveDestination;
+import pt.ua.dicoogle.sdk.datastructs.MoveDestination;
 import pt.ua.dicoogle.core.ServerSettings;
 
 /**

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/queryretrieve/CMoveServiceSCP.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/queryretrieve/CMoveServiceSCP.java
@@ -41,7 +41,7 @@ import pt.ua.dicoogle.core.exceptions.CFindNotSupportedException;
 import pt.ua.dicoogle.core.LogDICOM;
 import pt.ua.dicoogle.core.LogLine;
 import pt.ua.dicoogle.core.LogXML;
-import pt.ua.dicoogle.core.MoveDestination;
+import pt.ua.dicoogle.sdk.datastructs.MoveDestination;
 import pt.ua.dicoogle.server.DicomNetwork;
 import pt.ua.dicoogle.server.SearchDicomResult;
 import pt.ua.dicoogle.core.ServerSettings;

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/SettingsServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/SettingsServlet.java
@@ -20,7 +20,6 @@ package pt.ua.dicoogle.server.web;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.HashMap;
@@ -35,7 +34,7 @@ import org.apache.commons.lang3.StringUtils;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
-import pt.ua.dicoogle.core.MoveDestination;
+import pt.ua.dicoogle.sdk.datastructs.MoveDestination;
 import pt.ua.dicoogle.core.ServerSettings;
 import pt.ua.dicoogle.core.XMLSupport;
 import pt.ua.dicoogle.server.web.management.Dicoogle;
@@ -223,7 +222,6 @@ public class SettingsServlet extends HttpServlet
 					response.sendError(401,"No Moves Defined");
 					return;
 				}
-				
 				
 				ServerSettings set = ServerSettings.getInstance();
 				ArrayList<MoveDestination> nmoves = new ArrayList<MoveDestination>();

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/management/ServerStorageServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/management/ServerStorageServlet.java
@@ -27,7 +27,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import net.sf.json.JSONObject;
 import net.sf.json.JSONSerializer;
-import pt.ua.dicoogle.core.MoveDestination;
+import pt.ua.dicoogle.sdk.datastructs.MoveDestination;
 import pt.ua.dicoogle.core.ServerSettings;
 import pt.ua.dicoogle.core.XMLSupport;
 import pt.ua.dicoogle.server.web.utils.ResponseUtil;

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/core/DicooglePlatformInterface.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/core/DicooglePlatformInterface.java
@@ -48,8 +48,6 @@ import pt.ua.dicoogle.sdk.task.Task;
  */
 public interface DicooglePlatformInterface {
     
-    
-    
     /**
      * Get a implementation of the plugin name
      * @param name name of the plugin 
@@ -116,4 +114,9 @@ public interface DicooglePlatformInterface {
 	public List<Task<Report>> index(URI path);
 
 	public List<Report> indexBlocking(URI path);
+    
+    /** Obtain access to the server's settings.
+     * @return an object for read-only access to the settings
+     */
+    public ServerSettingsReader getSettings();
 }

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/core/ServerSettingsReader.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/core/ServerSettingsReader.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (C) 2014  Universidade de Aveiro, DETI/IEETA, Bioinformatics Group - http://bioinformatics.ua.pt/
+ *
+ * This file is part of Dicoogle/dicoogle-sdk.
+ *
+ * Dicoogle/dicoogle-sdk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Dicoogle/dicoogle-sdk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Dicoogle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pt.ua.dicoogle.sdk.core;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import pt.ua.dicoogle.sdk.datastructs.MoveDestination;
+
+/** A read-only interface for accessing server settings.
+ *
+ * @author Eduardo Pinho <eduardopinho@ua.pt>
+ */
+public interface ServerSettingsReader {
+
+    public WebSettingsReader getWeb();
+    
+    public String getAE();
+    
+    public int getAcceptTimeout();
+    
+    public String getAccessListFileName();
+    
+    public boolean getAutoStartPlugin(String name);
+
+    public ConcurrentMap<String,Boolean> getAutoStartPluginsSettings();
+    
+    public String[] getCAET();
+    
+    public int getConnectionTimeout();
+    
+    public int getDIMSERspTimeout();
+    
+    public String getDeviceDescription();
+    
+    public String getDicoogleDir();
+    
+    public Set<String> getExtensionsAllowed();
+    
+    public boolean getFullContentIndex();
+    
+    public String getID();
+    
+    public int getIdleTimeout();
+    
+    public String getIndexer();
+    
+    public String getNodeName();
+    
+    public boolean isNodeNameDefined();
+    
+    public String getNetworkInterfaceName();
+    
+    public int getIndexerEffort();
+    
+    public boolean isEncryptUsersFile();
+    
+    public boolean isIndexZIPFiles();
+    
+    public boolean isMonitorWatcher();
+    
+    public boolean isIndexAnonymous();
+    
+    public boolean isGzipStorage();
+    
+    public boolean getPermitAllAETitles();
+    
+    public String getPath();
+    
+    public int getStoragePort();
+    
+    public boolean getSaveThumbnails();
+    
+    public String getThumbnailsMatrix();
+    
+    public int getWlsPort();
+    
+    public int getRspDelay();
+    
+    public String[] getSOPClasses();
+    
+    public String getSOPClass();
+    
+    public String getTransfCap();
+    
+    public int getMaxClientAssoc();
+    
+    public int getMaxPDULengthReceive();
+    
+    public int getMaxPDULenghtSend();
+    
+    public String getLocalAETName();
+    
+    public String getPermitedLocalInterfaces();
+    
+    public String getPermitedRemoteHostnames();
+    
+    public boolean isStorage();
+    
+    public boolean isQueryRetrive();
+    
+    public boolean isWANModeEnabled();
+    
+    public int getMaxMessages();
+    
+    public String getNetworkInterfaceAddress();
+    
+    public List<String> getNetworkInterfacesNames();
+    
+    public Map<String, Object> getStorageSettings();
+    
+    public Map<String, Object> getQueryRetrieveSettings();
+    
+    public Map<String, String> getModalityFind();
+
+    public List<MoveDestination> getMoves();
+}
+

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/core/WebSettingsReader.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/core/WebSettingsReader.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2014  Universidade de Aveiro, DETI/IEETA, Bioinformatics Group - http://bioinformatics.ua.pt/
+ *
+ * This file is part of Dicoogle/dicoogle-sdk.
+ *
+ * Dicoogle/dicoogle-sdk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Dicoogle/dicoogle-sdk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Dicoogle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pt.ua.dicoogle.sdk.core;
+
+/** A read-only interface for accessing web server settings.
+ *
+ * @author Eduardo Pinho <eduardopinho@ua.pt>
+ */
+public interface WebSettingsReader {
+
+    public boolean isWebServer();
+    
+    public int getServerPort();
+    
+    public String getAccessControlAllowOrigins();
+}

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/MoveDestination.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/MoveDestination.java
@@ -28,15 +28,15 @@ public class MoveDestination implements Serializable
 {
     static final long serialVersionUID = 1L;
 
-    private String AETitle = null ;
-    private String ipAddrs = null ;
-    private int port ;
+    private final String AETitle;
+    private final String ipAddrs;
+    private final int port;
 
     public MoveDestination(String AETitle, String ipAddr, int port)
     {
-        this.AETitle = AETitle ;
-        this.ipAddrs = ipAddr ;
-        this.port = port ;
+        this.AETitle = AETitle;
+        this.ipAddrs = ipAddr;
+        this.port = port;
     }
 
     /**
@@ -50,10 +50,10 @@ public class MoveDestination implements Serializable
     /**
      * @param AETitle the AETitle to set
      */
-    public void setAETitle(String AETitle)
+/*    public void setAETitle(String AETitle)
     {
         this.AETitle = AETitle;
-    }
+    }*/
 
     /**
      * @return the ipAddrs
@@ -66,10 +66,10 @@ public class MoveDestination implements Serializable
     /**
      * @param ipAddrs the ipAddrs to set
      */
-    public void setIpAddrs(String ipAddrs)
+/*    public void setIpAddrs(String ipAddrs)
     {
         this.ipAddrs = ipAddrs;
-    }
+    } */
 
     /**
      * @return the port
@@ -82,10 +82,11 @@ public class MoveDestination implements Serializable
     /**
      * @param port the port to set
      */
-    public void setPort(int port)
+/*    public void setPort(int port)
     {
         this.port = port;
     }
+    */
 
     @Override
     public String toString()

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/MoveDestination.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/MoveDestination.java
@@ -1,14 +1,14 @@
 /**
  * Copyright (C) 2014  Universidade de Aveiro, DETI/IEETA, Bioinformatics Group - http://bioinformatics.ua.pt/
  *
- * This file is part of Dicoogle/dicoogle.
+ * This file is part of Dicoogle/dicoogle-sdk.
  *
- * Dicoogle/dicoogle is free software: you can redistribute it and/or modify
+ * Dicoogle/dicoogle-sdk is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Dicoogle/dicoogle is distributed in the hope that it will be useful,
+ * Dicoogle/dicoogle-sdk is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Dicoogle.  If not, see <http://www.gnu.org/licenses/>.
  */
-package pt.ua.dicoogle.core;
+package pt.ua.dicoogle.sdk.datastructs;
 
 import java.io.Serializable;
 


### PR DESCRIPTION
 - added read-only interfaces in the SDK for access to server settings
 - moved `MoveDestination` data structure to SDK
 - added AccessControllAllowOrigins property in web settings
 - deprecated a few more stuff

Although the SDK is modified, it does not break compatibility with existing plugins.