### PR TITLE
Fix detection of web UI packages on Windows

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/webui/WebUIPluginManager.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/webui/WebUIPluginManager.java
@@ -140,7 +140,7 @@ public class WebUIPluginManager {
     public void loadAllFromZip(ZipFile pluginZip) throws IOException {
         assert pluginZip != null;
         logger.trace("Discovering web UI plugins in {} ...", pluginZip.getName());
-        Pattern pckDescrMatcher = Pattern.compile("WebPlugins" + File.separatorChar + "(\\p{Alnum}|\\-|\\_)+" + File.separatorChar + "package.json");
+        Pattern pckDescrMatcher = Pattern.compile("WebPlugins\\" + File.separatorChar + "(\\p{Alnum}|\\-|\\_)+\\" + File.separatorChar + "package.json");
         Enumeration<? extends ZipEntry> entries = pluginZip.entries();
         final int DIRNAME_TAIL = "/package.json".length();
         while (entries.hasMoreElements()) {


### PR DESCRIPTION
File system resource separators are `/` on Unix and `\` on Windows. When put in a regex, `\` was being improperly used as an escape symbol.

Please test this on all 3 major platforms (Linux, Mac OSX, Windows).

Edit: Works under Linux.