### PR TITLE
Added capability to have DICOM public nodes and with a description.

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/core/XMLSupport.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/core/XMLSupport.java
@@ -126,9 +126,11 @@ public class XMLSupport extends DefaultHandler
 
     private int port = 0 ;
     private String AETitle = null ;
-    private String IP = null ; 
-   
-    
+    private String IP = null ;
+    private String description;
+    private String isPublic;
+
+
     private String currentService;
     
     private SOPList list;
@@ -143,6 +145,7 @@ public class XMLSupport extends DefaultHandler
     
     private boolean isIndexAnonymous = false;
 	private boolean isWANModeEnabled = false;
+    
     
     
     public XMLSupport()
@@ -356,8 +359,20 @@ public class XMLSupport extends DefaultHandler
             this.AETitle = this.resolveAttrib("ae", attribs, localName);
             this.port = Integer.parseInt(this.resolveAttrib("port", attribs, localName));
             this.IP = this.resolveAttrib("ip", attribs, localName);
+            this.description = this.resolveAttrib("description", attribs, "");
+            this.isPublic = this.resolveAttrib("public", attribs, "false");
 
             MoveDestination tmp = new MoveDestination(this.AETitle, this.IP, this.port)  ;
+            tmp.setDescription(description);
+            if (isPublic.contains("true"))
+            {
+                tmp.setIsPublic(true);
+            }
+            else
+            {
+                tmp.setIsPublic(false);
+            }
+            
             s.add(tmp);
 
         }
@@ -1549,6 +1564,9 @@ public class XMLSupport extends DefaultHandler
                 atts.clear();
                 atts.addAttribute("", "", "ae", "", m.getAETitle());
                 atts.addAttribute("", "", "ip", "", m.getIpAddrs());
+                atts.addAttribute("", "", "description", "", m.getDescription());
+                atts.addAttribute("", "", "public", "",Boolean.toString(m.isIsPublic()));
+
                 atts.addAttribute("", "", "port", "", String.valueOf(m.getPort()));
 
                 hd.startElement("", "", "dest", atts);

--- a/dicoogle/src/main/java/pt/ua/dicoogle/core/XMLSupport.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/core/XMLSupport.java
@@ -362,19 +362,9 @@ public class XMLSupport extends DefaultHandler
             this.description = this.resolveAttrib("description", attribs, "");
             this.isPublic = this.resolveAttrib("public", attribs, "false");
 
-            MoveDestination tmp = new MoveDestination(this.AETitle, this.IP, this.port)  ;
-            tmp.setDescription(description);
-            if (isPublic.contains("true"))
-            {
-                tmp.setIsPublic(true);
-            }
-            else
-            {
-                tmp.setIsPublic(false);
-            }
-            
+            MoveDestination tmp = new MoveDestination(this.AETitle, this.IP,
+                    this.port, this.isPublic.contains("true"), this.description);
             s.add(tmp);
-
         }
         else if (localName.equals("web"))
         {

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/MoveDestination.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/MoveDestination.java
@@ -19,28 +19,37 @@
 package pt.ua.dicoogle.sdk.datastructs;
 
 import java.io.Serializable;
+import java.util.Objects;
 
-/**
+/** An immutable data structure for describing a DICOM node (potential C-MOVE destinations).
  *
  * @author Luís A. Bastião Silva <bastiao@ua.pt>
  */
 public class MoveDestination implements Serializable
 {
-    static final long serialVersionUID = 1L;
+    static final long serialVersionUID = 2L;
 
     private final String AETitle;
     private final String ipAddrs;
     private final int port;
 
-    private String description = "" ;
-    private boolean isPublic = false;
+    private final String description;
+    private final boolean isPublic;
 
-
-    public MoveDestination(String AETitle, String ipAddr, int port)
-    {
+    public MoveDestination(String AETitle, String ipAddr, int port, boolean isPublic, String description) {
         this.AETitle = AETitle;
         this.ipAddrs = ipAddr;
         this.port = port;
+        this.isPublic = isPublic;
+        this.description = description;
+    }
+
+    public MoveDestination(String AETitle, String ipAddr, int port, boolean isPublic) {
+        this(AETitle, ipAddr, port, isPublic, "");
+    }
+
+    public MoveDestination(String AETitle, String ipAddr, int port) {
+        this(AETitle, ipAddr, port, false, "");
     }
 
     /**
@@ -83,23 +92,16 @@ public class MoveDestination implements Serializable
         return port;
     }
 
-    /**
-     * @param port the port to set
-     */
-/*    public void setPort(int port)
-    {
-        this.port = port;
-    }
-    */
-
     @Override
     public String toString()
     {
-        String result = "" ;
-
+        String result;
         result = "MoveDestination AET: " + this.AETitle + " (" + this.ipAddrs + ":" +
                 String.valueOf(this.port) + ")";
-
+        if (!description.isEmpty()) {
+            result += " - " + this.description;
+        }
+        
         return result ;
     }
 
@@ -112,24 +114,10 @@ public class MoveDestination implements Serializable
     }
 
     /**
-     * @param description the description to set
-     */
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    /**
      * @return the isPublic
      */
     public boolean isIsPublic() {
         return isPublic;
-    }
-
-    /**
-     * @param isPublic the isPublic to set
-     */
-    public void setIsPublic(boolean isPublic) {
-        this.isPublic = isPublic;
     }
 
     @Override
@@ -144,7 +132,14 @@ public class MoveDestination implements Serializable
 
         // To the list of MoveDestinations may not be repeated AETitles
         return move.AETitle.equals(AETitle) && move.ipAddrs.equals(ipAddrs) && move.port == port;
+    }
 
-        //return move.AETitle.equals(AETitle) && move.ipAddrs.equals(ipAddrs) && move.port == port;
+    @Override
+    public int hashCode() {
+        int hash = 3;
+        hash = 97 * hash + Objects.hashCode(this.AETitle);
+        hash = 97 * hash + Objects.hashCode(this.ipAddrs);
+        hash = 97 * hash + this.port;
+        return hash;
     }
 }

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/MoveDestination.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/MoveDestination.java
@@ -32,6 +32,10 @@ public class MoveDestination implements Serializable
     private final String ipAddrs;
     private final int port;
 
+    private String description = "" ;
+    private boolean isPublic = false;
+
+
     public MoveDestination(String AETitle, String ipAddr, int port)
     {
         this.AETitle = AETitle;
@@ -97,6 +101,35 @@ public class MoveDestination implements Serializable
                 String.valueOf(this.port) + ")";
 
         return result ;
+    }
+
+
+    /**
+     * @return the description
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * @param description the description to set
+     */
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+     * @return the isPublic
+     */
+    public boolean isIsPublic() {
+        return isPublic;
+    }
+
+    /**
+     * @param isPublic the isPublic to set
+     */
+    public void setIsPublic(boolean isPublic) {
+        this.isPublic = isPublic;
     }
 
     @Override


### PR DESCRIPTION
- There are DICOM nodes that are only used for internal use and should not appear in the interfaces.
- There are DICOM nodes that does not have a friendly description and so, a description was added.

For now, there is no need to bring that changes to the main interface, but this was a feature are required to external components better management the DICOM nodes.

Why master? 
- Required and urgent improvement to have.