### PR TITLE
Freedom for the result-batch slot.

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/js/components/plugin/pluginForm.jsx
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/js/components/plugin/pluginForm.jsx
@@ -49,21 +49,15 @@ export default class PluginFormModal extends React.Component {
   render() {
     const {plugin} = this.props;
     return (plugin &&
-      <Modal bsSize='lg' animation={false} {...this.props}>
-        <Modal.Header>
-          <Modal.Title>{this.props.plugin.caption}</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
+      <div {...this.props}>
+
           <dicoogle-slot {...this.props.data} ref={this.handleMounted} data-slot-id={this.props.slotId} data-plugin-name={plugin.name}>
             {plugin.name && <div className="loader-inner ball-pulse">
               <div/><div/><div/>
             </div>}
           </dicoogle-slot>
-        </Modal.Body>
-        <Modal.Footer>
-            <button className="btn btn_dicoogle" onClick={this.props.onHide}>Close</button>
-        </Modal.Footer>
-      </Modal>
+
+      </div>
     );
   }
 }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/js/components/plugin/pluginForm.jsx
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/js/components/plugin/pluginForm.jsx
@@ -1,5 +1,6 @@
 import React, {PropTypes} from 'react';
 import {Modal} from 'react-bootstrap';
+import PluginView from './pluginView.jsx';
 
 import {ResultsSelected} from '../../stores/resultSelected';
 
@@ -9,7 +10,7 @@ const Dicoogle = dicoogleClient();
 
 
 export default class PluginFormModal extends React.Component {
-
+  
   static get propTypes() {
     return {
       slotId: PropTypes.string.isRequired,
@@ -21,13 +22,13 @@ export default class PluginFormModal extends React.Component {
       onHide: PropTypes.func.isRequired
     };
   }
-
+  
   constructor(props) {
     super(props);
     this.handleMounted = this.handleMounted.bind(this);
     this.handleHideSignal = this.handleHideSignal.bind(this);
   }
-
+  
   onConfirm() {
     this.props.onHide();
   }
@@ -39,17 +40,17 @@ export default class PluginFormModal extends React.Component {
       Dicoogle.emitSlotSignal(node, 'result-selection-ready', ResultsSelected.get());
     }
   }
-
+  
   handleHideSignal({target}) {
       console.log('Plugin requested to hide');
       target.removeEventListener('hide', this.handleHideSignal);
       this.props.onHide();
   }
-
+  
   render() {
-    const {plugin} = this.props;
+    const {plugin, slotId, data} = this.props;
     return (plugin &&
-      <div {...this.props}>
+      <div>
 
           <dicoogle-slot {...this.props.data} ref={this.handleMounted} data-slot-id={this.props.slotId} data-plugin-name={plugin.name}>
             {plugin.name && <div className="loader-inner ball-pulse">


### PR DESCRIPTION
For instance, in result-options there is operation control and it makes a lot of sense. 
In result-option you force to introduce the content in the modal. Nevertheless, modal could be larger or smaller, we may need to overwrite the footer and add new buttons and with the current solution it was not possible. React-overlays could handle better the problem, but still limited somehow.

While security could be one of the concerns, it is not consistency with result-options for instance. And since you are in a browser, any plugin could change the DOM. 
