### PR TITLE
Update webapp devDependencies with gulp-util

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/package.json
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/package.json
@@ -71,6 +71,7 @@
     "gulp-sass": "^2.1.1",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-uglify": "^1.5.1",
+    "gulp-util": "^3.0.7",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.7.0"


### PR DESCRIPTION
As pointed out by @tmgodinho, we've been using a dependency that wasn't registered in our package.json.

It's a pity that we don't have CI at the moment. It would've caught this bug straight away.