### PR TITLE
Dead plugin awareness + /plugins web service

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/DeadPlugin.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/DeadPlugin.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) 2014  Universidade de Aveiro, DETI/IEETA, Bioinformatics Group - http://bioinformatics.ua.pt/
+ *
+ * This file is part of Dicoogle/dicoogle.
+ *
+ * Dicoogle/dicoogle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Dicoogle/dicoogle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Dicoogle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package pt.ua.dicoogle.plugins;
+
+import java.util.Objects;
+
+/** Data type containing information about a dead plugin. Plugins are considered dead when they perform
+ * some kind of irrecoverable misbehaviour, such as throwing exceptions during the configuration phase.
+ * Information about the plugin set's name and the exception that "killed" the plugin are kept here.
+ *
+ * @author Eduardo Pinho <eduardopinho@ua.pt>
+ */
+public final class DeadPlugin {
+    private final String name;
+    private final Exception cause;
+
+    public DeadPlugin(String name, Exception cause) {
+        this.name = name;
+        this.cause = cause;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Exception getCause() {
+        return cause;
+    }
+
+    @Override
+    public String toString() {
+        return "DeadPlugin{" +
+                "name='" + name + '\'' +
+                ", cause=" + cause +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DeadPlugin that = (DeadPlugin) o;
+        return Objects.equals(name, that.name) &&
+                Objects.equals(cause, that.cause);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, cause);
+    }
+}

--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
@@ -76,6 +76,7 @@ public class PluginController{
         return instance;
     }
     private final Collection<PluginSet> pluginSets;
+    private final Collection<DeadPlugin> deadPluginSets;
     private File pluginFolder;
     private TaskQueue tasks = null;
 
@@ -95,59 +96,18 @@ public class PluginController{
             pathToPluginDirectory.mkdirs();
         }
 
+        this.deadPluginSets = new ArrayList<>(4);
+
         //loads the plugins
         pluginSets = PluginFactory.getPlugins(pathToPluginDirectory);
         //load web UI plugins (they are not Java, so the process is delegated to another entity)
         this.webUI = new WebUIPluginManager();
-        // loadByPluginName all at "WebPlugins"
-        this.webUI.loadAll(new File("WebPlugins"));
-        
-        // go through each jar'd plugin and fetch their WebPlugins
-        for (File j : FileUtils.listFiles(pluginFolder, new String[]{"jar", "zip"}, false)) {
-            try {
-                this.webUI.loadAllFromZip(new ZipFile(j));
-            } catch (IOException ex) {
-                // ignore
-                logger.warn("Failed to load web UI plugins from {}: {}", j.getName(), ex.getMessage());
-            }
-        }
-        
+        this.loadWebUIPlugins();
+
         logger.info("Loaded Local Plugins");
 
-        //loads plugins' settings and passes them to the plugin
-        File settingsFolder = new File(pluginFolder.getPath() + "/settings/");
-        if (!settingsFolder.exists()) {
-        	logger.info("Creating Local Settings Folder");
-            settingsFolder.mkdir();
-        }
+        this.configurePlugins();
 
-        for (Iterator<PluginSet> it = pluginSets.iterator(); it.hasNext();) {
-            PluginSet plugin = it.next();
-            logger.info("Loading plugin: " + plugin.getName());
-            File pluginSettingsFile = new File(settingsFolder + "/" + plugin.getName().replace('/', '-') + ".xml");
-            try {
-                ConfigurationHolder holder = new ConfigurationHolder(pluginSettingsFile);
-                if(plugin.getName().equals("RemotePluginSet")) {
-                	this.remoteQueryPlugins = plugin;
-                	holder.getConfiguration().setProperty("NodeName", ServerSettings.getInstance().getNodeName());
-    	        	holder.getConfiguration().setProperty("TemporaryPath", ServerSettings.getInstance().getPath());
-                	
-                	logger.info("Started Remote Communications Manager");
-                }
-                applySettings(plugin, holder);
-            }
-            catch (ConfigurationException e){
-                logger.error("Failed to create configuration holder", e);
-			}
-            catch (RuntimeException e) {
-                logger.error("Unexpected error while loading plugin set {}. Plugin disabled.", plugin.getName(), e);
-                it.remove();
-            }
-        }
-        logger.info("Settings pushed to plugins");
-        webUI.loadSettings(settingsFolder);
-        logger.info("Settings pushed to web UI plugins");
-        
         pluginSets.add(new DefaultFileStoragePlugin());
         logger.info("Added default storage plugin");
         
@@ -157,6 +117,66 @@ public class PluginController{
         initRestInterface(pluginSets);
         initJettyInterface(pluginSets);
         logger.info("Initialized plugins");
+    }
+
+    private void loadWebUIPlugins() {
+        // loadByPluginName all at "WebPlugins"
+        this.webUI.loadAll(new File("WebPlugins"));
+
+        // go through each jar'd plugin and fetch their WebPlugins
+        for (File j : FileUtils.listFiles(pluginFolder, new String[]{"jar", "zip"}, false)) {
+            try {
+                this.webUI.loadAllFromZip(new ZipFile(j));
+            } catch (IOException ex) {
+                // ignore
+                logger.warn("Failed to load web UI plugins from {}: {}", j.getName(), ex.getMessage());
+            }
+        }
+    }
+
+    private void configurePlugins() {
+        //loads plugins' settings and passes them to the plugin
+        File settingsFolder = new File(pluginFolder.getPath() + "/settings/");
+        if (!settingsFolder.exists()) {
+            logger.info("Creating Local Settings Folder");
+            settingsFolder.mkdir();
+        }
+
+        for (Iterator<PluginSet> it = pluginSets.iterator(); it.hasNext();) {
+            PluginSet plugin = it.next();
+            try {
+                final String name = plugin.getName();
+                logger.info("Loading plugin: {}", name);
+                File pluginSettingsFile = new File(settingsFolder + "/" + name.replace('/', '-') + ".xml");
+                ConfigurationHolder holder = new ConfigurationHolder(pluginSettingsFile);
+                if(plugin.getName().equals("RemotePluginSet")) {
+                    this.remoteQueryPlugins = plugin;
+                    holder.getConfiguration().setProperty("NodeName", ServerSettings.getInstance().getNodeName());
+                    holder.getConfiguration().setProperty("TemporaryPath", ServerSettings.getInstance().getPath());
+
+                    logger.info("Started Remote Communications Manager");
+                }
+                applySettings(plugin, holder);
+            }
+            catch (ConfigurationException e){
+                logger.error("Failed to create configuration holder", e);
+            }
+            catch (RuntimeException e) {
+                String name;
+                try {
+                    name = plugin.getName();
+                } catch (Exception ex2) {
+                    logger.warn("Plugin set name cannot be retrieved: {}", ex2.getMessage());
+                    name = "UNKNOWN";
+                }
+                logger.error("Unexpected error while loading plugin set {}. Plugin set marked as dead.", name, e);
+                this.deadPluginSets.add(new DeadPlugin(name, e));
+                it.remove();
+            }
+        }
+        logger.debug("Settings pushed to plugins");
+        webUI.loadSettings(settingsFolder);
+        logger.debug("Settings pushed to web UI plugins");
     }
     
     private void initializePlugins(Collection<PluginSet> plugins) {
@@ -313,6 +333,34 @@ public class PluginController{
             }
         }
         return storagePlugins;
+    }
+
+    public Collection<JettyPluginInterface> getServletPlugins(boolean onlyEnabled) {
+        List<JettyPluginInterface> plugins = new ArrayList<>();
+        for (PluginSet pSet : pluginSets) {
+            for (JettyPluginInterface p : pSet.getJettyPlugins()) {
+                if (!p.isEnabled() && onlyEnabled) {
+                    continue;
+                }
+                plugins.add(p);
+            }
+        }
+        return plugins;
+    }
+    public Collection<JettyPluginInterface> getServletPlugins() {
+        return this.getServletPlugins(true);
+    }
+
+    public Collection<String> getPluginSetNames() {
+        Collection<String> l = new ArrayList<>();
+        for (PluginSet s: this.pluginSets) {
+            l.add(s.getName());
+        }
+        return l;
+    }
+
+    public Collection<DeadPlugin> getDeadPluginSets() {
+        return new ArrayList<>(this.deadPluginSets);
     }
 
     /**

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/DicoogleWeb.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/DicoogleWeb.java
@@ -30,6 +30,7 @@ import pt.ua.dicoogle.server.web.servlets.ExportCSVToFILEServlet;
 import pt.ua.dicoogle.server.web.servlets.SearchHolderServlet;
 import pt.ua.dicoogle.server.web.servlets.IndexerServlet;
 import pt.ua.dicoogle.server.web.servlets.ImageServlet;
+import pt.ua.dicoogle.server.web.servlets.plugins.PluginsServlet;
 import pt.ua.dicoogle.server.web.servlets.search.ExportServlet;
 import pt.ua.dicoogle.server.web.servlets.search.ExportServlet.ExportType;
 import pt.ua.dicoogle.server.web.servlets.search.ProvidersServlet;
@@ -205,6 +206,7 @@ public class DicoogleWeb {
             createServletHandler(new ServicesServlet(ServicesServlet.QUERY), "/management/dicom/query"),
             createServletHandler(new ServicesServlet(ServicesServlet.PLUGIN), "/management/plugins/"),
             createServletHandler(new AETitleServlet(), "/management/settings/dicom"),
+            createServletHandler(new PluginsServlet(), "/plugins/*"),
             createServletHandler(new WebUIServlet(), "/webui"),
             createWebUIModuleServletHandler(),
             createServletHandler(new LoggerServlet(), "/logger"),

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/plugins/PluginsServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/plugins/PluginsServlet.java
@@ -1,0 +1,208 @@
+/**
+ * Copyright (C) 2014  Universidade de Aveiro, DETI/IEETA, Bioinformatics Group - http://bioinformatics.ua.pt/
+ *
+ * This file is part of Dicoogle/dicoogle.
+ *
+ * Dicoogle/dicoogle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Dicoogle/dicoogle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Dicoogle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pt.ua.dicoogle.server.web.servlets.plugins;
+
+import net.sf.json.JSONObject;
+import org.json.JSONException;
+import org.json.JSONWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import pt.ua.dicoogle.plugins.DeadPlugin;
+import pt.ua.dicoogle.plugins.PluginController;
+import pt.ua.dicoogle.sdk.*;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * Retrieval of Dicoogle plugin information.
+ * 
+ * <b>This API is currently unstable.</b>
+ *
+ * @author Eduardo Pinho
+ */
+public class PluginsServlet extends HttpServlet {
+    private static final Logger logger = LoggerFactory.getLogger(PluginsServlet.class);
+    
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("application/json");
+
+        List<String> pathParts = sanitizedSubpathParts(req);
+
+        if (pathParts.size() > 1) {
+            sendError(resp, 400, "Illegal plugin request URI: resource path too deep");
+            return;
+        }
+
+        Set<String> validTypes = new HashSet<>();
+        Collections.addAll(validTypes, "query", "index", "storage", "servlet", "set", "dead");
+
+        boolean all = pathParts.isEmpty();
+        String type = !all ? pathParts.get(0) : null;
+
+        if (type != null && !validTypes.contains(type)) {
+            sendError(resp, 400, "Illegal plugin request type");
+            return;
+        }
+
+        final PluginController pc = PluginController.getInstance();
+
+        try {
+            JSONWriter writer = new JSONWriter(resp.getWriter());
+
+            writer.object(); // begin response
+
+            if (!"dead".equals(type) && !"set".equals(type)) {
+                writer.key("plugins").array(); // begin plugins
+
+                if (all || "query".equals(type)) {
+                    // Query Plugins
+                    List<QueryInterface> qlist = sorted(pc.getQueryPlugins(false));
+                    for (QueryInterface p : qlist) {
+                        writeQueryPlugin(writer, p);
+                    }
+                }
+
+                if (all || "index".equals(type)) {
+                    // Indexer Plugins
+                    List<IndexerInterface> ilist = sorted(pc.getIndexingPlugins(false));
+                    for (IndexerInterface p : ilist) {
+                        writeIndexPlugin(writer, p);
+                    }
+                }
+
+                if (all || "storage".equals(type)) {
+                    // Storage Plugins
+                    List<StorageInterface> slist = sorted(pc.getStoragePlugins(false));
+                    for (StorageInterface p : slist) {
+                        writeStoragePlugin(writer, p);
+                    }
+                }
+
+                if (all || "servlet".equals(type)) {
+                    // Servlet Plugins
+                    List<JettyPluginInterface> servlist = sorted(pc.getServletPlugins(false));
+                    for (JettyPluginInterface p : servlist) {
+                        writeServletPlugin(writer, p);
+                    }
+                }
+
+                writer.endArray(); // end plugins
+            }
+
+            if (all || "set".equals(type)) {
+                writer.key("sets").array(); // begin plugin sets
+                for (String p : pc.getPluginSetNames()) {
+                    writer.value(p);
+                }
+                writer.endArray(); // end plugin sets
+            }
+
+            if (all || "dead".equals(type)) {
+                writer.key("dead").array(); // begin dead plugins
+                for (DeadPlugin p : pc.getDeadPluginSets()) {
+                    writer.object()
+                          .key("name").value(p.getName())
+                          .key("cause").object()
+                            .key("class").value(p.getCause().getClass().getSimpleName())
+                            .key("message").value(p.getCause().getMessage())
+                            .endObject()
+                          .endObject();
+                }
+                writer.endArray(); // end dead plugins
+            }
+
+            writer.endObject(); // end response
+        } catch (JSONException ex) {
+            throw new IOException("Failed JSON serialization", ex);
+        }
+    }
+
+    private static <T extends DicooglePlugin> List<T> sorted(Collection<T> col) {
+        final Comparator<DicooglePlugin> byEnabledThenName = new Comparator<DicooglePlugin>() {
+            @Override
+            public int compare(DicooglePlugin p1, DicooglePlugin p2) {
+                int c1 = Boolean.compare(p1.isEnabled(), p2.isEnabled());
+                if (c1 != 0) return c1;
+                return p1.getName().compareTo(p2.getName());
+            }
+        };
+        List<T> l = new ArrayList<>(col);
+        Collections.sort(l, byEnabledThenName);
+        return l;
+    }
+
+    private static JSONWriter writeBaseProps(JSONWriter writer, DicooglePlugin plugin, String type) throws JSONException {
+        return writer.key("name").value(plugin.getName())
+                .key("type").value(type)
+                .key("enabled").value(plugin.isEnabled());
+    }
+
+    private static JSONWriter writeQueryPlugin(JSONWriter writer, QueryInterface plugin) throws JSONException {
+        return writeBaseProps(writer.object(), plugin, "query")
+                .key("dim").value(null)
+                .endObject();
+    }
+
+    private static JSONWriter writeIndexPlugin(JSONWriter writer, IndexerInterface plugin) throws JSONException {
+        return writeBaseProps(writer.object(), plugin, "index")
+                .key("dim").value(null)
+                .endObject();
+    }
+
+    private static JSONWriter writeStoragePlugin(JSONWriter writer, StorageInterface plugin) throws JSONException {
+        return writeBaseProps(writer.object(), plugin, "storage")
+                .key("scheme").value(plugin.getScheme())
+                .key("default").value(null)
+                .endObject();
+    }
+
+    private static JSONWriter writeServletPlugin(JSONWriter writer, JettyPluginInterface plugin) throws JSONException {
+        return writeBaseProps(writer.object(), plugin, "servlet")
+                .key("endpoints").value(null)
+                .endObject();
+    }
+
+    private List<String> sanitizedSubpathParts(HttpServletRequest req) {
+        String subpath = req.getRequestURI().substring(req.getServletPath().length());
+
+        String[] subpathParts = subpath.split("/");
+
+        List<String> l = new ArrayList<>();
+        for (String s : subpathParts) {
+            if (!s.isEmpty()) {
+                l.add(s);
+            }
+        }
+        return l;
+    }
+
+    private static void sendError(HttpServletResponse resp, int code, String message) throws IOException {
+        resp.setStatus(code);
+        JSONObject obj = new JSONObject();
+        obj.put("error", message);
+        resp.getWriter().append(obj.toString());
+    }
+}


### PR DESCRIPTION
- add data type for dead plugins
- add list of dead plugins in plugin controller
- mark plugins as dead when they fail on configuration
- add plugin controller methods for retrieving servlet plugins, dead plugins and plugin set names
- add PluginsServlet for retrieving plugin information, attach to `/plugins/*`

Current API: `GET /plugins[/{type}]`, where `{type}` can be one of "query", "index", "storage", "servlet", "set" and "dead". All plugins are output by default.

Output example:

```json
{
  "plugins": [
  {
    "name": "lucene",
    "type": "query",
    "enabled": true,
    "dim": null
  },
  {
    "name": "lucene",
    "type": "index",
    "enabled": true,
    "dim": null
  },
  {
    "name": "default-filesystem-plugin",
    "type": "storage",
    "enabled": true,
    "scheme": "file",
    "default": null
  },
  {
    "name": "file-storage",
    "type": "storage",
    "enabled": true,
    "scheme": "file",
    "default": null
  },
  {
    "name": "multimodal",
    "type": "servlet",
    "enabled": true,
    "endpoints": null
  },
  ],
  "sets": [
    "file-storage",
    "multimodal",
    "luceneset",
    "default-filesystem-plugin"
  ],
  "dead": [
    {
      "name": "cbir",
      "cause": {
        "class": "RuntimeIOException",
        "message": "Failed to receive reply"
      }
    }
  ]
}
```

This provides a requirement of #229, since it allows the webapp to fetch storage schemes.

Some fields are left null because their values are currently not available, but planned.
I would still like you to analyse the API before merging. Should the plugins follow any other hierarchy (by category or plugin set), or stay flat (how it currently is)? Likewise, is a list of strings sufficient or should it be an object instead, for more flexibility? Also, would you like more information about the cause of a plugin's death?
