### PR TITLE
Purge semaphores from active code

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/DicomLog/LogDICOM.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/DicomLog/LogDICOM.java
@@ -20,7 +20,6 @@
 package pt.ua.dicoogle.DicomLog;
 
 import java.util.ArrayList;
-import java.util.concurrent.Semaphore;
 import org.slf4j.LoggerFactory;
 import javax.xml.transform.TransformerConfigurationException;
 
@@ -31,7 +30,6 @@ import javax.xml.transform.TransformerConfigurationException;
 public class LogDICOM{
 
     private static LogDICOM instance = null ;
-    private static Semaphore sem = new Semaphore(1, true);
 
     private ArrayList<LogLine> ll = new ArrayList<LogLine>(); 
 
@@ -43,18 +41,8 @@ public class LogDICOM{
 
     public static synchronized LogDICOM getInstance()
     {
-        try
-        {
-            sem.acquire();
-            if (instance == null)
-            {
-                instance = new LogDICOM();
-            }
-            sem.release();
-        }
-        catch (InterruptedException ex)
-        {
-            LoggerFactory.getLogger(LogDICOM.class).error(ex.getMessage(), ex);
+        if (instance == null) {
+            instance = new LogDICOM();
         }
         return instance;
     }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/core/ExportDataSupport.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/core/ExportDataSupport.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Observable;
 import java.util.Observer;
-import java.util.concurrent.Semaphore;
 import org.slf4j.LoggerFactory;
 
 import pt.ua.dicoogle.plugins.PluginController;
@@ -52,7 +51,6 @@ public class ExportDataSupport extends Observable implements Observer, Serializa
     private ArrayList<String> tags;
     private String filePath;
 
-    private static Semaphore semFile = new Semaphore(1, true);
     private ListObservableSearch obsAux = null;
 
     

--- a/dicoogle/src/main/java/pt/ua/dicoogle/core/QueryHistorySupport.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/core/QueryHistorySupport.java
@@ -27,8 +27,6 @@ import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Observable;
-import java.util.concurrent.Semaphore;
-import org.slf4j.LoggerFactory;
 
 import pt.ua.dicoogle.sdk.Utils.Platform;
 
@@ -44,22 +42,11 @@ public class QueryHistorySupport extends Observable {
     private static String fileName = Platform.homePath() + "QueryHistory.ser";
 
     private static QueryHistorySupport instance = null;
-    private static Semaphore sem = new Semaphore(1, true);
 
     public static synchronized QueryHistorySupport getInstance()
     {
-        try
-        {
-            sem.acquire();
-            if (instance == null)
-            {
-                instance = new QueryHistorySupport();
-            }
-            sem.release();
-        }
-        catch (InterruptedException ex)
-        {
-            LoggerFactory.getLogger(QueryHistorySupport.class).error(ex.getMessage(), ex);
+        if (instance == null) {
+            instance = new QueryHistorySupport();
         }
         return instance;
     }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/SOPList.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/SOPList.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.List;
-import java.util.concurrent.Semaphore;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,7 +40,6 @@ import pt.ua.dicoogle.server.web.management.Dicoogle.SOPClassSettings;
 public class SOPList {
 
     private static SOPList instance = null;
-    private static Semaphore sem = new Semaphore(1, true);
     private static Logger logger = LoggerFactory.getLogger(SOPList.class);
 
     private Hashtable<String, TransfersStorage> table;    
@@ -134,18 +132,8 @@ public class SOPList {
 
     public static synchronized SOPList getInstance()
     {
-        try
-        {
-            sem.acquire();
-            if (instance == null)
-            {
-                instance = new SOPList();
-            }
-            sem.release();
-        }
-        catch (InterruptedException ex)
-        {
-            LoggerFactory.getLogger(SOPList.class).error(ex.getMessage(), ex);
+        if (instance == null) {
+            instance = new SOPList();
         }
         return instance;
     }

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/utils/TagsStruct.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/utils/TagsStruct.java
@@ -26,9 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.concurrent.Semaphore;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,11 +42,13 @@ import org.apache.commons.collections4.bidimap.DualHashBidiMap;
  * 
  * Other fields is the common designation for fields that do not belong to the DIM.
  *
- * @author Lu??s A. Basti??o Silva <bastiao@ua.pt>
+ * @author Luís A. Bastião Silva <bastiao@ua.pt>
  * @author Tiago Marques Godinho <tmgodinho@ua.pt> Refactor
  */
 public class TagsStruct
 {
+	private static final Logger logger = LoggerFactory.getLogger(TagsStruct.class);
+
 	//Optimization @TODO
 	//Map Structures
 	private BidiMap<Integer, String> tagNameMappings;	
@@ -65,25 +64,14 @@ public class TagsStruct
     //DeepSearch modalities
     private boolean deepSearchModalities = true;
     
-    private List<String> dictionaries = new ArrayList<String>();
+    private List<String> dictionaries = new ArrayList<>();
 
     private static TagsStruct instance = null ;
-    private static Semaphore sem = new Semaphore(1, true);
 
     public static synchronized TagsStruct getInstance()
     {
-        try
-        {
-            sem.acquire();
-            if (instance == null)
-            {
-                instance = new TagsStruct();
-            }
-            sem.release();
-        }
-        catch (InterruptedException ex)
-        {
-            LoggerFactory.getLogger(TagsStruct.class).error(ex.getMessage(), ex);
+        if (instance == null) {
+            instance = new TagsStruct();
         }
         return instance;
     }
@@ -93,8 +81,8 @@ public class TagsStruct
     {
     	//Initialize fields;
     	this.tagNameMappings = new DualHashBidiMap<>();
-    	this.tagValueMappings = new HashMap<Integer, TagValue>();
-    	this.nDICOMFields = new HashSet<TagValue>();
+    	this.tagValueMappings = new HashMap<>();
+    	this.nDICOMFields = new HashSet<>();
     	this.nDIMFields = new HashSet<>();
     	this.nPrivateFields = new HashSet<>();
     	this.modalitiesSet = new HashSet<>();
@@ -352,7 +340,7 @@ public class TagsStruct
     
     /**
      * 
-     * @param tagNumber
+     * @param tagName
      * @return The TagValue object for the given its name, or null.
      */
     public TagValue getTagValue(String tagName){


### PR DESCRIPTION
We are already using monitors for synchronized access, so semaphores are not needed. This PR removes the use of `Semaphore` from the most important components (some classes from rGUI were left alone because they're marked for death anyway).