### PR TITLE
UID awareness to Tasks

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
@@ -477,7 +477,8 @@ public class PluginController{
     private Task<Iterable<SearchResult>> getTaskForQuery(final String querySource, final String query, final Object ... parameters){
     	final QueryInterface queryEngine = getQueryProviderByName(querySource, true);
     	//returns a tasks that runs the query from the selected query engine
-        Task<Iterable<SearchResult>> queryTask = new Task<>(querySource,
+        String uid = UUID.randomUUID().toString();
+        Task<Iterable<SearchResult>> queryTask = new Task<>(uid, querySource,
             new Callable<Iterable<SearchResult>>(){
             @Override public Iterable<SearchResult> call() throws Exception {
                 if(queryEngine == null) return Collections.emptyList();
@@ -528,7 +529,7 @@ public class PluginController{
 
                 taskManager.dispatch(task);
                 rettasks.add(task);
-                RunningIndexTasks.getInstance().addTask(taskUniqueID, task);
+                RunningIndexTasks.getInstance().addTask(task);
             } catch (RuntimeException ex) {
                 logger.warn("Indexer {} failed unexpectedly", indexer.getName(), ex);
             }
@@ -538,7 +539,6 @@ public class PluginController{
         return rettasks;    	
     }
     
-    //
     public List<Task<Report>> index(String pluginName, URI path) {
     	logger.info("Starting Indexing procedure for {}", path);
         StorageInterface store = getStorageForSchema(path);
@@ -562,8 +562,6 @@ public class PluginController{
                     @Override
                     public void run() {
                         logger.info("Task [{}] complete: {} is indexed", taskUniqueID, pathF);
-
-                        //RunningIndexTasks.getInstance().removeTask(taskUniqueID);
                     }
                 });
 
@@ -571,7 +569,7 @@ public class PluginController{
 
                 rettasks.add(task);
                 logger.info("Fired indexer {} for URI {}", pluginName, path.toString());
-                RunningIndexTasks.getInstance().addTask(taskUniqueID, task);
+                RunningIndexTasks.getInstance().addTask(task);
             }
         } catch (RuntimeException ex) {
             logger.warn("Indexer {} failed unexpectedly", indexer.getName(), ex);

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/task/Task.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/task/Task.java
@@ -19,6 +19,7 @@
 package pt.ua.dicoogle.sdk.task;
 
 import java.util.ArrayList;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
 
@@ -30,20 +31,27 @@ import java.util.concurrent.FutureTask;
  */
 public class Task<Type> extends FutureTask<Type> {
 
-    private String taskName = "unnamed task";
+    private final String uid;
+    private String taskName;
     private Callable callable;
-    ArrayList<Runnable> toRunWhenComplete;
-    
-    public Task(Callable<Type> c){
-        super(c);
-        callable = c;
-        toRunWhenComplete = new ArrayList<>();//we could lazy initialize this in onCompletion
+    private ArrayList<Runnable> toRunWhenComplete;
+
+    /** Create a new task with a randomly generated ID. */
+    public Task(Callable<Type> c) {
+        this("unnamed task", c);
     }
-    
-    public Task(String name, Callable<Type> c){
+
+    /** Create a new task with a specific name and a randomly generated ID. */
+    public Task(String name, Callable<Type> c) {
+        this(generateUID(), name, c);
+    }
+
+    public Task(String uid, String name, Callable<Type> c) {
         super(c);
+        this.callable = c;
+        this.uid = uid;
         taskName = name;
-        toRunWhenComplete = new ArrayList<>();//we could lazy initialize this in onCompletion
+        toRunWhenComplete = new ArrayList<>();
     }
     
     @Override
@@ -53,7 +61,11 @@ public class Task<Type> extends FutureTask<Type> {
             r.run();
         }
     }
-    
+
+    public String getUid() {
+        return uid;
+    }
+
     public void onCompletion(Runnable r){
         toRunWhenComplete.add(r);
     }
@@ -77,6 +89,9 @@ public class Task<Type> extends FutureTask<Type> {
         }
         return -1;
     }
-    
+
+    private static String generateUID() {
+        return UUID.randomUUID().toString();
+    }
 }
 


### PR DESCRIPTION
 - add constant uid field and getter to Task, plus more constructors
 - add output containing the spawned tasks to ForceIndexing servlet's POST method
 - adjust RunningIndexTask singleton interface to retrieve UID from task itself

These changes are important because tasks in Dicoogle, at the moment, are only granted an ID when running, and task creators can not fetch the task's identity, leaving services unable to provide enough information about the tasks just created. In order to fulfill future requirements, such as those in #146 and #255, we should apply these modifications first.

Example of output (prettified a bit):

```json
{
  "tasks": [
    {"cancelled":false,"done":false,"name":"[class-db]index file:/abc","progress":0,"uid":"27b2b6ba-c41b-4b73-8a7d-26840a696fb4"},
    {"cancelled":false,"done":false,"name":"[lucene]index file:/abc","progress":-1,"uid":"7988c3df-82af-4209-83db-d77f659aba96"}
  ]
}
```

This PR adds methods, constructors and fields to the `Task` class in the SDK. However, it does not appear to be a breaking change.