### PR TITLE
DICOM Logging: avoid multiple access at the same time (causing lock)

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/queryretrieve/CFindServiceSCP.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/queryretrieve/CFindServiceSCP.java
@@ -160,14 +160,18 @@ public class CFindServiceSCP extends CFindService {
             LogLine ll = new LogLine("cfind", getDateTime(), as.getCallingAET(),
                     as.toString() + " -- " + add, queryParams);
             LogDICOM.getInstance().addLine(ll);
-            LogXML l = new LogXML();
-            try {
-                l.printXML();
-            } catch (TransformerConfigurationException ex) {
-                ex.printStackTrace();
+
+            synchronized (LogDICOM.getInstance()) {
+                LogXML l = new LogXML();
+                try {
+                    l.printXML();
+                } catch (TransformerConfigurationException ex) {
+                    ex.printStackTrace();
+                }
             }
-            Logs.getInstance().addLog(ll);
+
         }
+        //Logs.getInstance().addLog(ll);
 
 
         return replay;
@@ -186,7 +190,7 @@ public class CFindServiceSCP extends CFindService {
         return service;
     }
 
-    /**
+    /**<
      * @param service the service to set
      */
     public void setService(DicomNetwork service) {

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/queryretrieve/CMoveServiceSCP.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/queryretrieve/CMoveServiceSCP.java
@@ -241,16 +241,17 @@ public class CMoveServiceSCP extends CMoveService {
             LogLine ll = new LogLine("cmove", LogLine.getDateTime(), destination,
                     "Files: " + files.size() + " -- (" + hostDest + ":" + portAddr + ")","studyUID="+data.getString(Tag.StudyInstanceUID));
             LogDICOM.getInstance().addLine(ll);
-            LogXML l = new LogXML();
 
-            try
-            {
-                l.printXML();
-            } catch (TransformerConfigurationException ex) {
-                LoggerFactory.getLogger(CMoveServiceSCP.class).error(ex.getMessage(), ex);
+            synchronized (LogDICOM.getInstance()) {
+                try {
+                    LogXML l = new LogXML();
+                    l.printXML();
+                } catch (TransformerConfigurationException ex) {
+                    LoggerFactory.getLogger(CMoveServiceSCP.class).error(ex.getMessage(), ex);
+                }
             }
 
-            Logs.getInstance().addLog(ll);
+            //Logs.getInstance().addLog(ll);
             if (CMoveID==null||CMoveID.equals(""))
             {
                 //DebugManager.getInstance().debug("No originator message ID");


### PR DESCRIPTION
When trying to logging dicom queries at same time.
