### PR TITLE
Redefine default fields in search servlet

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/core/dim/DIMGeneric.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/core/dim/DIMGeneric.java
@@ -77,7 +77,6 @@ public class DIMGeneric
      * @param arr
      */
     public DIMGeneric(Collection<SearchResult> arr) {
-            HashMap<String, Object> extra = null;
             //DebugManager.getInstance().debug("Looking search results: " + arr.size() );
 
             //int size = arr.size();
@@ -90,7 +89,7 @@ public class DIMGeneric
                  */
 
                 //SearchResult r = (SearchResult) arr.get(i);
-                extra = r.getExtraData();
+                HashMap<String, Object> extra = r.getExtraData();
 
                 /** Get data from Study */
                 String studyUID = toTrimmedString(extra.get("StudyInstanceUID"),false);
@@ -128,13 +127,13 @@ public class DIMGeneric
 
                 /** Verify if Patient already exists */
 
-                if (this.patientsHash.containsKey(patientName))
+                if (this.patientsHash.containsKey(patientID))
                 {
                     /**
                      * Patient Already exists, let's check studys
                      */
 
-                    Patient p = this.patientsHash.get(patientName);
+                    Patient p = this.patientsHash.get(patientID);
 
 
                     /**
@@ -144,18 +143,18 @@ public class DIMGeneric
                      * data will be added for the Study that already exists
                      */
 
-                    Study s = new Study(p,studyUID,studyDate) ;
+                    Study s = new Study(p,studyUID,studyDate);
                     s.setInstitutuionName(InstitutionName);
                     s.setAccessionNumber(AccessionNumber);
                     s.setStudyTime(studyTime);
                     s.setStudyID(studyID);
                     s.setStudyDescription(StudyDescription);
                     Serie serie = new Serie(s, serieUID, modality);
-                    if (serieNumber!=null)
+                    if (serieNumber != null)
                         serie.setSerieNumber((int)Float.parseFloat(serieNumber));
                     serie.setSeriesDescription(serieDescription);
                     serie.addImage(r.getURI(),sopInstUID);
-                    s.addSerie(serie) ;
+                    s.addSerie(serie);
                     p.addStudy(s);
                 }
                 else {
@@ -187,7 +186,7 @@ public class DIMGeneric
                      serie.addImage(r.getURI(),sopInstUID);
                      s.addSerie(serie);
                      this.patients.add(p);
-                     this.patientsHash.put(patientName, p);
+                     this.patientsHash.put(patientID, p);
                 }
             }
 

--- a/dicoogle/src/main/java/pt/ua/dicoogle/core/dim/DIMGeneric.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/core/dim/DIMGeneric.java
@@ -127,13 +127,13 @@ public class DIMGeneric
 
                 /** Verify if Patient already exists */
 
-                if (this.patientsHash.containsKey(patientID))
+                if (this.patientsHash.containsKey(patientName))
                 {
                     /**
                      * Patient Already exists, let's check studys
                      */
-
-                    Patient p = this.patientsHash.get(patientID);
+		    // Real data does not have Patient Id - sometimes.
+                    Patient p = this.patientsHash.get(patientName);
 
 
                     /**

--- a/dicoogle/src/main/java/pt/ua/dicoogle/core/dim/DIMGeneric.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/core/dim/DIMGeneric.java
@@ -186,7 +186,7 @@ public class DIMGeneric
                      serie.addImage(r.getURI(),sopInstUID);
                      s.addSerie(serie);
                      this.patients.add(p);
-                     this.patientsHash.put(patientID, p);
+                     this.patientsHash.put(patientName, p);
                 }
             }
 

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/search/SearchServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/search/SearchServlet.java
@@ -48,18 +48,26 @@ import pt.ua.dicoogle.sdk.task.JointQueryTask;
 import pt.ua.dicoogle.sdk.task.Task;
 
 /**
- * Search the DICOM metadata Perform queries on images. Return data in JSON
+ * Search the DICOM metadata, perform queries on images. Returns the data in JSON.
  *
  * @author Frederico Silva <fredericosilva@ua.pt>
+ * @author Eduardo Pinho <eduardopinho@ua.pt>
  */
 public class SearchServlet extends HttpServlet {
 
   private static final long serialVersionUID = 1L;
+  
+    private final Collection<String> DEFAULT_FIELDS = Arrays.asList(
+            "SOPInstanceUID", "StudyInstanceUID", "SeriesInstanceUID", "PatientID",
+            "PatientName",    "PatientSex",       "Modality",          "StudyDate",
+            "StudyID",        "StudyDescription", "SeriesNumber",      "SeriesDescription",
+            "InstitutionName");
+  
   	public enum SearchType {
 
       ALL, PATIENT;
   	}
-  	private SearchType searchType;
+  	private final SearchType searchType;
   	public SearchServlet(){
   		searchType = SearchType.ALL;
   	}
@@ -123,16 +131,11 @@ public class SearchServlet extends HttpServlet {
 
         HashMap<String, String> extraFields = new HashMap<>();
         if (actualFields == null) {
+            
             //attaches the required extrafields
-            extraFields.put("PatientID", "PatientID");
-            extraFields.put("SOPInstanceUID", "SOPInstanceUID");
-            extraFields.put("StudyInstanceUID", "StudyInstanceUID");
-            extraFields.put("SeriesInstanceUID", "SeriesInstanceUID");
-            extraFields.put("PatientName", "PatientName");
-            extraFields.put("Modality", "Modality");
-            extraFields.put("StudyDate", "StudyDate");
-            extraFields.put("StudyID", "StudyID");
-            extraFields.put("Thumbnail", "Thumbnail");
+            for (String field : DEFAULT_FIELDS) {
+                extraFields.put(field, field);
+            }
         } else {
             for (String f : actualFields) {
                 extraFields.put(f, f);
@@ -165,7 +168,9 @@ public class SearchServlet extends HttpServlet {
         
         if (results == null) {
             response.sendError(500, "Could not generate results!");
-            //return;
+            response.setContentType("application/json");
+            response.getWriter().append("{\"results\":[],\"error\":\"Could not generate results\"}");
+            return;
         }
 
         ArrayList<SearchResult> resultsArr = new ArrayList<>();


### PR DESCRIPTION
Fixes #88. Some fields listed on the search interface were not being requested at the servlet side. I also adjusted the in-memory generic DIM patient table structure to index patients by ID rather than name.