### PR TITLE
Cached endpoint for web plugin modules

### DIFF
--- a/dicoogle/pom.xml
+++ b/dicoogle/pom.xml
@@ -20,7 +20,6 @@
 
         <maven.build.timestamp.format>yyyyMMdd_HHmm</maven.build.timestamp.format>
         <buildNumber>${maven.build.timestamp}</buildNumber>
-
     </properties>
 
     <repositories>

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/AbstractCacheFilter.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/AbstractCacheFilter.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) 2014  Universidade de Aveiro, DETI/IEETA, Bioinformatics Group - http://bioinformatics.ua.pt/
+ *
+ * This file is part of Dicoogle/dicoogle.
+ *
+ * Dicoogle/dicoogle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Dicoogle/dicoogle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Dicoogle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ */
+
+package pt.ua.dicoogle.server.web;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+/** A filter that can deal with non-static content caching.
+ * @author Eduardo Pinho <eduardopinho@ua.pt>
+ */
+public abstract class AbstractCacheFilter implements Filter {
+    
+    public static String CACHE_CONTROL_HEADER = "Cache-Control";
+    public static String IF_NONE_MATCH_HEADER = "If-None-Match";
+    public static String ETAG_HEADER = "ETag";
+
+    public static String CACHE_CONTROL_PARAM = "cacheControl";
+
+    private String cacheControl;
+
+    @Override
+    public void init(FilterConfig fc) throws ServletException {
+        this.cacheControl = fc.getInitParameter(CACHE_CONTROL_PARAM);
+    }
+
+    @Override
+    public void doFilter(ServletRequest sreq, ServletResponse sresp, FilterChain fc) throws IOException, ServletException {
+        if (sresp instanceof HttpServletResponse && sreq instanceof HttpServletRequest) {
+            HttpServletResponse resp = (HttpServletResponse) sresp;
+            HttpServletRequest req = (HttpServletRequest)sreq;
+
+            if (cacheControl != null) {
+                resp.addHeader(CACHE_CONTROL_HEADER, cacheControl);
+            }
+            String ifNoneMatchParam = req.getHeader(IF_NONE_MATCH_HEADER);
+            String thisETag = this.etag(req);
+            if (thisETag != null) {
+                resp.setHeader(ETAG_HEADER, thisETag);
+                if (ifNoneMatchParam != null) {
+                    List<String> matches = Arrays.asList(ifNoneMatchParam.split(" *, *"));
+                    if (matches.contains(thisETag)) {
+                        // intercept request, send 304
+                        resp.setStatus(304);
+                        return;
+                    }
+                }
+            }
+        }
+        fc.doFilter(sreq, sresp);
+    }
+
+    protected abstract String etag(HttpServletRequest req);
+
+    @Override
+    public void destroy() {
+    }
+}

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/DicoogleWeb.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/DicoogleWeb.java
@@ -18,6 +18,9 @@
  */
 package pt.ua.dicoogle.server.web;
 
+import org.apache.commons.codec.digest.Md5Crypt;
+import pt.ua.dicoogle.plugins.PluginController;
+import pt.ua.dicoogle.plugins.webui.WebUIPlugin;
 import pt.ua.dicoogle.server.web.rest.VersionResource;
 import pt.ua.dicoogle.server.web.servlets.RestletHttpServlet;
 import pt.ua.dicoogle.server.web.servlets.ExportToCSVServlet;
@@ -60,6 +63,8 @@ import org.eclipse.jetty.webapp.WebAppContext;
 
 import javax.servlet.DispatcherType;
 import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+
 import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.HandlerWrapper;
@@ -73,6 +78,7 @@ import pt.ua.dicoogle.server.LegacyRestletApplication;
 import pt.ua.dicoogle.server.web.servlets.accounts.LogoutServlet;
 import pt.ua.dicoogle.server.web.servlets.management.UnindexServlet;
 import pt.ua.dicoogle.server.web.servlets.search.DumpServlet;
+import pt.ua.dicoogle.server.web.servlets.webui.WebUIModuleServlet;
 import pt.ua.dicoogle.server.web.servlets.webui.WebUIServlet;
 import pt.ua.dicoogle.server.web.utils.LocalImageCache;
 import pt.ua.dicoogle.server.PluginRestletApplication;
@@ -150,11 +156,12 @@ public class DicoogleWeb {
         final WebAppContext webpages = new WebAppContext(warUrlString, CONTEXTPATH);
         webpages.setInitParameter("org.eclipse.jetty.servlet.Default.dirAllowed", "false"); // disables directory listing
         webpages.setInitParameter("useFileMappedBuffer", "false");
-        webpages.setInitParameter("cacheControl", "max-age=0, public");
-
+        webpages.setInitParameter("cacheControl", "public, max-age=2592000"); // cache for 30 days
+        webpages.setInitParameter("etags", "true"); // generate and handle weak entity validation tags
+        webpages.setDisplayName("webapp");
         webpages.setWelcomeFiles(new String[]{"index.html"});
         webpages.addServlet(new ServletHolder(new SearchHolderServlet()), "/search/holders");
-        FilterHolder gzFilter = webpages.addFilter(GzipFilter.class, "/*", EnumSet.of(DispatcherType.REQUEST));
+        webpages.addFilter(GzipFilter.class, "/*", EnumSet.of(DispatcherType.REQUEST));
         
         this.pluginApp = new PluginRestletApplication();
         this.pluginHandler = createServletHandler(new RestletHttpServlet(this.pluginApp), "/ext/*");
@@ -199,6 +206,7 @@ public class DicoogleWeb {
             createServletHandler(new ServicesServlet(ServicesServlet.PLUGIN), "/management/plugins/"),
             createServletHandler(new AETitleServlet(), "/management/settings/dicom"),
             createServletHandler(new WebUIServlet(), "/webui"),
+            createWebUIModuleServletHandler(),
             createServletHandler(new LoggerServlet(), "/logger"),
             createServletHandler(new RunningTasksServlet(), "/index/task"),
             createServletHandler(new ExportServlet(ExportType.EXPORT_CVS), "/export/cvs"),
@@ -217,7 +225,37 @@ public class DicoogleWeb {
         // and then start the server
         server.start();
     }
-    
+
+    private ServletContextHandler createWebUIModuleServletHandler() {
+        ServletContextHandler handler = new ServletContextHandler(ServletContextHandler.SESSIONS); // servlet with session support enabled
+        handler.setContextPath(CONTEXTPATH);
+
+        HttpServlet servletModule = new WebUIModuleServlet();
+        // CORS support
+        this.addCORSFilter(handler);
+        // Caching!
+        FilterHolder cacheHolder = new FilterHolder(new AbstractCacheFilter() {
+            @Override
+            protected String etag(HttpServletRequest req) {
+                String name = req.getRequestURI().substring("/webui/module/".length());
+                WebUIPlugin plugin = PluginController.getInstance().getWebUIPlugin(name);
+                if (plugin == null) return null;
+                if (WebUIModuleServlet.isPrerelease(plugin.getVersion())) {
+                    // pre-release, use hash (to facilitate development)
+                    String fingerprint = PluginController.getInstance().getWebUIModuleJS(name);
+                    return '"' + Md5Crypt.md5Crypt(fingerprint.getBytes()) + '"';
+                } else {
+                    // normal release, use weak ETag
+                    return "W/\"" + plugin.getName() + '@' + plugin.getVersion() + '"';
+                }
+            }
+        });
+        cacheHolder.setInitParameter(AbstractCacheFilter.CACHE_CONTROL_PARAM, "private, max-age=2592000"); // cache for 30 days
+        handler.addFilter(cacheHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
+        handler.addServlet(new ServletHolder(servletModule), "/webui/module/*");
+        return handler;
+    }
+
     private ServletContextHandler createServletHandler(HttpServlet servlet, String path){
         ServletContextHandler handler = new ServletContextHandler(ServletContextHandler.SESSIONS); // servlet with session support enabled
         handler.setContextPath(CONTEXTPATH);
@@ -228,7 +266,7 @@ public class DicoogleWeb {
         handler.addServlet(new ServletHolder(servlet), path);
         return handler;
     }
-    
+
     private void addCORSFilter(ServletContextHandler handler) {
         String origins = ServerSettings.getInstance().getWeb().getAllowedOrigins();
         if (origins != null) {

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/DicoogleWeb.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/DicoogleWeb.java
@@ -246,7 +246,13 @@ public class DicoogleWeb {
                     return '"' + Md5Crypt.md5Crypt(fingerprint.getBytes()) + '"';
                 } else {
                     // normal release, use weak ETag
-                    return "W/\"" + plugin.getName() + '@' + plugin.getVersion() + '"';
+                    String pProcess = req.getParameter("process");
+                    boolean process = pProcess == null || Boolean.parseBoolean(pProcess);
+                    if (process) {
+                        return "W/\"" + plugin.getName() + '@' + plugin.getVersion() + '"';
+                    } else {
+                        return "W/\"" + plugin.getName() + '@' + plugin.getVersion() + ";raw\"";
+                    }
                 }
             }
         });

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/webui/WebUIModuleServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/webui/WebUIModuleServlet.java
@@ -36,7 +36,7 @@ import java.nio.ByteBuffer;
 /**
  * Retrieval of web UI plugins and respective packages/modules.
  * 
- * <b>This API is unstable. It is currently only compatible with dicoogle-webcore 0.13.x</b>
+ * <b>This API is unstable. It is currently only compatible with dicoogle-webcore 0.14.x</b>
  *
  * @author Eduardo Pinho
  */

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/webui/WebUIModuleServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/webui/WebUIModuleServlet.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (C) 2014  Universidade de Aveiro, DETI/IEETA, Bioinformatics Group - http://bioinformatics.ua.pt/
+ *
+ * This file is part of Dicoogle/dicoogle.
+ *
+ * Dicoogle/dicoogle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Dicoogle/dicoogle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Dicoogle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pt.ua.dicoogle.server.web.servlets.webui;
+
+import org.apache.commons.codec.binary.Base64;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import pt.ua.dicoogle.plugins.PluginController;
+import pt.ua.dicoogle.plugins.webui.WebUIPlugin;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.ByteBuffer;
+
+/**
+ * Retrieval of web UI plugins and respective packages/modules.
+ * 
+ * <b>This API is unstable. It is currently only compatible with dicoogle-webcore 0.13.x</b>
+ *
+ * @author Eduardo Pinho
+ */
+public class WebUIModuleServlet extends HttpServlet {
+    private static final Logger logger = LoggerFactory.getLogger(WebUIModuleServlet.class);
+    
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        String name = req.getRequestURI().substring("/webui/module/".length());
+        if (name.isEmpty()) {
+            resp.sendError(400);
+            return;
+        }
+        logger.debug("Service request: retrieve webplugin module {}", name);
+
+        String process = req.getParameter("process");
+
+        resp.setContentType("application/javascript");
+        boolean doProcess = process == null || Boolean.parseBoolean(process);
+
+        WebUIPlugin plugin = PluginController.getInstance().getWebUIPlugin(name);
+        if (plugin == null) {
+            resp.sendError(404);
+            return;
+        }
+        String js = PluginController.getInstance().getWebUIModuleJS(name);
+
+        this.writeModule(resp.getWriter(), name, js, doProcess);
+    }
+
+    /** Convert from dash-lowercase to camelCase
+     * @param s a string in dash-lowercase
+     * @return a string in camelCase
+     */
+    public static String camelize(String s) {
+        String [] words = s.split("-");
+        if (words.length == 0) return "";
+        String t = words[0];
+        for (int i = 1 ; i < words.length ; i++) {
+            if (!words[i].isEmpty()) {
+                t += Character.toUpperCase(words[i].charAt(0)) + words[i].substring(1);
+            }
+        }
+        return t;
+    }
+
+    public static boolean isPrerelease(String version) {
+        return version.indexOf('-') != -1;
+    }
+    
+    public static void writeModule(Writer writer, String name, String module, boolean process) throws IOException {
+        if (process) {
+            writer.append("(function(r,f){\n");
+            writer.append("var w=r.DicoogleWebcore||require(\"dicoogle-webcore\");");
+            writer.append("if (w.__esModule)w=w.default;");
+            writer.append("var c=(r.Dicoogle||require(\"dicoogle-client\"))();");
+            writer.append("var m={exports:{}};");
+            writer.append("f(c,m,m.exports);");
+            writer.append("var o=m.exports.__esModule?m.exports.default:m.exports;");
+            writer.append("w.constructors[\"");
+              writer.append(name);
+              writer.append("\"]=o;");
+            writer.append("w.onRegister(new o(),\"");
+              writer.append(name);
+              writer.append("\");");
+            writer.append("})(this,function(Dicoogle,module,exports){\n");
+        }
+        writer.append(module);
+        if (process) {
+            writer.append("});\n");
+        }
+    }
+}

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/webui/WebUIServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/webui/WebUIServlet.java
@@ -42,7 +42,7 @@ import pt.ua.dicoogle.server.web.auth.Authentication;
 /**
  * Retrieval of web UI plugins and respective packages/modules.
  * 
- * <b>This API is unstable. It is currently only compatible with dicoogle-webcore 0.10.x</b>
+ * <b>This API is unstable. It is currently only compatible with dicoogle-webcore 0.12.x and 0.13.x</b>
  *
  * @author Eduardo Pinho
  */
@@ -55,7 +55,6 @@ public class WebUIServlet extends HttpServlet {
         String[] slotIdArr = req.getParameterValues("slot-id");
         String module = req.getParameter("module");
         String process = req.getParameter("process");
-
 
         if (name != null) {
             resp.setContentType("application/json");
@@ -137,7 +136,11 @@ public class WebUIServlet extends HttpServlet {
         }
         return t;
     }
-    
+
+    /**
+     * @deprecated Use the endpoint associated to the {@link WebUIModuleServlet} instead
+     */
+    @Deprecated
     public static String processModule(String name, String module, boolean process) {
         StringBuilder writer = new StringBuilder();
         if (process) {

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/webui/WebUIServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/webui/WebUIServlet.java
@@ -42,7 +42,7 @@ import pt.ua.dicoogle.server.web.auth.Authentication;
 /**
  * Retrieval of web UI plugins and respective packages/modules.
  * 
- * <b>This API is unstable. It is currently only compatible with dicoogle-webcore 0.12.x and 0.13.x</b>
+ * <b>This API is unstable. It is currently only compatible with dicoogle-webcore >= 0.12.x && <= 0.14.x</b>
  *
  * @author Eduardo Pinho
  */

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/webui/WebUIServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/webui/WebUIServlet.java
@@ -56,22 +56,23 @@ public class WebUIServlet extends HttpServlet {
         String module = req.getParameter("module");
         String process = req.getParameter("process");
 
+        resp.setContentType("application/json");
         if (name != null) {
-            resp.setContentType("application/json");
             resp.getWriter().append(this.getPlugin(resp, name));
         } else if (module != null) {
+            /**
+             * deprecated: Use {@link WebUIModuleServlet} instead
+             */
             resp.setContentType("application/javascript");
             boolean doProcess = process == null || Boolean.parseBoolean(process);
-            resp.getWriter().append(this.getModule(resp, module, doProcess));
+            resp.sendRedirect("/webui/module/" + module + (!doProcess ? "?process=false" : ""));
         } else {
-            resp.setContentType("application/json");
-            resp.getWriter().append(this.getPluginsBySlot(req, resp, slotIdArr));
+            resp.getWriter().append(this.getPluginsBySlot(req, slotIdArr));
         }
     }
 
     /** Retrieve plugins. */
-    private String getPluginsBySlot(HttpServletRequest req,
-                                    HttpServletResponse resp, String... slotIds) throws IOException {
+    private String getPluginsBySlot(HttpServletRequest req, String... slotIds) throws IOException {
         String token = req.getHeader("Authorization");
         User user = Authentication.getInstance().getUsername(token);
 
@@ -110,17 +111,6 @@ public class WebUIServlet extends HttpServlet {
         return json;
     }
 
-    private String getModule(HttpServletResponse resp, String name, boolean process) throws IOException {
-        resp.setContentType("application/javascript");
-        WebUIPlugin plugin = PluginController.getInstance().getWebUIPlugin(name);
-        if (plugin == null) {
-            return null;
-        }
-        String js = PluginController.getInstance().getWebUIModuleJS(name);
-        
-        return processModule(name, js, process);
-    }
-    
     /** Convert from dash-lowercase to camelCase
      * @param s a string in dash-lowercase
      * @return a string in camelCase
@@ -128,41 +118,14 @@ public class WebUIServlet extends HttpServlet {
     public static String camelize(String s) {
         String [] words = s.split("-");
         if (words.length == 0) return "";
-        String t = words[0];
+        StringBuilder t = new StringBuilder();
+        t.append(words[0]);
         for (int i = 1 ; i < words.length ; i++) {
             if (!words[i].isEmpty()) {
-                t += Character.toUpperCase(words[i].charAt(0)) + words[i].substring(1);
+                t.append(Character.toUpperCase(words[i].charAt(0)));
+                t.append(words[i].substring(1));
             }
         }
-        return t;
-    }
-
-    /**
-     * @deprecated Use the endpoint associated to the {@link WebUIModuleServlet} instead
-     */
-    @Deprecated
-    public static String processModule(String name, String module, boolean process) {
-        StringBuilder writer = new StringBuilder();
-        if (process) {
-            writer.append("(function(root,factory){\n");
-            writer.append("var w=root.DicoogleWebcore||require(\"dicoogle-webcore\");");
-            writer.append("if (w.__esModule)w=w.default;");
-            writer.append("var c=(root.Dicoogle||require(\"dicoogle-client\"))();");
-            writer.append("var m={exports:{}};");
-            writer.append("factory(c,m,m.exports);");
-            writer.append("var o=m.exports.__esModule?m.exports.default:m.exports;");
-            writer.append("w.constructors[\"");
-              writer.append(name);
-              writer.append("\"]=o;");
-            writer.append("w.onRegister(new o(),\"");
-              writer.append(name);
-              writer.append("\");");
-            writer.append("})(this,function(Dicoogle,module,exports){\n");
-        }
-        writer.append(module);
-        if (process) {
-            writer.append("});\n");
-        }
-        return writer.toString();
+        return t.toString();
     }
 }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/package.json
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/package.json
@@ -11,12 +11,12 @@
     "webapp"
   ],
   "contributors": [
-    "Luís A. Bastião <bastiao@ua.pt>",
+    "Luís A. Bastião <bastiao@bmd-software.com>",
     "Frederico Silva <fredericosilva@ua.pt>",
     "Eduardo Pinho <eduardopinho@ua.pt>"
   ],
   "maintainers": [
-    "Luís A. Bastião <bastiao@ua.pt>",
+    "Luís A. Bastião <bastiao@bmd-software.com>",
     "Eduardo Pinho <eduardopinho@ua.pt>"
   ],
   "repository": {
@@ -39,7 +39,7 @@
   "dependencies": {
     "bootstrap": "^3.3.2",
     "core-js": "^2.0.3",
-    "dicoogle-client": "^3.0.2",
+    "dicoogle-client": "^3.6.0",
     "dicoogle-webcore": "../../../../../../../../../../../webcore",
     "history": "^3.0.0",
     "jquery": "^1.10.2",

--- a/webcore/package.json
+++ b/webcore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dicoogle-webcore",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "private": true,
   "author": "Universidade de Aveiro, DETI/IEETA, Bioinformatics Group (http://bioinformatics.ua.pt/)",
   "maintainers": [

--- a/webcore/src/dicoogle-webcore.js
+++ b/webcore/src/dicoogle-webcore.js
@@ -494,7 +494,7 @@ const DicoogleWebcore = (function () {
         }
     };
     script.onload = script.onreadystatechange = onLoadHandler;
-    script.src = base_url+'/webui?module='+moduleName+'&process=true';
+    script.src = base_url+'/webui/module/'+moduleName;
     prior.parentNode.insertBefore(script, prior);
   }
 


### PR DESCRIPTION
- Created a new endpoint (with caching directives) for retrieving web plugin JS modules (`/webui/module/«package-name»`) and updated webcore to use the new endpoint; the old one (`/webui?module=...`) will still work, but is deprecated.
- Updated dicoogle-client dependency to latest;
- Tweaked cache control directives in webpages context.