### PR TITLE
Correct default logging configuration file

### DIFF
--- a/dicoogle/pom.xml
+++ b/dicoogle/pom.xml
@@ -78,19 +78,20 @@
             <resource>
                 <directory>src/main/resources</directory>
                 <includes>
-						<include>webapp/assets/**</include>
-						<include>webapp/bootstrap/css/*.css</include>
-						<include>webapp/bootstrap/fonts/*</include>
-						<include>webapp/fonts/**</include>
-						<include>webapp/css/**</include>
-						<include>webapp/lib/**</include>
-						<include>webapp/index.html</include>
+                    <include>log4j2.xml</include>
+                    <include>webapp/assets/**</include>
+                    <include>webapp/bootstrap/css/*.css</include>
+                    <include>webapp/bootstrap/fonts/*</include>
+                    <include>webapp/fonts/**</include>
+                    <include>webapp/css/**</include>
+                    <include>webapp/lib/**</include>
+                    <include>webapp/index.html</include>
                 </includes>
-   <excludes>
-<exclude>META-INF/*.SF</exclude>
-<exclude>META-INF/*.DSA</exclude>
-<exclude>META-INF/*.RSA</exclude>
-                                     </excludes>
+                <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                </excludes>
             </resource>
            <resource>
                <directory>src/main/resources</directory>

--- a/dicoogle/src/main/resources/log4j2.xml
+++ b/dicoogle/src/main/resources/log4j2.xml
@@ -13,11 +13,16 @@
         </RollingRandomAccessFile>
     </Appenders>
     <Loggers>
-        <Root level="debug">
+        <Root level="info">
             <AppenderRef ref="STDOUT" level="info" />
             <AppenderRef ref="Rolling" level="info" />
         </Root>
         <Logger name="pt.ua.dicoogle" level="info" additivity="false">
+            <AppenderRef ref="STDOUT" />
+            <AppenderRef ref="Rolling" />
+        </Logger>
+        <Logger name="org.eclipse.jetty" additivity="false">
+            <AppenderRef ref="STDOUT" level="warn" />
             <AppenderRef ref="Rolling" level="info" />
         </Logger>
     </Loggers>


### PR DESCRIPTION
The latest version was not importing log4j2.xml as a resource, which led to poor logging capabilities without specifying a log4j2 config file explicitly.

This PR also increases the logging level of Jetty loggers to "warn", which reduces the number of useless log entries when Dicoogle boots.