### PR TITLE
update to dcm4che2 version 2.0.29

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <jetty.version>9.0.3.v20130506</jetty.version>
         <restlet.version>2.1.2</restlet.version>
-        <dcm4che.version>2.0.27</dcm4che.version>
+        <dcm4che.version>2.0.29</dcm4che.version>
         <slf4j.version>1.7.12</slf4j.version>
     </properties>
     <build>


### PR DESCRIPTION
why?
- solve problems with decode. 
- we will not necessary our jai compilation anymore.
- improved performance in parse big files.