### PR TITLE
Change interface to receive a parameters (storage, index)

### DIFF
--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/IndexerInterface.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/IndexerInterface.java
@@ -39,7 +39,7 @@ public interface IndexerInterface extends DicooglePlugin {
      * @param file directory or file to index
      * @return a representation of the asynchronous indexation task
      */
-    public Task<Report> index(StorageInputStream file);
+    public Task<Report> index(StorageInputStream file, Object ... parameters);
 
     /**
      * Indexes multiple file paths to the database. Indexation procedures are asynchronous, and will return
@@ -49,7 +49,7 @@ public interface IndexerInterface extends DicooglePlugin {
      * @param files a collection of directories and/or files to index
      * @return a representation of the asynchronous indexation task
      */
-    public Task<Report> index(Iterable<StorageInputStream> files);
+    public Task<Report> index(Iterable<StorageInputStream> files, Object ... parameters);
 
     
     /**

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/StorageInterface.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/StorageInterface.java
@@ -69,7 +69,7 @@ public interface StorageInterface extends DicooglePlugin {
      * @param dicomObject Object to be Stored
      * @return The URI of the previously stored Object.
      */
-    public URI store(DicomObject dicomObject);
+    public URI store(DicomObject dicomObject, Object ... parameters);
 
     /**
      * Stores a new element into the storage.
@@ -78,7 +78,7 @@ public interface StorageInterface extends DicooglePlugin {
      * @return the URI of the stored data
      * @throws IOException if an I/O error occurs
      */
-    public URI store(DicomInputStream inputStream) throws IOException;
+    public URI store(DicomInputStream inputStream, Object ... parameters) throws IOException;
     
     /** Removes an element at the given URI.
      * 


### PR DESCRIPTION
Changed the interface of storage and index to receive optional arguments.

This has been a request of few developers (@eriksson included). The idea is to give flexibility to the developers and pass adicional information to store, or to index. Moreover, it will keep coherency with query(String query, Object ... args) interface.