### PR TITLE
Support for returning to the last query

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/.eslintrc
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/.eslintrc
@@ -34,6 +34,7 @@
     "comma-dangle": 1,
     "no-extra-semi": 1,
     "eol-last": 1,
+    "no-empty": 1,
     "consistent-this": [2, "self"],
     "no-dupe-args": 2,
     "no-dupe-keys": 2,

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/gulpfile.js
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/gulpfile.js
@@ -22,10 +22,10 @@ var EXTERNAL_REQUIRES = [
 
 function createBrowserify(debug, watch) {
   // set up the browserify instance on a task basis
-  var opt = {};
-  if (watch) Object.assign(opt, {cache: {}, packageCache: {}});
-  Object.assign(opt, {
-    entries: './js/app.js',
+  var b = browserify('./js/app.js', {
+    cache: {},
+    packageCache: {},
+    extensions: ['.jsx'],
     debug: debug,
     transform: [
       [
@@ -41,8 +41,7 @@ function createBrowserify(debug, watch) {
         }
       ]
     ]
-  })
-  var b = browserify(opt);
+  });
   if (watch) {
     b.plugin(watchify);
   }
@@ -50,7 +49,7 @@ function createBrowserify(debug, watch) {
 }
 
 gulp.task('lint', function () {
-  return gulp.src('js/**/*.js')
+  return gulp.src(['js/**/*.js', 'js/**/*.jsx'])
     .pipe(eslint({
       configFile: ".eslintrc"
     }))
@@ -148,7 +147,7 @@ gulp.task('css:watch', function () {
 });
 
 gulp.task('production', ['js', 'html', 'css']);
-gulp.task('development', ['js-debug', 'html-debug', 'css']);
+gulp.task('development', ['js-debug', 'html-debug', 'css-debug']);
 
 gulp.task( 'clean', function() {
   return gulp.src(['lib/bundle.*', 'css/dicoogle.css*', 'index.html'], { read: false })

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/js/app.js
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/js/app.js
@@ -9,7 +9,7 @@ import Webcore from 'dicoogle-webcore';
 import {Router, Route, IndexRoute} from 'react-router';
 
 import {Search} from './components/search/searchView';
-import {ResultSearch} from './components/search/searchResultView';
+import {SearchResultView} from './components/search/searchResultView';
 import {IndexStatusView} from './components/indexer/IndexStatusView';
 import {ManagementView} from './components/management/managementView';
 import {DirectImageView} from './components/direct/directImageView';
@@ -38,7 +38,6 @@ class App extends React.Component {
 			pluginMenuItems: []
 		};
 		this.logout = this.logout.bind(this);
-
 	}
 
 	/**
@@ -53,7 +52,7 @@ class App extends React.Component {
 					caption: pkg.dicoogle.caption || pkg.name,
 					isPlugin: true
 				})))
-	});
+		});
 	}
 
 
@@ -105,7 +104,7 @@ class App extends React.Component {
 		const Dicoogle = dicoogleClient();
 		Dicoogle.request('POST', 'logout', {}, (error) => {
       if (error) {
-		    console.error(error);
+				console.error(error);
       }
 
       this.setState({pluginMenuItems: []});
@@ -149,12 +148,10 @@ class App extends React.Component {
 	}
 }
 
-class NotFoundView extends React.Component {
-	render() {
-		return <div>
-      <h1>Not Found</h1>
-		</div>;
-	}
+function NotFoundView() {
+	return (<div>
+    <h1>Not Found</h1>
+	</div>);
 }
 
 ReactDOM.render((
@@ -163,7 +160,7 @@ ReactDOM.render((
       <IndexRoute component={LoadingView} />
       <Route path="search" component={Search} />
       <Route path="management" component={ManagementView} />
-      <Route path="results" component={ResultSearch} />
+      <Route path="results" component={SearchResultView} />
       <Route path="indexer" component={IndexStatusView} />
       <Route path="about" component={AboutView} />
       <Route path="login" component={LoginView} />

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/js/components/indexer/TaskStatus.jsx
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/js/components/indexer/TaskStatus.jsx
@@ -47,7 +47,7 @@ class TaskStatus extends React.Component {
        <div className="row">
       <div className="col-sm-10">
         <div className="progress indexstatusprogress">
-          <div style={{width : percentage}} className={barstate} role="progressbar"  aria-valuemin="0" aria-valuemax="100">
+          <div style={{width: percentage}} className={barstate} role="progressbar"  aria-valuemin="0" aria-valuemax="100">
             {!unknownPercentage && percentage}
           </div>
         </div>

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/js/components/management/servicesView.js
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/js/components/management/servicesView.js
@@ -4,7 +4,7 @@ import ServiceAction from '../../actions/servicesAction';
 import ServicesStore from '../../stores/servicesStore';
 import QueryAdvancedOptionsModal from './queryadvoptions';
 import Webcore from 'dicoogle-webcore';
-import PluginView from '../plugin/pluginView.jsx';
+import PluginView from '../plugin/pluginView';
 
 var ServicesView = React.createClass({
 

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/js/components/plugin/pluginForm.jsx
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/js/components/plugin/pluginForm.jsx
@@ -1,6 +1,6 @@
 import React, {PropTypes} from 'react';
 import {Modal} from 'react-bootstrap';
-import PluginView from './pluginView.jsx';
+import PluginView from './pluginView';
 
 import {ResultsSelected} from '../../stores/resultSelected';
 
@@ -10,7 +10,7 @@ const Dicoogle = dicoogleClient();
 
 
 export default class PluginFormModal extends React.Component {
-  
+
   static get propTypes() {
     return {
       slotId: PropTypes.string.isRequired,
@@ -22,13 +22,13 @@ export default class PluginFormModal extends React.Component {
       onHide: PropTypes.func.isRequired
     };
   }
-  
+
   constructor(props) {
     super(props);
     this.handleMounted = this.handleMounted.bind(this);
     this.handleHideSignal = this.handleHideSignal.bind(this);
   }
-  
+
   onConfirm() {
     this.props.onHide();
   }
@@ -40,13 +40,13 @@ export default class PluginFormModal extends React.Component {
       Dicoogle.emitSlotSignal(node, 'result-selection-ready', ResultsSelected.get());
     }
   }
-  
+
   handleHideSignal({target}) {
       console.log('Plugin requested to hide');
       target.removeEventListener('hide', this.handleHideSignal);
       this.props.onHide();
   }
-  
+
   render() {
     const {plugin, slotId, data} = this.props;
     return (plugin &&

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/js/components/search/advancedSearch.js
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/js/components/search/advancedSearch.js
@@ -5,7 +5,7 @@ import React from 'react';
 import {SearchStore} from '../../stores/searchStore';
 import {ActionCreators} from '../../actions/searchActions';
 
-import {ResultSearch} from '../search/searchResultView';
+import {SearchResultView} from '../search/searchResultView';
 
 var AdvancedSearch = React.createClass({
     getInitialState: function (){
@@ -197,7 +197,7 @@ var AdvancedSearch = React.createClass({
        ///////
        var params = {text: query, keyword: true, other: true, provider};
 
-       React.render(<ResultSearch items={params}/>, document.getElementById("container"));
+       React.render(<SearchResultView items={params}/>, document.getElementById("container"));
   },
    checkEmpty: function(text){
      if(text.length === 0 )

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/js/components/search/result/imageView.js
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/js/components/search/result/imageView.js
@@ -6,7 +6,7 @@ import ConfirmModal from './confirmModal';
 import {Endpoints} from '../../../constants/endpoints';
 import {DumpStore} from '../../../stores/dumpStore';
 import ImageLoader from 'react-imageloader';
-import PluginView from '../../plugin/pluginView.jsx';
+import PluginView from '../../plugin/pluginView';
 import {DumpActions} from '../../../actions/dumpActions';
 import {BootstrapTable, TableHeaderColumn} from 'react-bootstrap-table';
 import {Input} from 'react-bootstrap';

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/js/components/search/searchResult.jsx
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/js/components/search/searchResult.jsx
@@ -1,7 +1,4 @@
-import React from 'react';
-
-import {SearchStore} from '../../stores/searchStore';
-import {ActionCreators} from '../../actions/searchActions';
+import React, {PropTypes} from 'react';
 
 import {PatientView} from './result/patientView';
 import {StudyView} from './result/studyView';
@@ -9,15 +6,36 @@ import {SeriesView} from './result/serieView';
 import {ImageView} from './result/imageView';
 import {ExportView} from './exportView';
 import Webcore from 'dicoogle-webcore';
-import PluginForm from '../plugin/pluginForm.jsx';
+import PluginForm from '../plugin/pluginForm';
 import {DefaultOptions} from '../../constants/defaultOptions';
 
-var ResultSearch = React.createClass({
+const SearchResult = React.createClass({
+
+  propTypes: {
+    requestedQuery: PropTypes.shape({
+      text: PropTypes.string,
+      keyword: PropTypes.bool,
+      other: PropTypes.bool,
+      provider: PropTypes.string
+    }).isRequired, // requested query
+    searchOutcome: PropTypes.shape({
+      data: PropTypes.shape({
+        numResults: PropTypes.number,
+        results: PropTypes.array
+      }),
+      error: PropTypes.any
+    }).isRequired,
+    onReturn: PropTypes.func
+  },
+
+  getDefaultProps() {
+    return {
+      onReturn: null
+    }
+  },
 
   getInitialState: function() {
     return {
-      data: [],
-      status: "loading",
       showExport: false,
       showDangerousOptions: DefaultOptions.showSearchOptions,
       current: 0,
@@ -26,13 +44,7 @@ var ResultSearch = React.createClass({
     };
   },
 
-  componentDidMount: function() {
-    this.initSearch(this.props.items);
-  },
-
   componentWillMount: function() {
-    // Subscribe to the store.
-    SearchStore.listen(this._onChange);
     Webcore.fetchPlugins('result-batch', (packages) => {
       Webcore.fetchModules(packages);
       this.setState({batchPlugins: packages.map(pkg => ({
@@ -42,9 +54,13 @@ var ResultSearch = React.createClass({
     });
   },
 
-	initSearch: function(props){
-    ActionCreators.search(props);
-	},
+  componentWillUpdate(nextProps) {
+    if (this.props.requestedQuery.queryText !== nextProps.requestedQuery.queryText) {
+      //init StepView
+      if(!this.state.current)
+        this.onStepClicked(0);
+    }
+  },
 
   handleClickExport() {
     this.setState({showExport: true, currentPlugin: null});
@@ -62,9 +78,22 @@ var ResultSearch = React.createClass({
     this.setState({currentPlugin: null});
   },
 
-  render: function() {
+  handleClickBack() {
+    this.props.onReturn();
+  },
 
-		if (this.state.status === "loading"){
+  isLoading() {
+    return !this.props.searchOutcome;
+  },
+
+  getError() {
+    return this.props.searchOutcome.error;
+  },
+
+  render: function() {
+    const {searchOutcome} = this.props;
+
+		if (this.isLoading()){
       //loading animation
       return (<div className="loader-inner ball-pulse">
         <div/>
@@ -73,19 +102,28 @@ var ResultSearch = React.createClass({
       </div>);
 		}
 
-    //Check if search fails
-    if(this.state.success === false)
-    {
-      return (<div>Search error</div>);
+    const btnBack = (this.props.onReturn &&
+      <button className="btn btn_dicoogle fa fa-level-up" onClick={this.handleClickBack}>
+        &nbsp; Back to Query
+      </button>);
+
+    //Check if search failed
+    if(this.getError()) {
+      return (
+        <div>
+          {btnBack}
+          <p>{this.getError()}</p>
+        </div>
+        );
     }
     //Check if search return no results
-    if(this.state.data.numResults === 0)
+    if(searchOutcome.data && searchOutcome.data.numResults === 0)
     {
       return (
         <div>
-        No results for that query
+          {btnBack}
+          <p>No results for that query</p>
         </div>
-
         );
     }
 
@@ -98,6 +136,7 @@ var ResultSearch = React.createClass({
 
     let toggleModalClassNames = this.state.showDangerousOptions ? "btn btn_dicoogle fa fa-toggle-on" : "btn btn_dicoogle fa fa-toggle-off";
     return (<div>
+        {btnBack}
         <Step current={this.state.current} onClick={this.onStepClicked}/>
         <div id="step-container">
           {this.getCurrentView()}
@@ -105,32 +144,19 @@ var ResultSearch = React.createClass({
         <button className="btn btn_dicoogle fa fa-download" onClick={this.handleClickExport}>Export</button>
         <button className={toggleModalClassNames} onClick={this.toggleAdvOpt}> Advanced Options </button>
         {pluginButtons}
-        <ExportView show={this.state.showExport} onHide={this.handleHideExport} query={this.props.items}/>
+        <ExportView show={this.state.showExport} onHide={this.handleHideExport} query={this.props.requestedQuery}/>
         <PluginForm show={!!this.state.currentPlugin} slotId="result-batch"
                     plugin={this.state.currentPlugin} onHide={this.handleHideBatchForm}
-                    data={{results: this.state.data.results}} />
+                    data={{results: this.props.searchOutcome.data.results}} />
       </div>);
 	},
-
-  _onChange: function(data) {
-    if (this.isMounted())
-    {
-      this.setState({data: data.data,
-      status: "stopped",
-      success: data.success});
-
-      //init StepView
-      if(!this.state.current)
-        this.onStepClicked(0);
-    }
-  },
 
   getCurrentView() {
     let view;
     switch (this.state.current) {
       case 0:
-        view = ( <PatientView items={this.state.data}
-                              provider={this.props.items.provider}
+        view = ( <PatientView items={this.props.searchOutcome.data}
+                              provider={this.props.requestedQuery.provider}
                               enableAdvancedSearch={this.state.showDangerousOptions}
                               onItemClick={this.onPatientClicked}/>);
         break;
@@ -169,7 +195,7 @@ var ResultSearch = React.createClass({
   }
 });
 
-var Step = React.createClass({
+const Step = React.createClass({
   getInitialState: function() {
     return {current: this.props.current};
   },
@@ -218,4 +244,4 @@ var Step = React.createClass({
 
 });
 
-export {ResultSearch};
+export {SearchResult};

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/js/components/search/searchResult.jsx
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/js/components/search/searchResult.jsx
@@ -103,8 +103,8 @@ const SearchResult = React.createClass({
 		}
 
     const btnBack = (this.props.onReturn &&
-      <button className="btn btn_dicoogle fa fa-level-up" onClick={this.handleClickBack}>
-        &nbsp; Back to Query
+      <button className="btn btn_dicoogle" onClick={this.handleClickBack}>
+       <i className="fa fa-level-up"/> &nbsp; Back to Query
       </button>);
 
     //Check if search failed
@@ -133,16 +133,16 @@ const SearchResult = React.createClass({
                 {plugin.caption}
               </button>)
     );
-
-    let toggleModalClassNames = this.state.showDangerousOptions ? "btn btn_dicoogle fa fa-toggle-on" : "btn btn_dicoogle fa fa-toggle-off";
+    
+    let toggleModalClassNames = this.state.showDangerousOptions ? "fa fa-toggle-on" : "fa fa-toggle-off";
     return (<div>
         {btnBack}
         <Step current={this.state.current} onClick={this.onStepClicked}/>
         <div id="step-container">
           {this.getCurrentView()}
         </div>
-        <button className="btn btn_dicoogle fa fa-download" onClick={this.handleClickExport}>Export</button>
-        <button className={toggleModalClassNames} onClick={this.toggleAdvOpt}> Advanced Options </button>
+        <button className="btn btn_dicoogle" onClick={this.handleClickExport}><i className="fa fa-download"/>Export</button>
+        <button className="btn btn_dicoogle" onClick={this.toggleAdvOpt}><i className={toggleModalClassNames}/> Advanced Options </button>
         {pluginButtons}
         <ExportView show={this.state.showExport} onHide={this.handleHideExport} query={this.props.requestedQuery}/>
         <PluginForm show={!!this.state.currentPlugin} slotId="result-batch"

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/js/components/search/searchResultView.jsx
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/js/components/search/searchResultView.jsx
@@ -1,0 +1,77 @@
+import React, {PropTypes} from 'react';
+
+import {SearchStore} from '../../stores/searchStore';
+import {ActionCreators} from '../../actions/searchActions';
+
+import Webcore from 'dicoogle-webcore';
+import {DefaultOptions} from '../../constants/defaultOptions';
+import {SearchResult} from './searchResult';
+
+const SearchResultView = React.createClass({
+
+  propTypes: {
+    items: PropTypes.shape({
+      text: PropTypes.string,
+      keyword: PropTypes.bool,
+      other: PropTypes.bool,
+      provider: PropTypes.string
+    }).isRequired // the requested query
+  },
+
+  getInitialState: function() {
+    return {
+      data: {}, // {numResults, results}
+      status: "loading",
+      showExport: false,
+      showDangerousOptions: DefaultOptions.showSearchOptions,
+      current: 0,
+      success: undefined,
+      batchPlugins: [],
+      currentPlugin: null
+    };
+  },
+
+  componentDidMount: function() {
+    this.initSearch(this.props.items);
+  },
+
+  componentWillMount: function() {
+    // Subscribe to the store.
+    SearchStore.listen(this._onChange);
+    Webcore.fetchPlugins('result-batch', (packages) => {
+      Webcore.fetchModules(packages);
+      this.setState({batchPlugins: packages.map(pkg => ({
+        name: pkg.name,
+        caption: pkg.dicoogle.caption || pkg.name
+      }))});
+    });
+  },
+
+	initSearch: function(props){
+    ActionCreators.search(props);
+	},
+
+  render: function() {
+    const sOut = {
+      data: this.state.data,
+      error: !this.state.success && 'An error occurred. Please contact your system administrator.'
+    };
+    const rq = this.props.items;
+    return (<SearchResult requestedQuery={rq} searchOutcome={sOut} />);
+	},
+
+  _onChange: function(outcome) {
+    if (this.isMounted())
+    {
+      console.log('outcome:', outcome);
+
+      this.setState({
+        data: outcome.data,
+        status: "stopped",
+        success: outcome.success
+      });
+    }
+  }
+});
+
+export {SearchResultView};

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/js/components/search/searchView.jsx
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/js/components/search/searchView.jsx
@@ -1,25 +1,39 @@
-/*jshint esnext: true*/
 
-import React from 'react';
+import React, {PropTypes} from 'react';
 import $ from 'jquery';
 import {ActionCreators} from '../../actions/searchActions';
 import {ProvidersStore} from '../../stores/providersStore';
 import {ProvidersActions} from '../../actions/providersActions';
 import {AdvancedSearch} from '../search/advancedSearch';
-import {ResultSearch} from '../search/searchResultView';
+import {SearchResult} from '../search/searchResult';
 import {DimFields} from '../../constants/dimFields';
 import {getUrlVars} from '../../utils/url';
+import {SearchStore} from '../../stores/searchStore';
 
 var Search = React.createClass({
+    propTypes: {
+      params: PropTypes.object.isRequired,
+      location: PropTypes.object.isRequired
+    },
+
     getInitialState: function (){
         this.keyHash = getUrlVars()['_k'];
         return {
           label: 'login',
           searchState: "simple",
           providers: ["All providers"],
-          requestedQuery: null
+          queryText: '',
+          requestedQuery: null,
+          error: null,
+          data: null
         };
     },
+
+    componentWillMount: function(){
+      ProvidersStore.listen(this._onProvidersChange);
+      SearchStore.listen(this._onSearchResult);
+    },
+
     componentDidMount: function(){
 
       this.enableAutocomplete();
@@ -29,13 +43,11 @@ var Search = React.createClass({
         this.onSearchByUrl();
       }
 
-      //document.getElementById('container').style.display = 'block';
-
       ProvidersActions.get();
     },
     componentWillUpdate: function() {
 
-        if (getUrlVars()['_k']!=this.keyHash)
+        if (getUrlVars()['_k'] !== this.keyHash)
         {
             this.keyHash = getUrlVars()['_k'];
             this.setState({
@@ -43,26 +55,30 @@ var Search = React.createClass({
             });
         }
         this.keyHash = getUrlVars()['_k'];
-        
-
     },
     componentDidUpdate: function(){
       this.enableAutocomplete();
       this.enableEnterKey();
     },
-    componentWillMount: function(){
-      ProvidersStore.listen(this._onChange);
+
+    onReturn(error) {
+      this.setState({
+        requestedQuery: null,
+        error
+      });
     },
+
+    getSearchOutcome() {
+      const {data, error} = this.state;
+      return data ? { data, error } : null;
+    },
+
     render: function() {
 
-      var self = this;
-      var providersList = (
-        self.state.providers.map(function(item, index){
-          return (<option key={index}> {item} </option>);
-        })
-      );
+      let providersList = this.state.providers.map(
+          (item, index) => (<option key={index}> {item} </option>));
 
-      var selectionButtons = (
+      let selectionButtons = (
           <div>
           <button type="button" className="btn btn_dicoogle" onClick={this.renderFilter} data-trigger="advance-search" id="btn-advance">
             {this.state.searchState === "simple" ? "Advanced" : "Basic"}
@@ -75,33 +91,62 @@ var Search = React.createClass({
               </div>
         );
 
-        var simpleSearchInstance = (
+      let simpleSearchInstance = (
             <div className="row space_up" id="main-search">
                     <div className="col-xs-8 col-sm-10">
-                        <input id="free_text" type="text" className="form-control" placeholder="Free text or advanced query"></input>
+                        <input id="free_text" type="text" className="form-control" placeholder="Free text or advanced query"
+                               onChange={this.handleQueryTextChanged} value={this.state.queryText} />
                     </div>
                     <div className="col-xs-4 col-sm-2">
-                        <button type="button" className="btn btn_dicoogle" id="search-btn" onClick={this.onSearchClicked}>Search</button>
+                        <button type="button" className="btn btn_dicoogle" id="search-btn"
+                                onClick={this.onSearchClicked}>Search</button>
                     </div>
                 </div>
             );
 
-       if (this.state.requestedQuery !== null) {
-         return <ResultSearch items={this.state.requestedQuery}/>;
-       } else if(this.state.searchState === "simple"){
-            return (<div> {selectionButtons} {simpleSearchInstance} </div>);
-       }
-       else if(this.state.searchState === "advanced")
-       {
-            return (<div> {selectionButtons} <AdvancedSearch/> </div>);
+       if (this.state.requestedQuery !== null && !this.state.error) {
+         return <SearchResult requestedQuery={this.state.requestedQuery}
+                              searchOutcome={this.getSearchOutcome()}
+                              onReturn={this.onReturn} />;
+       } else if(this.state.searchState === "simple") {
+            return (<div>
+              {selectionButtons}
+              {simpleSearchInstance}
+              <div>{this.state.error}</div>
+            </div>);
+       } else if(this.state.searchState === "advanced") {
+            return (<div>
+              {selectionButtons}
+              <AdvancedSearch/>
+              <div>{this.state.error}</div>
+            </div>);
        }
     },
-    _onChange: function(data) {
+    _onProvidersChange: function(data) {
         if (this.isMounted())
         this.setState({providers: data.data});
     },
+    _onSearchResult: function(outcome) {
+      if (this.isMounted())
+      {
+        console.log('outcome:', outcome);
+
+        let error = null;
+        if (!outcome.success) {
+          error = "An error occurred. Please contact your system administrator.";
+        } else if (outcome.data.numResults === 0) {
+          error = "No studies were found for that search.";
+        }
+        this.setState({
+          data: outcome.data,
+          status: "stopped",
+          success: outcome.success,
+          requestedQuery: error ? null : this.state.requestedQuery,
+          error
+        });
+      }
+    },
     renderFilter: function(){
-      //React.render(<AdvancedSearch/>, this.getDOMNode());
       var switchState;
       if(this.state.searchState === "simple"){
         switchState = "advanced";
@@ -117,10 +162,13 @@ var Search = React.createClass({
         requestedQuery: params
       });
     },
-    onSearchClicked: function(){
-        // TODO don't do this, use state instead
-        let text = document.getElementById("free_text").value;
+    handleQueryTextChanged(e) {
+      this.setState({queryText: e.target.value});
+    },
+    onSearchClicked: function() {
+        let text = this.state.queryText;
 
+        // TODO support multi-select ; use state instead of fetching element from DOM
         let providerEl = document.getElementById("providersList");
         let selectedId = providerEl.selectedIndex;
         let provider = "";
@@ -131,17 +179,23 @@ var Search = React.createClass({
         }
 
         let params = {text, keyword: this.isKeyword(text), other: true, provider};
+        this.triggerSearch(params);
+    },
+    triggerSearch: function(params){
         this.setState({
-          requestedQuery: params
-        })
+          requestedQuery: params,
+          data: null,
+          error: null
+        });
+      ActionCreators.search(params);
     },
     isKeyword: function(freetext) {
       return !!freetext.match(/[^\s\\]:\S/);
     },
-  isAutocompletOpened: function(){
-    if($('.ui-autocomplete').css('display') === 'none'){return false;}
-    return true;
-  },
+    isAutocompletOpened: function(){
+      if($('.ui-autocomplete').css('display') === 'none'){return false;}
+      return true;
+    },
 
     enableAutocomplete: function(){
       function split( val ) {

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/package.json
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/package.json
@@ -72,6 +72,7 @@
     "gulp-sourcemaps": "^1.6.0",
     "gulp-uglify": "^1.5.1",
     "gulp-util": "^3.0.7",
+    "react-addons-update": "^0.14.8",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.7.0"


### PR DESCRIPTION
Fixes #143 and #225.

- Added a "Back to Query" button when looking at search results to return to the query input state (the contents of the last query are preserved)
- Made it so that search errors or no search results will automatically send the user back to the query input state.
- Split the search result into a simple component and a view. The simple component receives the outcome of a search via props, whereas views perform the actual search and provide the results.
- Added module resolution in Browserify for .jsx files. We should prefer to use .jsx when dealing with JSX (and gradually update the other files).
- Added the `react-addons-update` dependency explicitly, so that `react-toastr` (in `react-bootstrap-table`) would not resolve to v15 (as we're still using React v0.14). More info [here](https://github.com/tomchentw/react-toastr/issues/33#issuecomment-217409741).