### PR TITLE
Update SDK with default methods and Java 8

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
@@ -240,7 +240,7 @@ public class PluginController{
 
         ArrayList<ServerResource> restInterfaces = new ArrayList<>();
         for (PluginSet set : plugins) {
-            Collection<ServerResource> restInterface = set.getRestPlugins();
+            Collection<? extends ServerResource> restInterface = set.getRestPlugins();
             if (restInterface == null) {
                 continue;
             }
@@ -258,7 +258,7 @@ public class PluginController{
                 
          ArrayList<JettyPluginInterface> jettyInterfaces = new ArrayList<>();
          for(PluginSet set : plugins){
-        	 Collection<JettyPluginInterface> jettyInterface = set.getJettyPlugins();
+        	 Collection<? extends JettyPluginInterface> jettyInterface = set.getJettyPlugins();
         	 if(jettyInterface == null) continue;
         	 jettyInterfaces.addAll(jettyInterface);
          }
@@ -713,75 +713,25 @@ public class PluginController{
     }
 
     //METHODs FOR PluginController4Users
-    //TODO:this method is a workaround! we do get rightmenu items, but only for the search window
-    //which should be moved to plugins and hence we are assuming too much in here!
+    // which are obsolete and no longer supported
  
     @Deprecated
 	public List<JMenuItem> getRightButtonItems() {
         logger.info("getRightButtonItems()");
-        ArrayList<JMenuItem> rightMenuItems = new ArrayList<>();
-        
-        for (PluginSet set : pluginSets) {
-            logger.info("Set plugins: {}", set.getGraphicalPlugins());
-            Collection<GraphicalInterface> graphicalPlugins = set.getGraphicalPlugins();
-            if (graphicalPlugins == null) {
-                continue;
-            }
-            logger.info("Looking for plugin");
-            for (GraphicalInterface gpi : graphicalPlugins) {
-                logger.info("GPI: {}", gpi);
-                ArrayList<JMenuItem> rbPanels = gpi.getRightButtonItems();
-                if (rbPanels == null) {
-                    continue;
-                }
-                rightMenuItems.addAll(rbPanels);
-            }
-        }
-        return rightMenuItems;
+        return Collections.EMPTY_LIST;
     }
 
     //returns a list of tabs from all plugins
     @Deprecated
     public List<JPanel> getTabItems() {
         logger.info("getTabItems");
-        ArrayList<JPanel> panels = new ArrayList<>();
-
-        for (PluginSet set : pluginSets) {
-            Collection<GraphicalInterface> graphicalPlugins = set.getGraphicalPlugins();
-            if (graphicalPlugins == null) {
-                continue;
-            }
-            for (GraphicalInterface gpi : graphicalPlugins) {
-                ArrayList<JPanel> tPanels = gpi.getTabPanels();
-                if (tPanels == null) {
-                    continue;
-                }
-                panels.addAll(tPanels);
-            }
-        }
-        return panels;
+        return Collections.EMPTY_LIST;
     }
 
     @Deprecated
     public List<JMenuItem> getMenuItems() {
         logger.info("getMenuItems");
-        ArrayList<JMenuItem> items = new ArrayList<>();
-
-        for (PluginSet set : pluginSets) {
-            Collection<GraphicalInterface> graphicalPlugins = set.getGraphicalPlugins();
-            if (graphicalPlugins == null) {
-                continue;
-            }
-
-            for (GraphicalInterface gpi : graphicalPlugins) {
-                Collection<JMenuItem> setItems = gpi.getMenuItems();
-                if (setItems == null) {
-                    continue;
-                }
-                items.addAll(setItems);
-            }
-        }
-        return items;
+        return Collections.EMPTY_LIST;
     }
     
     // Methods for Web UI 

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -82,8 +82,8 @@
                 <version>2.3.2</version>
                 <configuration>
                     <encoding>${project.build.sourceEncoding}</encoding>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -120,12 +120,6 @@
     </build>
 
     <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.8.1</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>commons-configuration</groupId>
             <artifactId>commons-configuration</artifactId>

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/DicooglePlugin.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/DicooglePlugin.java
@@ -40,7 +40,7 @@ public interface DicooglePlugin extends Plugin {
      * 
      * @return the name of the plugin
      */
-    public abstract String getName();
+    public String getName();
     
     /**
      * Issues the plugin to become enabled. It is expected that an enabled plugin, once configured, is ready
@@ -48,14 +48,14 @@ public interface DicooglePlugin extends Plugin {
      * 
      * @return whether the plugin was successfully enabled
      */
-    public abstract boolean enable();
+    public boolean enable();
     
     /**
      * Issues the plugin to become disabled. When called, the plugin is responsible
      * for stopping all services that the plugin is running. 
      * @return whether the plugin was successfully disabled
      */
-    public abstract boolean disable();
+    public boolean disable();
     
     
     /**
@@ -63,18 +63,18 @@ public interface DicooglePlugin extends Plugin {
      *
      * @return whether the plugin is enabled
      */
-    public abstract boolean isEnabled();
+    public boolean isEnabled();
 
     /** Sets the settings of this plugin.
      * This method lets the plugin receive its settings from the core Dicoogle system.
      * 
      * @param settings the parameters that will be used by the plugin
      */
-    public abstract void setSettings(ConfigurationHolder settings);
+    public void setSettings(ConfigurationHolder settings);
     
     /**
      * Obtains access to the settings of the plugin.
      * @return the plugin's settings
      */
-    public abstract ConfigurationHolder getSettings();    
+    public ConfigurationHolder getSettings();
 }

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/GraphicalInterface.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/GraphicalInterface.java
@@ -31,7 +31,7 @@ import javax.swing.JPanel;
  * @author Frederico Valente
  * @author Luís A. Bastião Silva <bastiao@ua.pt>
  * 
- * @deprecated The remote Swing-based GUI is outdated and will no longer be supported.
+ * @deprecated The remote Swing-based GUI is outdated and is no longer supported.
  */
 @Deprecated
 public interface GraphicalInterface extends DicooglePlugin

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/IndexerInterface.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/IndexerInterface.java
@@ -60,7 +60,9 @@ public interface IndexerInterface extends DicooglePlugin {
      * @param path a URI to the file to check
      * @return whether the indexer can handle the file at the given path
      */
-    public boolean handles(URI path);    
+    public default boolean handles(URI path) {
+        return true;
+    }
     
     /**
      * Removes the indexed file at the given path from the database.

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/PluginBase.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/PluginBase.java
@@ -34,15 +34,12 @@ import pt.ua.dicoogle.sdk.core.PlatformCommunicatorInterface;
  * @author Luís A. Bastião Silva <bastiao@ua.pt>
  * @author Luís S. Ribeiro
  */
-public abstract class PluginBase implements PluginSet, PlatformCommunicatorInterface{
+public abstract class PluginBase implements PluginSet, PlatformCommunicatorInterface {
     
 	protected List<IndexerInterface> indexPlugins = new ArrayList<>();
-    protected List<GraphicalInterface> graphicPlugins = new ArrayList<>();
     protected List<QueryInterface> queryPlugins = new ArrayList<>();
     protected List<JettyPluginInterface> jettyPlugins = new ArrayList<>();
-    //protected List<StorageInterface> storagePlugins = new ArrayList<>();
-    protected List<StorageInterface> storagePlugins = new LinkedList<>();
-    
+    protected List<StorageInterface> storagePlugins = new ArrayList<>();
     protected List<ServerResource> services = new ArrayList<>();
     protected ConfigurationHolder settings = null;
     
@@ -53,18 +50,10 @@ public abstract class PluginBase implements PluginSet, PlatformCommunicatorInter
         return indexPlugins;
     }
 
- 
-    @Override
-    public List<GraphicalInterface> getGraphicalPlugins() {
-        return graphicPlugins;
-    }
-
-
     @Override
     public List<QueryInterface> getQueryPlugins() {
         return queryPlugins;
     }
-
    
     @Override
     public List<ServerResource> getRestPlugins() {
@@ -88,12 +77,6 @@ public abstract class PluginBase implements PluginSet, PlatformCommunicatorInter
     public void setSettings(ConfigurationHolder xmlSettings){
         settings = xmlSettings;
     }
-    
-    @Override
-    public void shutdown(){
-        
-        //settings.save();
-    }
 
     @Override
     public Collection<StorageInterface> getStoragePlugins() 
@@ -105,5 +88,4 @@ public abstract class PluginBase implements PluginSet, PlatformCommunicatorInter
 	public void setPlatformProxy(DicooglePlatformInterface core) {
 		this.platform = core;
 	}
-    
 }

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/PluginSet.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/PluginSet.java
@@ -19,6 +19,7 @@
 package pt.ua.dicoogle.sdk;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import net.xeoh.plugins.base.Plugin;
 
@@ -28,31 +29,33 @@ import pt.ua.dicoogle.sdk.settings.ConfigurationHolder;
 
 /**
  * This is the class responsible for creating a Dicoolge plugin.
- * The developer may use this interface in order to manage and expose the implemented plugins. One instance
- * of each installed plugin set is created by injecting it as a {@link PluginImplementation}. All instances
- * are expected to be thread safe. It is highly recommended that provided collections are immutable, and
+ * The developer may use this interface in order to manage and expose the implemented plugins.
+ * One instance of each installed plugin set is created by injecting it as a
+ * {@link net.xeoh.plugins.base.annotations.PluginImplementation}. All instances are expected
+ * to be thread safe. It is highly recommended that provided collections are immutable, and
  * that no modifications are performed in getter methods.
  * 
  * @author psytek
  * @author Luís A. Bastião Silva <bastiao@ua.pt>
+ * @author Eduardo Pinho <eduardopinho@ua.pt>
  */
 public interface PluginSet extends Plugin {
-    
+    /**
+     * Gets the plugin's name. This name will be used for identifying index/query/storage providers,
+     * and should be unique among the total plugin sets installed.
+     * @return the name of the plugin, never changes
+     */
+    public String getName();
+
     /**
      * Gets the indexer plugins enclosed in this plugin set.
      * This collection must be immutable.
      * @return IndexPluginInterface returns a list of active index plugins
      * @see IndexerInterface
      */
-    public Collection<IndexerInterface> getIndexPlugins();
-
-    /**
-     * Gets the graphical plugins enclosed in this plugin set.
-     * This collection must be immutable.
-     * @return 
-     * @deprecated the Swing-based remote user interface is deprecated
-     */
-    public Collection<GraphicalInterface> getGraphicalPlugins();
+    public default Collection<? extends IndexerInterface> getIndexPlugins() {
+        return Collections.EMPTY_LIST;
+    }
 
     /**
      * Gets the query plugins enclosed in this plugin set.
@@ -60,14 +63,18 @@ public interface PluginSet extends Plugin {
      * @return a collection of query plugins
      * @see QueryInterface
      */
-    public Collection<QueryInterface> getQueryPlugins();
+    public default Collection<? extends QueryInterface> getQueryPlugins() {
+        return Collections.EMPTY_LIST;
+    }
     
     /**
      * Gets the storage plugins enclosed in this plugin set.
      * This collection must be immutable.
      * @return Collection holding the StoragePlugins of this PluginSet
      */
-    public Collection<StorageInterface> getStoragePlugins();
+    public default Collection<? extends StorageInterface> getStoragePlugins() {
+        return Collections.EMPTY_LIST;
+    }
     
     /**
      * Obtains a collection of access to the RESTful resources. These plugins will be installed to
@@ -76,7 +83,9 @@ public interface PluginSet extends Plugin {
      * @return a collection of Restlet-based server resources, implementing {@code toString()}
      * to provide the resource name
      */
-    public Collection<ServerResource> getRestPlugins();
+    public default Collection<? extends ServerResource> getRestPlugins() {
+        return Collections.EMPTY_LIST;
+    }
     
     /**
      * Obtains a collection of Jetty plugins, so as to implement web services via Dicoogle.
@@ -84,14 +93,9 @@ public interface PluginSet extends Plugin {
      * @return a collection of Jetty plugins to the core application
      * @see JettyPluginInterface
      */
-    public Collection<JettyPluginInterface> getJettyPlugins();
-    
-    /**
-     * Gets the plugin's name. This name will be used for identifying index/query/storage providers,
-     * and should be unique among the total plugin sets installed.
-     * @return the name of the plugin, never changes
-     */
-    public String getName();
+    public default Collection<? extends JettyPluginInterface> getJettyPlugins() {
+        return Collections.EMPTY_LIST;
+    }
     
     /**
      * Defines the plugin's settings. This method will be called once after the plugin set was instantiated
@@ -112,6 +116,19 @@ public interface PluginSet extends Plugin {
      * Signals a plugin to stop. Upon an invocation of this method, the plugin may clean allocated resources
      * and save state if required.
      */
-    public void shutdown();
-    
+    public default void shutdown() {
+        // do nothing
+    }
+
+    /**
+     * Gets the graphical plugins enclosed in this plugin set.
+     * This collection must be immutable.
+     * @return
+     * @deprecated the Swing-based remote user interface is no longer available
+     */
+    @Deprecated
+    public default Collection<? extends GraphicalInterface> getGraphicalPlugins() {
+        return Collections.EMPTY_LIST;
+    }
+
 }

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/QueryInterface.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/QueryInterface.java
@@ -33,7 +33,8 @@ public interface QueryInterface extends DicooglePlugin
      * Performs a search on the database.
      * 
      * The consumer of the results would either request an iterator or use a for-each loop. The underlying
-     * iterator implementation can be redefined to wait for more results at the caller.
+     * iterator implementation can be redefined to wait for more results at the caller. Furthermore, the
+     * resulting iterable is expected to be traversed only once.
      *
      * @param query a string describing the query. The underlying plugin is currently free to follow any
      * query format, but only those based on Lucene with work with the search user interface.

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/StorageInputStream.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/StorageInputStream.java
@@ -34,19 +34,19 @@ public interface StorageInputStream {
      * 
      * @return the URI path of the file
      */
-    public abstract URI getURI();
+    public URI getURI();
     
     /** Obtains a new input stream for reading the file.
      * 
      * @return a new input stream
      * @throws IOException if an I/O error occurs
      */
-    public abstract InputStream getInputStream() throws IOException;
+    public InputStream getInputStream() throws IOException;
     
     /** Obtains the file's size.
      * 
      * @return the storage element's size in byte
      * @throws IOException if an I/O error occurs
      */
-    public abstract long getSize() throws IOException;
+    public long getSize() throws IOException;
 }

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/StorageInterface.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/StorageInterface.java
@@ -20,6 +20,8 @@ package pt.ua.dicoogle.sdk;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Objects;
+
 import org.dcm4che2.data.DicomObject;
 import org.dcm4che2.io.DicomInputStream;
 
@@ -45,7 +47,10 @@ public interface StorageInterface extends DicooglePlugin {
      * @param location a URI containing a scheme to be verified
      * @return true if this storage plugin is in charge of URIs in the given form 
      */
-    public boolean handles(URI location);
+    @Deprecated
+    public default boolean handles(URI location) {
+        return Objects.equals(this.getScheme(), location.getScheme());
+    }
     
     /**
      * Provides a means of iteration over existing objects at a specified location.


### PR DESCRIPTION
These changes will allow us to expand the plugin set without future breaking changes, as well as make future plugin implementations simpler. For instance, developers will no longer need to implement every single getter method, including those that we no longer support. 

Possible breaking changes:
 - Java 8 is required. This is fine, since Java 8 has been stable for quite a while, and we no longer feel the need to support Dicoogle running over Java 7.
 - If a plugin was using reflection to fetch `PluginSet` instances, attempting to get the plugins within might lead to a runtime exception. Since AFAIK no one has tried doing this, it should not become a problem.

Additional changes:
 - Method prototypes in PluginSet getters are slightly modified to return collections of `? extends Plugin` (this fixes some inconsistencies that led to casts in our implementations)
 - Many methods in PluginSet and some plugin interfaces are given a default implementation: getters in PluginSet return empty collections of plugins, `shutdown()` does nothing, `handles()` in indexers return true, and `handles()` in storage interface was marked as deprecated (according to #257).
- Getters for graphical plugins in `PluginController` were also simplified to return empty lists.
