### PR TITLE
Corrections to project poms

### DIFF
--- a/dicoogle/pom.xml
+++ b/dicoogle/pom.xml
@@ -2,17 +2,21 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>pt.ua.ieeta</groupId>
     <artifactId>dicoogle</artifactId>
-    <version>2.0</version>
     <packaging>jar</packaging>
-
     <name>dicoogle</name>
-    <url>http://maven.apache.org</url>
+    <url>http://www.dicoogle.com</url>
+    
+    <parent>
+        <groupId>pt.ua.ieeta</groupId>
+        <artifactId>dicoogle-all</artifactId>
+        <version>2.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.0.3.v20130506</jetty.version>
+        <log4j.version>2.2</log4j.version>
     </properties>
 
     <repositories>
@@ -219,7 +223,7 @@
         <dependency>
             <groupId>dcm4che</groupId>
             <artifactId>dcm4che-imageio</artifactId>
-            <version>2.0.27</version>
+            <version>${dcm4che.version}</version>
         </dependency>
 
         <dependency>
@@ -237,13 +241,13 @@
         <dependency>
             <groupId>pt.ua.ieeta</groupId>
             <artifactId>dicoogle-sdk</artifactId>
-            <version>2.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>pt.ua.ieeta</groupId>
             <artifactId>dicoogle-sdk-ext</artifactId>
-            <version>2.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -281,7 +285,7 @@
         <dependency>
             <groupId>org.restlet.jee</groupId>
             <artifactId>org.restlet.ext.servlet</artifactId>
-            <version>2.1.2</version>
+            <version>${restlet.version}</version>
         </dependency>
         <dependency>
             <groupId>com.emailreport</groupId>
@@ -328,19 +332,19 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.12</version>
+            <version>${slf4j.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.2</version>
+            <version>${log4j.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.2</version>
+            <version>${log4j.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,13 @@
   <version>2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>dicoogle-all</name>
+  
+    <properties>
+        <jetty.version>9.0.3.v20130506</jetty.version>
+        <restlet.version>2.1.2</restlet.version>
+        <dcm4che.version>2.0.27</dcm4che.version>
+        <slf4j.version>1.7.12</slf4j.version>
+    </properties>
     <build>
         <plugins>
             <plugin>

--- a/sdk-ext/pom.xml
+++ b/sdk-ext/pom.xml
@@ -2,13 +2,18 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>pt.ua.ieeta</groupId>
 	<artifactId>dicoogle-sdk-ext</artifactId>
-	<version>2.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
-
 	<name>dicoogle-sdk-ext</name>
-	<url>http://maven.apache.org</url>
+	<url>http://www.dicoogle.com</url>
+
+        <parent>
+            <groupId>pt.ua.ieeta</groupId>
+            <artifactId>dicoogle-all</artifactId>
+            <version>2.0-SNAPSHOT</version>
+            <relativePath>../pom.xml</relativePath>
+        </parent>
+
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -29,27 +34,35 @@
 		<finalName>${project.artifactId}</finalName>
 		<plugins>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-shade-plugin</artifactId>
-				<version>2.3</version>
-				<executions>
-					<execution>
-						<phase>package</phase>
-						<goals>
-							<goal>shade</goal>
-						</goals>
-						<configuration>
-							<artifactSet>
-								<excludes>
-									<exclude>org.dicoogle.sdk:dicoogle-sdk</exclude>
-								</excludes>
-							</artifactSet>
-						</configuration>
-					</execution>
-				</executions>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-shade-plugin</artifactId>
+                            <version>2.3</version>
+                            <executions>
+                                <execution>
+                                    <phase>package</phase>
+                                    <goals>
+                                        <goal>shade</goal>
+                                    </goals>
+                                    <configuration>
+                                            <artifactSet>
+                                                <excludes>
+                                                    <exclude>org.dicoogle.sdk:dicoogle-sdk</exclude>
+                                                </excludes>
+                                            </artifactSet>
+                                            <filters>
+                                                <filter>
+                                                    <artifact>*:*</artifact>
+                                                    <excludes>
+                                                        <exclude>**/*.SF</exclude>
+                                                        <exclude>**/*.DSA</exclude>
+                                                        <exclude>**/*.RSA</exclude>
+                                                    </excludes>
+                                                </filter>
+                                            </filters>
+                                    </configuration>
+                                </execution>
+                            </executions>
 			</plugin>
-
-
 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -57,7 +70,6 @@
                                 <version>2.3</version>
 				<configuration>
 					<systemProperties>
-
 					</systemProperties>
 				</configuration>
 			</plugin>
@@ -116,7 +128,7 @@
 		<dependency>
 			<groupId>pt.ua.ieeta</groupId>
 			<artifactId>dicoogle-sdk</artifactId>
-			<version>2.0-SNAPSHOT</version>
+                        <version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>dom4j</groupId>
@@ -127,7 +139,7 @@
                 <dependency>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
-                    <version>1.7.12</version>
+                    <version>${slf4j.version}</version>
                 </dependency>
 
 	</dependencies>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -2,17 +2,20 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>pt.ua.ieeta</groupId>
 	<artifactId>dicoogle-sdk</artifactId>
-	<version>2.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
-
 	<name>dicoogle-sdk</name>
-	<url>http://maven.apache.org</url>
+	<url>http://www.dicoogle.com</url>
+
+        <parent>
+            <groupId>pt.ua.ieeta</groupId>
+            <artifactId>dicoogle-all</artifactId>
+            <version>2.0-SNAPSHOT</version>
+            <relativePath>../pom.xml</relativePath>
+        </parent>
 
 	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-            <jetty.version>9.0.3.v20130506</jetty.version>
+            <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
 	<repositories>
@@ -132,13 +135,13 @@
 		<dependency>
 			<groupId>dcm4che</groupId>
 			<artifactId>dcm4che-core</artifactId>
-			<version>2.0.27</version>
+			<version>${dcm4che.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>dcm4che</groupId>
 			<artifactId>dcm4che-net</artifactId>
-			<version>2.0.27</version>
+			<version>${dcm4che.version}</version>
 		</dependency>
 
 		<dependency>
@@ -149,13 +152,13 @@
 		<dependency>
 			<groupId>org.restlet.jse</groupId>
 			<artifactId>org.restlet</artifactId>
-			<version>2.1.2</version>
+			<version>${restlet.version}</version>
 		</dependency>
 
 	       <dependency>
         	   	 <groupId>org.restlet.jse</groupId>
             		<artifactId>org.restlet.ext.json</artifactId>
-           	 	<version>2.1.2</version>
+           	 	<version>${restlet.version}</version>
         	</dependency>
 		<dependency>
 			<groupId>org.swinglabs</groupId>
@@ -182,7 +185,7 @@
                 <dependency>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
-                    <version>1.7.12</version>
+                    <version>${slf4j.version}</version>
                 </dependency>
                 
 	</dependencies>


### PR DESCRIPTION
- Updated pom files in sub-projects to have dicoogle-all as parent (properties and version are inherited)
- Replaced constant dependency version definitions with properties
- Fixed manifest signature issue when building everything: The sdk-ext was not excluding checks to the .SF, .DSA and .RSA files in the `shade` goal.