### PR TITLE
Fix corrupted PNG images in dic2png due to concurrency

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/ImageServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/ImageServlet.java
@@ -142,15 +142,15 @@ public class ImageServlet extends HttpServlet
                 {
                     try {
                         // get the requested frame as a PNG stream
-                        byte[] pngBytes = getPNGStream(imgFile, frame, thumbnail).toByteArray();
+                        ByteArrayOutputStream pngStream = getPNGStream(imgFile, frame, thumbnail);
                         // write the stream to the file
                         try (FileOutputStream fos = new FileOutputStream(cf)) {
-                            fos.write(pngBytes);
+                            pngStream.writeTo(fos);
                         }
                         response.setContentType("image/png");
-                        response.setContentLength(pngBytes.length);
+                        response.setContentLength(pngStream.size());
                         try(ServletOutputStream out = response.getOutputStream()) {
-                            out.write(pngBytes);
+                            pngStream.writeTo(out);
                         }
                     } catch (IOException ex) {
                         logger.error("Could not load cached image", ex);
@@ -179,13 +179,10 @@ public class ImageServlet extends HttpServlet
             }
 		} else {
             // if the cache is invalid or not running convert the image and return it "on-the-fly"
-
-            // get the requested frame as a PNG stream
             try {
                 ByteArrayOutputStream pngStream = getPNGStream(imgFile, frame, thumbnail);
                 response.setContentType("image/png"); // set the appropriate type for the PNG image
                 response.setContentLength(pngStream.size()); // set the image size
-                // write the PNG stream to the response output
                 try (ServletOutputStream out = response.getOutputStream()) {
                     pngStream.writeTo(out);
                     pngStream.flush();
@@ -197,7 +194,7 @@ public class ImageServlet extends HttpServlet
 		}
     }
     
-    private synchronized ByteArrayOutputStream getPNGStream(StorageInputStream imgFile, int frame, boolean thumbnail) throws IOException {
+    private ByteArrayOutputStream getPNGStream(StorageInputStream imgFile, int frame, boolean thumbnail) throws IOException {
         ByteArrayOutputStream pngStream;
         if (thumbnail) {
             int thumbSize;

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/dicom/Convert2PNG.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/dicom/Convert2PNG.java
@@ -55,7 +55,6 @@ public class Convert2PNG
         Iterator<ImageReader> it = ImageIO.getImageReadersByFormatName("DICOM"); // gets the first registered ImageReader that can read DICOM data
         
         ImageReader sReader = it.next();
-        
         return sReader;
     }
     
@@ -65,7 +64,6 @@ public class Convert2PNG
         Iterator<ImageWriter> it = ImageIO.getImageWritersByFormatName("PNG"); // gets the first registered ImageWriter that can write PNG data
         
         ImageWriter sWriter = it.next();
-        
         return sWriter;
     }
     
@@ -187,8 +185,6 @@ public class Convert2PNG
 	public static ByteArrayOutputStream DICOM2PNGStream(StorageInputStream dcmStream, int frameIndex) throws IOException {
 		// setup the PNG writer
 		ImageWriter writer = createImageWriter();
-		if (writer == null)
-			return null;
 
 		ImageWriteParam writeParams = writer.getDefaultWriteParam(); // and set the default params for it (height, weight, alpha)
 		writeParams.setProgressiveMode(ImageWriteParam.MODE_DEFAULT); // activate progressive mode (adam7), best for low bandwidth connections
@@ -234,8 +230,6 @@ public class Convert2PNG
         
 		// setup the PNG writer
 		ImageWriter writer = createImageWriter();
-		if (writer == null)
-			return null;
 
 		ImageWriteParam writeParams = writer.getDefaultWriteParam(); // and set the default params for it
 		writeParams.setProgressiveMode(ImageWriteParam.MODE_DEFAULT); // activate progressive mode (adam7), best for low bandwidth connections
@@ -266,8 +260,6 @@ public class Convert2PNG
 	{	
 		// setup the DICOM reader
         ImageReader reader = createDICOMImageReader();                
-		if (reader == null) // if no valid reader was found abort
-			return -1;
 	
 		try (ImageInputStream inStream = ImageIO.createImageInputStream(dcmFile.getInputStream())) {
 

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/dicom/Convert2PNG.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/dicom/Convert2PNG.java
@@ -31,7 +31,6 @@ import pt.ua.dicoogle.sdk.StorageInputStream;
 
 import java.awt.Image;
 import java.awt.image.BufferedImage;
-import java.io.File;
 import java.io.IOException;
 import java.io.ByteArrayOutputStream;
 import java.util.Iterator;
@@ -52,7 +51,7 @@ public class Convert2PNG
     private static ImageReader sReader;
     private static ImageWriter sWriter;
     
-    private static ImageReader getDICOMImageReader() {
+    private synchronized static ImageReader getDICOMImageReader() {
         if(sReader != null)
             return sReader; 
         
@@ -65,13 +64,13 @@ public class Convert2PNG
         return sReader;
     }
     
-    private static ImageWriter getImageWriter() {
+    private synchronized static ImageWriter getImageWriter() {
         if(sWriter != null)
             return sWriter; 
         
         ImageIO.scanForPlugins();
         
-        Iterator<ImageWriter> it = ImageIO.getImageWritersByFormatName("PNG"); // gets the first registered ImageReader that can read DICOM data
+        Iterator<ImageWriter> it = ImageIO.getImageWritersByFormatName("PNG"); // gets the first registered ImageWriter that can write PNG data
         
         sWriter = it.next();
         
@@ -246,9 +245,8 @@ public class Convert2PNG
 		if (writer == null)
 			return null;
 
-		ImageWriteParam writeParams = writer.getDefaultWriteParam(); // and set the default params for it (height, weight, alpha)
+		ImageWriteParam writeParams = writer.getDefaultWriteParam(); // and set the default params for it
 		writeParams.setProgressiveMode(ImageWriteParam.MODE_DEFAULT); // activate progressive mode (adam7), best for low bandwidth connections
-		
         BufferedImage image = ImageLoader.loadImage(dcmStream);
         
         image = scaleImage(image, width, height);
@@ -331,7 +329,6 @@ public class Convert2PNG
 
 		Image scaledImage = image.getScaledInstance(-1, height, Image.SCALE_SMOOTH); // scale the input, smooth scaled
 		BufferedImage result = new BufferedImage(scaledImage.getWidth(null), scaledImage.getHeight(null), BufferedImage.TYPE_INT_RGB); // create the output image
-
 		result.getGraphics().drawImage(scaledImage, 0, 0, null); // draw the scaled image onto the output
 
 		return result;

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/utils/LocalImageCache.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/utils/LocalImageCache.java
@@ -23,6 +23,9 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Set;
 import org.slf4j.LoggerFactory;
@@ -259,41 +262,43 @@ public class LocalImageCache extends Thread
 
     // delegating cache entry writing to the caller is bound to bring issues in the long run
     @Deprecated
-    public synchronized File getFile(String name, int frameNumber, boolean thumbnail) {
+    public synchronized File getFile(String name, int frameNumber, boolean thumbnail) throws IOException {
         return this.implGetFile(toFileName(name, frameNumber, thumbnail));
     }
 
     // delegating cache entry writing to the caller is bound to bring issues in the long run
     @Deprecated
-    public synchronized File getFile(String name, boolean thumbnail) {
+    public synchronized File getFile(String name, boolean thumbnail) throws IOException {
         return getFile(name, 1, thumbnail);
     }
 
     // delegating cache entry writing to the caller is bound to bring issues in the long run
     @Deprecated
-    public synchronized File getFile(String name, int frameNumber) {
+    public synchronized File getFile(String name, int frameNumber) throws IOException {
         return getFile(name, frameNumber, false);
     }
 
     // delegating cache entry writing to the caller is bound to bring issues in the long run
     @Deprecated
-    public synchronized File getFile(String name) {
+    public synchronized File getFile(String name) throws IOException {
         return getFile(name, 1, false);
     }
     
     // delegating cache entry writing to the caller is bound to bring issues in the long run
 	@Deprecated
-    public synchronized File getFileFromName(String fileName) {
+    public synchronized File getFileFromName(String fileName) throws IOException {
         return implGetFile(fileName);
     }
     
-	private File implGetFile(String fileName) {
+	private File implGetFile(String fileName) throws IOException {
 		// check if the file is currently being written to
+        Path thatFilePath = Paths.get(fileName);
 		for (File f : filesBeingWritten)
 		{
 			// and if it is, return a common handle for it (common so outside code can synchronize on it, same object, to allow other threads to wait for the write to finish)
-			if (f.getName().equalsIgnoreCase(fileName))
+			if (Files.isSameFile(f.toPath(), thatFilePath)) {
 				return f;
+            }
 		}
 
 		String absoluteFileName = cacheFolder + File.separator + fileName;
@@ -305,15 +310,8 @@ public class LocalImageCache extends Thread
 
 		// if it does not exist add it to the list of files being written (because new content is going to be written to it outside this class) and create the empty file
 		filesBeingWritten.add(f);
-		try
-		{
-			f.createNewFile();
-			f.deleteOnExit();
-		}
-		catch (IOException ex)
-		{
-			return null; // abort
-		}
+        f.createNewFile();
+        f.deleteOnExit();
 
 		// return the common handle to the currently created and empty file
 		return f;


### PR DESCRIPTION
There was a problem in the image servlet that lead to corrupted images and internal server errors in concurrent calls.