### PR TITLE
Fixed bug when trying to visualize thumbnails on Windows.

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/utils/LocalImageCache.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/utils/LocalImageCache.java
@@ -239,7 +239,8 @@ public class LocalImageCache extends Thread implements ImageRetriever
     
     protected static String toFileName(String imageUri, int frameNumber, boolean thumbnail) {
         String filename = imageUri.replace('/', '_') + "_" + frameNumber;
-        if (thumbnail) {
+		filename = filename.replace(':', '_') ; // only for windows.
+		if (thumbnail) {
             filename += "__thumb";
         }
         return filename + ".png";

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/utils/LocalImageCache.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/utils/LocalImageCache.java
@@ -239,8 +239,8 @@ public class LocalImageCache extends Thread implements ImageRetriever
     
     protected static String toFileName(String imageUri, int frameNumber, boolean thumbnail) {
         String filename = imageUri.replace('/', '_') + "_" + frameNumber;
-		filename = filename.replace(':', '_') ; // only for windows.
-		if (thumbnail) {
+        filename = filename.replace(':', '_') ; // only for windows.
+        if (thumbnail) {
             filename += "__thumb";
         }
         return filename + ".png";


### PR DESCRIPTION
If you are use Windows systems, using the classic approach in URI it may be returned  ":". This is a hot fix to avoid this kind of problems. 