### PR TITLE
Resolve cancellation issue on running tasks service

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/management/RunningTasksServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/management/RunningTasksServlet.java
@@ -40,12 +40,7 @@ public class RunningTasksServlet extends HttpServlet {
 			throws ServletException, IOException {
 		
 		resp.setContentType("application/json");
-		try {
-			resp.getWriter().write(RunningIndexTasks.getInstance().toJson());
-		} catch (InterruptedException | ExecutionException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
+		resp.getWriter().write(RunningIndexTasks.getInstance().toJson());
 	}
 
 	@Override

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/js/components/indexer/TaskStatus.jsx
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/webapp/WEB-INF/js/components/indexer/TaskStatus.jsx
@@ -12,6 +12,7 @@ class TaskStatus extends React.Component {
       item: PropTypes.shape({
           taskUid: PropTypes.string.isRequired,
           complete: PropTypes.bool,
+          canceled: PropTypes.bool,
           taskProgress: PropTypes.number,
           elapsedTime: PropTypes.number,
           nIndexed: PropTypes.number,
@@ -23,9 +24,9 @@ class TaskStatus extends React.Component {
 
   render() {
     const {item, onCloseStopClicked} = this.props;
-    const {complete} = item;
+    const {complete, canceled} = item;
     const unknownPercentage = (typeof item.taskProgress !== 'number' || item.taskProgress < 0);
-    const percentage = (complete || unknownPercentage) ? '100%'
+    const percentage = (complete || canceled || unknownPercentage) ? '100%'
       : (Math.round(item.taskProgress * 100) + '%');
 
     let barstate = "indexprogress progress-bar progress-bar-striped";
@@ -37,9 +38,15 @@ class TaskStatus extends React.Component {
       barstate += " progress-bar-info active";
     } else {
       barstate += " progress-bar-success";
-      if (!complete) {
+      if (!complete && !canceled) {
         barstate += " active";
       }
+    }
+    const barStyle = {
+      width: percentage
+    };
+    if (canceled) {
+      barStyle.backgroundColor = '#CCCCCC';
     }
 
   return (
@@ -47,14 +54,14 @@ class TaskStatus extends React.Component {
        <div className="row">
       <div className="col-sm-10">
         <div className="progress indexstatusprogress">
-          <div style={{width: percentage}} className={barstate} role="progressbar" aria-valuemin="0" aria-valuemax="100">
-            {!unknownPercentage && percentage}
+          <div style={barStyle} className={barstate} role="progressbar" aria-valuemin="0" aria-valuemax="100">
+            {canceled ? 'canceled' : (!unknownPercentage && percentage)}
           </div>
         </div>
       </div>
       <div className="col-sm-2">
         <button className="btn btn-danger" onClick={onCloseStopClicked}>
-          {complete ? "Close" : "Stop"}
+          {(complete || canceled) ? "Close" : "Stop"}
         </button>
       </div>
     </div>


### PR DESCRIPTION
Fixes #127, to some extent...

- fix server throwing an exception (CancellationException) when requesting for the running services after a task stop was requested
- add "canceled" attribute to the running task information output (visible only when true)
- adjust webapp to recognize canceled tasks (will show a grey progress bar)

![screenshot_2016-07-15_15-42-16](https://cloud.githubusercontent.com/assets/4738426/16878117/3a0ad074-4aa3-11e6-91e8-a0d2a84a6bb2.png)

The bad news is that this doesn't solve the problem entirely: our Lucene plugin doesn't stop indexing when a termination is triggered. I also don't believe it's safe for an indexation procedure to be terminated like this. For the time being however, this fix will make Dicoogle work much better than before, and should stage in the next release.
