### PR TITLE
Search service: optimize and support pagination

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/core/dim/DIMGeneric.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/core/dim/DIMGeneric.java
@@ -81,7 +81,7 @@ public class DIMGeneric
     public DIMGeneric(ConcatTags tags, Iterable<SearchResult> arr) throws Exception
     {
         this.tags = tags;
-        fill(arr);
+        fill(arr, 4);
 
     }
 
@@ -89,76 +89,38 @@ public class DIMGeneric
      * it is allow to handle a ArrayList of Strings or SearchResults
      * @param arr
      */
+    public DIMGeneric(Iterable<SearchResult> arr, int depth) throws Exception{
+        fill(arr, depth);
+    }
+
     public DIMGeneric(Iterable<SearchResult> arr) throws Exception{
-        fill(arr);
-
+        this(arr, 4);
     }
-    
-    
+
     /**
      * it is allow to handle a ArrayList of Strings or SearchResults
      * @param arr
      */
-    private void fill(Iterable<SearchResult> arr) {
+    private void fill(Iterable<SearchResult> arr, int depth) {
             //DebugManager.getInstance().debug("Looking search results: " + arr.size() );
 
             Map<String, String> descriptions = new HashMap<String, String>();
 
-
             for(SearchResult r : arr){
 
-            
                 /**
-                 * Looking for SeachResults and put it in right side :) 
+                 * Looking for SearchResults and put it in right side :)
                  */
 
                 //SearchResult r = (SearchResult) arr.get(i);
-                HashMap<String, Object> extra = r.getExtraData();
+                final HashMap<String, Object> extra = r.getExtraData();
 
                 /** Get data from Study */
-                String studyUID = toTrimmedString(extra.get("StudyInstanceUID"),false);
-                String studyID = toTrimmedString(extra.get("StudyID"), false);
-                String studyDate = toTrimmedString( extra.get("StudyDate"), false);
-                String studyTime = toTrimmedString( extra.get("StudyTime"), true);
-                String AccessionNumber = toTrimmedString( extra.get("AccessionNumber"), false);
+                final String studyUID = toTrimmedString(extra.get("StudyInstanceUID"),false);
+                final String modality = toTrimmedString( extra.get("Modality"), false);
+                final String patientID =  toTrimmedString( extra.get("PatientID"), false);
+                final String patientName =  toTrimmedString(extra.get("PatientName"), false);
                 String StudyDescription = toTrimmedString( extra.get("StudyDescription"), false);
-                String InstitutionName = toTrimmedString( extra.get("InstitutionName"), false);
-                String operatorsName = toTrimmedString (extra.get("OperatorsName"), false);
-                String RequestingPhysician = toTrimmedString (extra.get("RequestingPhysician"), false);
-        
-                
-                /**
-                 * Get data to Series
-                 */
-                String serieUID =  toTrimmedString( extra.get("SeriesInstanceUID"), false);
-                String BodyPartThickness = (String) extra.get("BodyPartThickness");
-                //System.out.println("serieUID"+serieUID);
-                String serieNumber = toTrimmedString(extra.get("SeriesNumber"), true);
-                String serieDescription = toTrimmedString(  extra.get("SeriesDescription"), false);
-                String modality = toTrimmedString( extra.get("Modality"), false);
-                String patientID =  toTrimmedString( extra.get("PatientID"), false);
-                
-
-                String ViewPosition = toTrimmedString( extra.get("ViewPosition"), false);
-                String ImageLaterality = toTrimmedString( extra.get("ImageLaterality"), false);
-                String AcquisitionDeviceProcessingDescription = toTrimmedString( extra.get("AcquisitionDeviceProcessingDescription"), false);
-
-
-                String ViewCodeSequence_CodeValue =  toTrimmedString( extra.get("ViewCodeSequence_CodeValue"), false);
-                String ViewCodeSequence_CodingSchemeDesignator =  toTrimmedString( extra.get("ViewCodeSequence_CodingSchemeDesignator"), false);
-                String ViewCodeSequence_CodingSchemeVersion =  toTrimmedString( extra.get("ViewCodeSequence_CodingSchemeVersion"), false);
-                String ViewCodeSequence_CodeMeaning =  toTrimmedString( extra.get("ViewCodeSequence_CodeMeaning"), false);
-
-
-                /* Get Patient Data */
-
-                String patientSex = toTrimmedString(  extra.get("PatientSex"), false);
-                String patientBirthDate = toTrimmedString(  extra.get("PatientBirthDate"), false);
-                
-                String patientName =  toTrimmedString(extra.get("PatientName"), false);
-
-                String SeriesDate =  toTrimmedString(extra.get("SeriesDate"), false);
-                String ProtocolName =  toTrimmedString(extra.get("ProtocolName"), false);
 
                 /**
                  * Get data to Image
@@ -170,33 +132,27 @@ public class DIMGeneric
                 if(sopInstUID == null)
                     sopInstUID ="no uid";
 
-                logger.debug("StudyDescription: " + StudyDescription);
+                logger.debug("StudyDescription: {}", StudyDescription);
                 
                 // This is a quick fix for changing the parameters for the query.
                 if ((StudyDescription==null||StudyDescription.equals("")||StudyDescription.toLowerCase().contains("fuji"))
                         &&
-                        this.tags!=null)
-                {
-                    logger.debug("Checking if the Rule applies." + studyUID);
+                        this.tags!=null) {
+                    logger.debug("Checking if the Rule applies: {}", studyUID);
                     String description = "";
 
-                    if (descriptions.containsKey(studyUID))
-                    {
+                    if (descriptions.containsKey(studyUID)) {
                         description = descriptions.get(studyUID);
                     }
 
                     for (ConcatTags.Rule rule : this.tags.getRules())
                     {
-                        logger.debug("Checking if the Rule applies." + modality);
+                        logger.debug("Checking if the Rule applies: {}", modality);
 
-                        if (modality.equals(rule.getModality()))
-                        {
-
-
+                        if (modality.equals(rule.getModality())) {
                             String valueTagToReplace = (String) extra.get(rule.getTagToReplace());
-                            logger.debug("Checking if the Rule value." + valueTagToReplace);
-                            logger.debug("Checking if the Rule value." + rule.getTagToReplace());
-
+                            logger.debug("Checking if the Rule value. {}", valueTagToReplace);
+                            logger.debug("Checking if the Rule value. {}", rule.getTagToReplace());
 
                             if (valueTagToReplace!=null)
                             {
@@ -204,149 +160,157 @@ public class DIMGeneric
                                 // complete ported.
                                 valueTagToReplace = valueTagToReplace.trim().replaceAll("[^a-zA-Z0-9\\. ÉéàÀÃ;,]+","");
                                 description = description + valueTagToReplace + "; ";
-
                             }
-
-
                         }
 
                     }
                     StudyDescription = description;
                     descriptions.put(studyUID, StudyDescription);
 
-
                 }
 
-                String patientIdentifier = "";
-                if (patientID.equals(""))
-                {
+                String patientIdentifier = patientID;
+                if (patientID.equals("")) {
                     patientIdentifier = patientName;
                 }
-                else
-                {
-                    patientIdentifier = patientID;
-                }
-                
 
                 /** Verify if Patient already exists */
 
                 if (this.patientsHash.containsKey(patientIdentifier))
                 {
-                    /**
-                     * Patient Already exists, let's check studys
-                     */
-		            // Real data does not have Patient Id - sometimes.
-                    Patient p = this.patientsHash.get(patientIdentifier);
+                    if (depth >= 1) {
+                        /**
+                         * Patient Already exists, let's check studys
+                         */
+                        // Real data does not have Patient Id - sometimes.
+                        Patient p = this.patientsHash.get(patientIdentifier);
 
-
-                    /**
-                     * Add Study
-                     * It also verify if it exists
-                     * In the last case Object will be discarded and the
-                     * data will be added for the Study that already exists
-                     */
-
-                    Study s = new Study(p,studyUID,studyDate);
-
-                    s.setInstitutuionName(InstitutionName);
-                    s.setAccessionNumber(AccessionNumber);
-                    s.setStudyTime(studyTime);
-                    s.setStudyID(studyID);
-                    s.setStudyDescription(StudyDescription);
-
-                    s.setPatientName(patientName);
-
-                    s.setOperatorsName(operatorsName);
-                    s.setRequestingPhysician(RequestingPhysician);
-
-
-                    Serie serie = new Serie(s, serieUID, modality);
-                    try
-                    {
-                        if (serieNumber!=null)
-                            serie.setSerieNumber((int)Float.parseFloat(serieNumber));
+                        Study s = this.fillStudy(p, extra, StudyDescription);
+                        if (depth > 2) {
+                            Serie serie = this.fillSeries(s, extra);
+                            if (depth > 3) {
+                                serie.addImage(r.getURI(), sopInstUID);
+                            }
+                        }
                     }
-                    catch (Exception ex)
-                    {
-                        // nothing to do anyway
-                    }
-                    serie.setSeriesDescription(serieDescription);
-                    serie.setSeriesDescription(serieDescription);
-                    serie.setProtocolName(ProtocolName);
-                    serie.setSeriesDate(SeriesDate);
-                    serie.setBodyPartThickness(BodyPartThickness);
-                    serie.setViewPosition(ViewPosition);
-                    serie.setImageLaterality(ImageLaterality);
-                    serie.setAcquisitionDeviceProcessingDescription(AcquisitionDeviceProcessingDescription);
-                    serie.setViewCodeSequence_CodeMeaning(ViewCodeSequence_CodeMeaning);
-                    serie.setViewCodeSequence_CodeValue(ViewCodeSequence_CodeValue);
-                    serie.setViewCodeSequence_CodingSchemeDesignator(ViewCodeSequence_CodingSchemeDesignator);
-                    serie.setViewCodeSequence_CodingSchemeVersion(ViewCodeSequence_CodingSchemeVersion);
-
-                    serie.addImage(r.getURI(),sopInstUID);
-                    s.addSerie(serie);
-                    p.addStudy(s);
-                    
-                    
                 }
                 else {
                     /**
                      * Patient does not exist
                      */
-                     Patient p = new Patient(patientID, patientName);
-                     p.setPatientSex(patientSex);
-                     p.setPatientBirthDate(patientBirthDate);
+                    Patient p = new Patient(patientID, patientName);
 
-                     /**
-                      * Create Study
-                      */
-                     Study s = new Study(p, studyUID,studyDate) ;
-                    s.setAccessionNumber(AccessionNumber);
-                    s.setStudyTime(studyTime);
-                    s.setStudyDescription(StudyDescription);
-                    s.setStudyID(studyID);
-                    s.setInstitutuionName(InstitutionName);
-                    s.setPatientName(patientName);
+                    /* Get Patient Data */
+                    String patientSex = toTrimmedString(  extra.get("PatientSex"), false);
+                    p.setPatientSex(patientSex);
 
-                    s.setOperatorsName(operatorsName);
-                    s.setRequestingPhysician(RequestingPhysician);
+                    String patientBirthDate = toTrimmedString(  extra.get("PatientBirthDate"), false);
+                    p.setPatientBirthDate(patientBirthDate);
 
-
-                    p.addStudy(s);
-
-                    /**
-                    * Create Series
-                    */
-                    Serie serie = new Serie(s,serieUID, modality);
-                    if (serieNumber!=null && !serieNumber.equals(""))
-                       serie.setSerieNumber((int)Float.parseFloat(serieNumber));
-                    serie.setSeriesDescription(serieDescription);
-                    serie.setProtocolName(ProtocolName);
-
-                    serie.setSeriesDate(SeriesDate);
-                    serie.setViewPosition(ViewPosition);
-                    serie.setImageLaterality(ImageLaterality);
-                    serie.setAcquisitionDeviceProcessingDescription(AcquisitionDeviceProcessingDescription);
-                    serie.setViewCodeSequence_CodeMeaning(ViewCodeSequence_CodeMeaning);
-                    serie.setViewCodeSequence_CodeValue(ViewCodeSequence_CodeValue);
-                    serie.setViewCodeSequence_CodingSchemeDesignator(ViewCodeSequence_CodingSchemeDesignator);
-                    serie.setViewCodeSequence_CodingSchemeVersion(ViewCodeSequence_CodingSchemeVersion);
-
-
-
-                    serie.addImage(r.getURI(),sopInstUID);
-                    s.addSerie(serie);
+                    if (depth >= 1) {
+                        /**
+                         * Create Study
+                         */
+                        Study s = this.fillStudy(p, extra, StudyDescription);
+                        if (depth > 2) {
+                            Serie serie = this.fillSeries(s, extra);
+                            if (depth > 3) {
+                                serie.addImage(r.getURI(), sopInstUID);
+                            }
+                        }
+                    }
                     this.patients.add(p);
                     this.patientsHash.put(patientIdentifier, p);
                 }
             }
 
     }
-    public void writeJSON(Writer destinationWriter) throws IOException {
-        this.writeJSON(destinationWriter, 4);
+
+    /**
+     * Add Study
+     * It also verify if it exists
+     * In the last case Object will be discarded and the
+     * data will be added for the Study that already exists
+     */
+    public Study fillStudy(Patient parent, Map<String, Object> extra, String StudyDescription) {
+        /** Get data from Study */
+        String studyUID = toTrimmedString(extra.get("StudyInstanceUID"),false);
+        String studyID = toTrimmedString(extra.get("StudyID"), false);
+        String studyDate = toTrimmedString( extra.get("StudyDate"), false);
+        String studyTime = toTrimmedString( extra.get("StudyTime"), true);
+        String AccessionNumber = toTrimmedString( extra.get("AccessionNumber"), false);
+        String InstitutionName = toTrimmedString( extra.get("InstitutionName"), false);
+        String operatorsName = toTrimmedString (extra.get("OperatorsName"), false);
+        String RequestingPhysician = toTrimmedString (extra.get("RequestingPhysician"), false);
+
+        Study s = parent.getStudy(studyUID);
+        if (s == null) {
+            s = new Study(parent, studyUID, studyDate);
+            parent.addStudy(s);
+        }
+        s.setInstitutuionName(InstitutionName);
+        s.setAccessionNumber(AccessionNumber);
+        s.setStudyTime(studyTime);
+        s.setStudyID(studyID);
+        s.setStudyDescription(StudyDescription);
+        s.setPatientName(parent.getPatientName());
+        s.setOperatorsName(operatorsName);
+        s.setRequestingPhysician(RequestingPhysician);
+        return s;
     }
 
-    public void writeJSON(Writer destinationWriter, int depth) throws IOException {
+    public Serie fillSeries(Study parent, Map<String, Object> extra) {
+        String seriesUID =  toTrimmedString( extra.get("SeriesInstanceUID"), false);
+        String modality = toTrimmedString( extra.get("Modality"), false);
+        Serie s = parent.getSeries(seriesUID);
+        if (s == null) {
+            s = new Serie(parent, seriesUID, modality);
+            parent.addSerie(s);
+        }
+
+        String serieNumber = toTrimmedString(extra.get("SeriesNumber"), true);
+        if (serieNumber != null && !serieNumber.equals("")) {
+            s.setSerieNumber((int) Float.parseFloat(serieNumber));
+        }
+
+        String serieDescription = toTrimmedString(  extra.get("SeriesDescription"), false);
+        s.setSeriesDescription(serieDescription);
+
+        String SeriesDate =  toTrimmedString(extra.get("SeriesDate"), false);
+        s.setSeriesDate(SeriesDate);
+
+        String ProtocolName =  toTrimmedString(extra.get("ProtocolName"), false);
+        s.setProtocolName(ProtocolName);
+
+        String ViewPosition = toTrimmedString( extra.get("ViewPosition"), false);
+        s.setViewPosition(ViewPosition);
+
+        String ImageLaterality = toTrimmedString( extra.get("ImageLaterality"), false);
+        s.setImageLaterality(ImageLaterality);
+
+        String ViewCodeSequence_CodeValue =  toTrimmedString( extra.get("ViewCodeSequence_CodeValue"), false);
+        s.setViewCodeSequence_CodeValue(ViewCodeSequence_CodeValue);
+
+        String ViewCodeSequence_CodingSchemeDesignator =  toTrimmedString( extra.get("ViewCodeSequence_CodingSchemeDesignator"), false);
+        s.setViewCodeSequence_CodingSchemeDesignator(ViewCodeSequence_CodingSchemeDesignator);
+
+        String ViewCodeSequence_CodingSchemeVersion =  toTrimmedString( extra.get("ViewCodeSequence_CodingSchemeVersion"), false);
+        s.setViewCodeSequence_CodingSchemeVersion(ViewCodeSequence_CodingSchemeVersion);
+
+        String ViewCodeSequence_CodeMeaning =  toTrimmedString( extra.get("ViewCodeSequence_CodeMeaning"), false);
+        s.setViewCodeSequence_CodeMeaning(ViewCodeSequence_CodeMeaning);
+
+        String AcquisitionDeviceProcessingDescription = toTrimmedString( extra.get("AcquisitionDeviceProcessingDescription"), false);
+        s.setAcquisitionDeviceProcessingDescription(AcquisitionDeviceProcessingDescription);
+
+        return s;
+    }
+
+    public void writeJSON(Writer destinationWriter, long elapsedTime) throws IOException {
+        this.writeJSON(destinationWriter, elapsedTime, 4, 0, Integer.MAX_VALUE);
+    }
+
+    public void writeJSON(Writer destinationWriter, long elapsedTime, int depth, int offset, int psize) throws IOException {
         JSONWriter writer = new JSONWriter(destinationWriter);
         try {
             writer.object()
@@ -355,6 +319,8 @@ public class DIMGeneric
                 writer.key("results").array();
 
                 for (Patient p : this.patients) {
+                    if (offset-- > 0) continue;
+
                     writer.object()
                             .key("id").value(p.getPatientID())
                             .key("name").value(p.getPatientName())
@@ -377,7 +343,6 @@ public class DIMGeneric
 
                             if (depth > 2) {
                                 writer.key("series").array(); // begin series (array)
-                                // TODO
                                 for (Serie series : study.getSeries()) {
                                     String modality = series.getModality();
                                     int nimages = series.getSOPInstanceUIDList().size();
@@ -422,10 +387,13 @@ public class DIMGeneric
                         writer.endArray(); // end studies
                     }
                     writer.endObject(); // end patient
+                    if (--psize <= 0) break;
                 }
                 writer.endArray(); // end patients
             }
-            writer.endObject(); // end output
+            writer
+                    .key("elapsedTime").value(elapsedTime)
+                    .endObject(); // end output
         } catch (JSONException e) {
             throw new IOException("JSON serialization error", e);
         }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/core/dim/Patient.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/core/dim/Patient.java
@@ -19,7 +19,9 @@
 package pt.ua.dicoogle.core.dim;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Hashtable;
+import java.util.Map;
 
 /**
  *
@@ -27,25 +29,24 @@ import java.util.Hashtable;
  */
 public class Patient
 {
-    private String PatientID ;
-    private String PatientName ;
-    private String PatientSex ;
+    private String PatientID;
+    private String PatientName;
+    private String PatientSex;
     private String PatientBirthDate;
-    
 
-
-    private ArrayList<Study> studies = new ArrayList<Study>() ;
-    private Hashtable<String, Study> studiesHash = new Hashtable<String, Study>();
+    private ArrayList<Study> studies = new ArrayList<>() ;
+    private Map<String, Study> studiesHash = new HashMap<>();
+    private int nStudyOverride = -1;
 
     public Patient(String PatientID, String PatientName)
     {
-        this.PatientName = PatientName ;
-        this.PatientID = PatientID ; 
+        this.PatientName = PatientName;
+        this.PatientID = PatientID;
     }
+
     public Patient(String PatientID)
     {
-        this.PatientID = PatientID ;
-        
+        this.PatientID = PatientID;
     }
 
     /**
@@ -58,16 +59,15 @@ public class Patient
         if (this.studiesHash.containsKey(s.getStudyInstanceUID()))
         {
             /** 
-             * The studie exists, so it will take the series and add the series
+             * The study exists, so it will take the series and add the series
              */
 
             Study es = this.studiesHash.get(s.getStudyInstanceUID()) ;
             es.setStudyDescription(s.getStudyDescription());
             for (Serie e: s.getSeries())
             {
-                es.addSerie(e) ; 
+                es.addSerie(e);
             }
-            
            
         }
         else
@@ -83,12 +83,9 @@ public class Patient
      * will be returned. Otherwise a null is returned
      * @return s Stydy Result
      */
-    public Study getStudy(String instaceUID)
+    public Study getStudy(String studyInstanceUID)
     {
-
-        Study s = null ;
-
-        return null ;
+        return this.studiesHash.get(studyInstanceUID);
     }
 
 
@@ -168,6 +165,5 @@ public class Patient
     public void setPatientBirthDate(String PatientBirthDate) {
         this.PatientBirthDate = PatientBirthDate;
     }
-
 
 }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/core/dim/Study.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/core/dim/Study.java
@@ -26,8 +26,7 @@ import java.util.Hashtable;
  *
  * @author Luís A. Bastião Silva <bastiao@ua.pt>
  */
-public class Study
-{
+public class Study {
 
     private Patient parent;
     private String StudyInstanceUID ;
@@ -122,6 +121,10 @@ public class Study
      */
     public ArrayList<Serie> getSeries() {
         return series;
+    }
+
+    public Serie getSeries(String seriesInstanceUID) {
+        return this.seriesHash.get(seriesInstanceUID);
     }
 
     /**

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/search/SearchServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/search/SearchServlet.java
@@ -24,16 +24,16 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.*;
 
-import java.util.List;
 import java.util.Map.Entry;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
+
+import net.sf.json.JSONArray;
+import org.apache.commons.collections.ArrayStack;
+import org.json.JSONException;
+import org.json.JSONWriter;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import net.sf.json.JSONObject;
@@ -54,8 +54,9 @@ import pt.ua.dicoogle.sdk.task.Task;
  * @author Eduardo Pinho <eduardopinho@ua.pt>
  */
 public class SearchServlet extends HttpServlet {
+    private static final Logger logger = LoggerFactory.getLogger(SearchServlet.class);
 
-  private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
   
     private final Collection<String> DEFAULT_FIELDS = Arrays.asList(
             "SOPInstanceUID", "StudyInstanceUID", "SeriesInstanceUID", "PatientID",
@@ -76,16 +77,46 @@ public class SearchServlet extends HttpServlet {
   		else
   		searchType = stype;
   	}
-    //TODO: QIDO;
+
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         /*
-         Example: http://localhost:8080/search?query=wrix&keyword=false&provicer=lucene
+         Example: http://localhost:8080/search?query=wrix&keyword=false&provider=lucene&psize=10&offset=10
          */
+        response.setContentType("application/json");
+
         String query = request.getParameter("query");
         String providers[] = request.getParameterValues("provider");
         boolean keyword = Boolean.parseBoolean(request.getParameter("keyword"));
         String[] fields = request.getParameterValues("field");
+
+        final int psize;
+        final int offset;
+        final int depth;
+        try {
+            psize = getReqParameter(request, "psize", Integer.MAX_VALUE);
+            if (psize < 0) throw new NumberFormatException();
+        } catch (NumberFormatException e) {
+            sendError(response, 400, "Invalid parameter psize: must be a non-negative integer");
+            return;
+        }
+        try {
+            offset = getReqParameter(request, "offset", 0);
+            if (offset < 0) throw new NumberFormatException();
+        } catch (NumberFormatException e) {
+            sendError(response, 400, "Invalid parameter offset: must be a non-negative integer");
+            return;
+        }
+        try {
+            depth = getReqParameter(request, "depth", -1);
+            if (depth < -1 || depth > 4) throw new NumberFormatException();
+            if (this.searchType != SearchType.PATIENT && depth != -1) {
+                sendError(response, 400, "Parameter depth is only applicable to /searchDIM endpoint");
+            }
+        } catch (NumberFormatException e) {
+            sendError(response, 400, "Invalid parameter depth: must be an integer between 0 and 4");
+            return;
+        }
 
         // retrieve desired fields
         Set<String> actualFields;
@@ -94,9 +125,9 @@ public class SearchServlet extends HttpServlet {
         } else {
             actualFields = new HashSet<>(Arrays.asList(fields));
         }
-      
+
         if (StringUtils.isEmpty(query)) {
-            response.sendError(400, "No query supplied!");
+            sendError(response, 400, "No query supplied!");
             return;
         }
         
@@ -151,73 +182,94 @@ public class SearchServlet extends HttpServlet {
             }
         };
 
-        Iterable<SearchResult> results = null;
-        long elapsedTime = System.currentTimeMillis();
         try {
+            long elapsedTime = System.currentTimeMillis();
+            Iterable<SearchResult> results;
             if (queryAllProviders) {
                 results = PluginController.getInstance().queryAll(queryTaskHolder, query, extraFields).get();
             } else {
                 results = PluginController.getInstance().query(queryTaskHolder, knownProviders, query, extraFields).get();
             }
+            elapsedTime = System.currentTimeMillis() - elapsedTime;
+
+            if (this.searchType == SearchType.PATIENT) {
+                this.writeResponseDIM(response, results, elapsedTime, offset, psize, depth);
+            } else {
+                this.writeResponse(response, results, elapsedTime, offset, psize);
+            }
+
         } catch (InterruptedException | ExecutionException ex) {
-            LoggerFactory.getLogger(SearchServlet.class).error(ex.getMessage(), ex);
-        }
-        elapsedTime = System.currentTimeMillis()-elapsedTime;
-        
-        if (results == null) {
-            response.sendError(500, "Could not generate results!");
-            response.setContentType("application/json");
-            response.getWriter().append("{\"results\":[],\"error\":\"Could not generate results\"}");
+            logger.error("Failed to retrieve results", ex);
+            sendError(response, 500, "Could not generate results");
+            return;
+        } catch (JSONException e) {
+            logger.error("Failed to serialize results", e);
             return;
         }
-
-        ArrayList<SearchResult> resultsArr = new ArrayList<>();
-        for (SearchResult r : results) {
-            resultsArr.add(r);
-        }
-                
-        String json;
-        if(searchType == SearchType.PATIENT) {
-        	response.setContentType("application/json");
-            response.getWriter().append(getDIM(resultsArr));
-        	return;
-        }
-        json = processJSON(resultsArr, elapsedTime);
-
-        response.setContentType("application/json");
-        response.getWriter().append(json);
     }
 
-    private static String processJSON(Collection<SearchResult> results, long elapsedTime) {
-        JSONObject resp = new JSONObject();
-        for (SearchResult r : results) {
-            JSONObject rj = new JSONObject();
-            rj.put("uri", String.valueOf(r.getURI()));
-
-            JSONObject fields = new JSONObject();
-
-            for (Entry<String,Object> f : r.getExtraData().entrySet()) {
-                // remove padding from string representations before accumulating
-                fields.accumulate(f.getKey(), String.valueOf(f.getValue()).trim());
+    private void writeResponse(HttpServletResponse resp, Iterable<SearchResult> results, long elapsedTime, int offset, int psize) throws IOException, JSONException {
+        JSONWriter writer = new JSONWriter(resp.getWriter());
+        writer.object(); //begin output
+        // results
+        writer.key("results").array(); // begin results
+        int count = 0;
+        for (Iterator<SearchResult> it = results.iterator(); it.hasNext(); ++count) {
+            SearchResult res = it.next();
+            if (count < offset || count >= offset + psize) continue;
+            writer.object() // begin result
+                    .key("uri").value(res.getURI().toString())
+                    .key("fields").object();
+            for (Map.Entry<String, Object> e : res.getExtraData().entrySet()) {
+                writer.key(e.getKey()).value(String.valueOf(e.getValue()).trim());
             }
-            
-            rj.put("fields", fields);
-
-            resp.accumulate("results", rj);
+            writer.endObject().endObject(); // end result
         }
-        resp.put("numResults", results.size());
-        resp.put("elapsedTime", elapsedTime);
-
-        return resp.toString();
+        // other fields
+        writer.endArray() // end results
+                .key("elapsedTime").value(elapsedTime)
+                .key("numResults").value(count);
+        writer.endObject(); // end output
     }
-    
-    private static String getDIM(ArrayList<SearchResult> allresults){
-    	try {
-        	DIMGeneric dimModel = new DIMGeneric(allresults);
-            return dimModel.getJSON();
-		} catch (Exception e) {
-            LoggerFactory.getLogger(SearchServlet.class).warn("failed to get DIM", e);
-            return "";
-		}
+
+    private void writeResponseDIM(HttpServletResponse resp, Iterable<SearchResult> results, long elapsedTime, int offset, int psize, int depth) throws IOException {
+        try {
+            DIMGeneric dimModel = new DIMGeneric(collectPage(results, offset, psize));
+            if (depth == -1) {
+                resp.getWriter().append(dimModel.getJSON());
+            } else {
+                dimModel.writeJSON(resp.getWriter(), depth);
+            }
+        } catch (Exception e) {
+            logger.warn("Failed to get DIM", e);
+        }
+    }
+
+    private <T> List<T> collectPage(Iterable<T> iterable, int offset, int psize) {
+        int count = 0;
+        List<T> o = new ArrayList<>(psize > 128 ? 128 : psize);
+        for (Iterator<T> it = iterable.iterator(); it.hasNext() && count < offset + psize; ++count) {
+            T e = it.next();
+            if (count < offset) continue;
+            o.add(e);
+        }
+        return o;
+    }
+
+    private int getReqParameter(HttpServletRequest req, String name, int defaultValue) throws NumberFormatException {
+        String param = req.getParameter(name);
+        int val = defaultValue;
+        if (param != null) {
+            val = Integer.parseInt(param);
+        }
+        return val;
+    }
+
+    private static void sendError(HttpServletResponse resp, int code, String message) throws IOException {
+        resp.setStatus(500);
+        JSONObject obj = new JSONObject();
+        obj.put("results", new JSONArray());
+        obj.put("error", message);
+        resp.getWriter().append(obj.toString());
     }
 }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/search/SearchServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/search/SearchServlet.java
@@ -107,15 +107,25 @@ public class SearchServlet extends HttpServlet {
             sendError(response, 400, "Invalid parameter offset: must be a non-negative integer");
             return;
         }
-        try {
-            depth = getReqParameter(request, "depth", -1);
-            if (depth < -1 || depth > 4) throw new NumberFormatException();
-            if (this.searchType != SearchType.PATIENT && depth != -1) {
+        String paramDepth = request.getParameter("depth");
+        if (paramDepth != null) {
+            if (this.searchType != SearchType.PATIENT) {
                 sendError(response, 400, "Parameter depth is only applicable to /searchDIM endpoint");
+                return;
             }
-        } catch (NumberFormatException e) {
-            sendError(response, 400, "Invalid parameter depth: must be an integer between 0 and 4");
-            return;
+            switch (paramDepth.toLowerCase()) {
+                case "none": depth = 0; break;
+                case "patient": depth = 1; break;
+                case "study": depth = 2; break;
+                case "series": depth = 3; break;
+                case "images": depth = 4; break;
+                default:
+                sendError(response, 400, "Invalid parameter depth: must be a valid level: "
+                        + "'none', 'patient', 'study', 'series' or 'images'");
+                return;
+            }
+        } else {
+            depth = 4;
         }
 
         // retrieve desired fields


### PR DESCRIPTION
- Optimized memory usage of `DIMGeneric` and `SearchServlet` by avoiding in-memory JSON representations.
- Added new parameters `psize` (page size) and `offset` to `/search` in order to have pagination.
   - When provided, the length of `results` will be at most `psize`, and the first `offset` results are not sent.
   - `numResults` still shows the total number of results obtained from the search (it is not clamped when paging)
- Added parameter `depth` to `/searchDIM` in order to restrict rendering certain levels of the DIM hierarchy.
   - `depth` can be either "none", "patient", "study", "series" or "images" (default)
   - "none", although apparently useless, can be used to retrieve only the number of patients.
- Adjusted search service output to always be valid JSON, even in case of error.

![screenshot_2016-06-01_00-30-22](https://cloud.githubusercontent.com/assets/4738426/15693934/78fe25f4-2791-11e6-9fdd-3faed9734138.png)
