### PR TITLE
Require at least npm v2 because of local path in webcore dependency

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/package.json
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/package.json
@@ -33,6 +33,9 @@
     "lib/",
     "index.html"
   ],
+  "engines": {
+    "npm": ">=2.0.0"
+  },
   "dependencies": {
     "bootstrap": "^3.3.2",
     "react-font-awesome": "https://github.com/tkurki/react-font-awesome/tarball/master"


### PR DESCRIPTION
As discovered by @tmgodinho, we need at least version 2 of npm to build the web app.