### PR TITLE
Plugin controller - propagate settings and platform to sub-plugins

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
@@ -179,6 +179,7 @@ public class PluginController{
                     set.getRestPlugins()
             );
             for (Collection interfaces : all) {
+                if (interfaces == null) continue;
                 for (Object o : interfaces) {
                     if (o instanceof PlatformCommunicatorInterface) {
                         ((PlatformCommunicatorInterface)o).setPlatformProxy(proxy);
@@ -201,8 +202,9 @@ public class PluginController{
                 set.getIndexPlugins(),
                 set.getQueryPlugins(),
                 set.getJettyPlugins()
-       );
+        );
         for (Collection<? extends DicooglePlugin> interfaces : all) {
+            if (interfaces == null) continue;
             for (DicooglePlugin p : interfaces) {
                 p.setSettings(holder);
             }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginFactory.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginFactory.java
@@ -25,29 +25,34 @@ import java.util.Collection;
 import net.xeoh.plugins.base.PluginManager;
 import net.xeoh.plugins.base.impl.PluginManagerFactory;
 import net.xeoh.plugins.base.util.PluginManagerUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import pt.ua.dicoogle.sdk.PluginSet;
 
-/**
+/** A collection of factory methods for retrieving Dicoogle plugins from a directory.
  * 
  * @author psytek
+ * @author Eduardo Pinho <eduardopinho@ua.pt>
  */
 
 public class PluginFactory {
-    //TODO:configurable directory
+    private static final Logger logger = LoggerFactory.getLogger(PluginFactory.class);
+    
     public static Collection<PluginSet> getPlugins(File pluginDirectory){
+        if (pluginDirectory == null) {
+            throw new NullPointerException("pluginDirectory");
+        }
+        if (!pluginDirectory.isDirectory()) {
+            throw new IllegalArgumentException("Plugin base must be a directory");
+        }
         PluginManager pm = PluginManagerFactory.createPluginManager();
-        System.err.println(pluginDirectory.getAbsolutePath());
+        logger.debug("Plugin Directory: {}", pluginDirectory.getAbsolutePath());
         pm.addPluginsFrom(pluginDirectory.toURI());
         PluginManagerUtil pmu = new PluginManagerUtil(pm);
         return pmu.getPlugins(PluginSet.class);
     }
     
      public static Collection<PluginSet> getPlugins(){
-        PluginManager pm = PluginManagerFactory.createPluginManager();
-        File path = new File("Plugins");
-        System.err.println(path.getAbsolutePath());
-        pm.addPluginsFrom(path.toURI());
-        PluginManagerUtil pmu = new PluginManagerUtil(pm);
-        return pmu.getPlugins(PluginSet.class);
+        return getPlugins(new File("Plugins"));
     }
 }


### PR DESCRIPTION
- Made it so that settings and the platform interface are propagated to plugins in a set (Query, Storage, Indexer and Servlet). Settings are not propagated to Rest Resources because they do not implement an interface for retrieving them.
- Refactored the plugin factory a bit.