### PR TITLE
Human-readable elapsed time in task status

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/js/components/indexer/TaskStatus.jsx
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/js/components/indexer/TaskStatus.jsx
@@ -1,4 +1,5 @@
 import React, {PropTypes} from 'react';
+import {toHumanReadable} from '../../utils/time';
 
 class TaskStatus extends React.Component {
   constructor(props) {
@@ -62,7 +63,7 @@ class TaskStatus extends React.Component {
       <p><b>Name: </b> {item.taskName}</p>
       <div style={{visibility: item.complete ? '' : 'hidden'}}>
           {(typeof item.elapsedTime === 'number') && (
-            <p><b>Elapsed Time: </b> {item.elapsedTime} ms</p>)}
+            <p><b>Elapsed Time: </b> {toHumanReadable(item.elapsedTime)}</p>)}
           {(typeof item.nIndexed === 'number') && (
             <p><b>Indexed: </b> {item.nIndexed} </p>)}
           {(typeof item.nErrors === 'number') && (

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/js/utils/time.js
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/js/utils/time.js
@@ -1,0 +1,44 @@
+
+/** Split a duration into human-readable parts.
+ *
+ * @param {number} time a number representing the number of milliseconds
+ * @return {array[]} an array representing the parts of the given duration,
+ * in least significant order: ms, s, m, h, d. The returned array will have
+ * a shorter length if the remaining parts are 0 (but the array will always
+ * have at least one element).
+ */
+export function splitTime(time) {
+    const o = [];
+    o.push(time % 1000); // ms
+    time = (time / 1000) | 0;
+    if (time === 0) return o;
+
+    o.push(time % 60) // s
+    time = (time / 60) | 0;
+    if (time === 0) return o;
+
+    o.push(time % 60); // m
+    time = (time / 60) | 0;
+    if (time === 0) return o;
+
+    o.push(time % 24); // h
+    time = (time / 24) | 0;
+    if (time === 0) return o;
+
+    o.push(time); // d
+    return o;
+}
+
+/** Convert a duration into human-readable text
+ * @param {number} timeValue a number representing the number of milliseconds
+ * @return {string} a text representing the duration. Example: "2h 17m 20s 837ms"
+ */
+export function toHumanReadable(timeValue) {
+    const suffix = ['ms', 's', 'm', 'h', 'd'];
+
+    const parts = splitTime(timeValue);
+
+    return parts.map((v, i) =>
+      v + suffix[i]
+    ).reduceRight((pval, cval) => pval + ' ' + cval);
+}


### PR DESCRIPTION
Before:
![screenshot_2016-06-13_13-56-45](https://cloud.githubusercontent.com/assets/4738426/16008911/431ccc84-3172-11e6-98b6-d4cf34dfce5f.png)

After:
![screenshot_2016-06-13_14-20-19](https://cloud.githubusercontent.com/assets/4738426/16008916/47797d68-3172-11e6-8f52-a7c52af623fa.png)
