### PR TITLE
Purge uses of ReactComponent.isMounted()

### DIFF
--- a/dicoogle/src/main/resources/webapp/.eslintrc
+++ b/dicoogle/src/main/resources/webapp/.eslintrc
@@ -76,6 +76,6 @@
     "react/no-did-mount-set-state": 1,
     "react/no-did-update-set-state": 1,
     "react/jsx-boolean-value": 1,
-    "react/no-is-mounted": 0
+    "react/no-is-mounted": 2
   }
 }

--- a/dicoogle/src/main/resources/webapp/js/components/direct/directDumpView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/direct/directDumpView.js
@@ -19,20 +19,20 @@ const DirectDumpView = React.createClass({
   },
   componentWillMount: function() {
     // Subscribe to the store.
-    DumpStore.listen(this._onChange);
+    this.unsubscribe = DumpStore.listen(this._onChange);
+  },
+  componentWillUnmount() {
+    this.unsubscribe();
   },
   componentDidUpdate: function(){
     $('#dumptable').dataTable({paging: false, searching: false, info: false, responsive: false});
   },
 
   _onChange(data) {
-    if (this.isMounted())
-    {
-      this.setState({
-        data,
-        status: "stopped"
-      });
-    }
+    this.setState({
+      data,
+      status: "stopped"
+    });
   },
 
 	render() {

--- a/dicoogle/src/main/resources/webapp/js/components/indexer/IndexStatusView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/indexer/IndexStatusView.js
@@ -27,7 +27,7 @@ const IndexStatusView = React.createClass({
          console.log("IndexStatusView unmounted");
          //Stop refresh interval
          clearInterval(refreshIntervalId);
-
+         this.unsubscribe();
        },
       update: function(){
         IndexStatusActions.get();
@@ -35,13 +35,10 @@ const IndexStatusView = React.createClass({
       componentWillMount: function() {
          // Subscribe to the store.
          console.log("subscribe listener");
-         IndexStatusStore.listen(this._onChange);
+         this.unsubscribe = IndexStatusStore.listen(this._onChange);
        },
       _onChange: function(data){
-        if (this.isMounted()){
-
-          this.setState({data: data.data, status: "done"});
-        }
+        this.setState({data: data.data, status: "done"});
       },
       render: function() {
         if(this.state.status === "loading"){

--- a/dicoogle/src/main/resources/webapp/js/components/login/loadingView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/login/loadingView.js
@@ -11,8 +11,7 @@ const LoadingView = React.createClass({
   _onChange: function(data){
     const {router} = this.context;
     console.log(data);
-    if(data.isLoggedIn && this.isMounted())
-    {
+    if (data.isLoggedIn) {
       router.replace('/search');
     }
     else if(data.isLoggedIn === false){

--- a/dicoogle/src/main/resources/webapp/js/components/login/loginView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/login/loginView.js
@@ -16,8 +16,10 @@ const LoginView = React.createClass({
     };
   },
   componentWillMount: function() {
-    UserStore.listen(this._onChange);
-
+    this.unsubscribe = UserStore.listen(this._onChange);
+  },
+  componentWillUnmount() {
+    this.unsubscribe();
   },
   _onChange: function(data){
     console.log(data);
@@ -28,8 +30,7 @@ const LoginView = React.createClass({
       return;
     }
 
-    if(data.isLoggedIn && this.isMounted())
-    {
+    if(data.isLoggedIn) {
       router.replace('search');
     }
   },

--- a/dicoogle/src/main/resources/webapp/js/components/management/indexerView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/management/indexerView.js
@@ -44,17 +44,18 @@ const IndexerView = React.createClass({
       componentWillMount: function() {
         // Subscribe to the store
          console.log("subscribe listener");
-         IndexerStore.listen(this._onChange);
+         this.unsubscribe = IndexerStore.listen(this._onChange);
+      },
+      componentWillUnmount() {
+        this.unsubscribe();
       },
       _onChange: function(data){
-        if (this.isMounted()){
-          console.log(data);
-          var nState = {data: data.data, status: "done"};
-          if (data.data.watcher) {
-            nState.currentWatch = data.data.watcher;
-          }
-          this.setState(nState);
+        console.log(data);
+        var nState = {data: data.data, status: "done"};
+        if (data.data.watcher) {
+          nState.currentWatch = data.data.watcher;
         }
+        this.setState(nState);
       },
       onToggleWatcher() {
         this.setState({currentWatch: !this.state.currentWatch});

--- a/dicoogle/src/main/resources/webapp/js/components/management/loggerView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/management/loggerView.js
@@ -24,13 +24,13 @@ const LoggerView = React.createClass({
   componentWillMount: function() {
      // Subscribe to the store.
      console.log("subscribe listener");
-     LoggerStore.listen(this._onChange);
+     this.unsubscribe = LoggerStore.listen(this._onChange);
    },
+  componentWillUnmount() {
+    this.unsubscribe();
+  },
   _onChange: function(data){
-    if (this.isMounted()){
-
-      this.setState({data: data.data, status: "done"});
-    }
+    this.setState({data: data.data, status: "done"});
   },
       render: function() {
         if(this.state.status === "loading"){

--- a/dicoogle/src/main/resources/webapp/js/components/management/queryadvoptions.js
+++ b/dicoogle/src/main/resources/webapp/js/components/management/queryadvoptions.js
@@ -17,24 +17,25 @@ const QueryAdvancedOptionsModal = React.createClass({
     };
   },
   componentWillMount: function() {
-    ServicesStore.listen(this._onChange);
+    this.unsubscribe = ServicesStore.listen(this._onChange);
+  },
+  componentWillUnmount() {
+    this.unsubscribe();
   },
   componentDidMount: function() {
   },
   _onChange: function(data){
-    if (this.isMounted()) {
-      const querySettings = data.querySettings;
-      this.setState({
-        connectionTimeout: querySettings.connectionTimeout,
-        acceptTimeout: querySettings.acceptTimeout,
-        idleTimeout: querySettings.idleTimeout,
-        maxAssociations: querySettings.maxAssociations,
-        maxPduReceive: querySettings.maxPduReceive,
-        maxPduSend: querySettings.maxPduSend,
-        responseTimeout: querySettings.responseTimeout,
-        status: "done"
-      });
-    }
+    const querySettings = data.querySettings;
+    this.setState({
+      connectionTimeout: querySettings.connectionTimeout,
+      acceptTimeout: querySettings.acceptTimeout,
+      idleTimeout: querySettings.idleTimeout,
+      maxAssociations: querySettings.maxAssociations,
+      maxPduReceive: querySettings.maxPduReceive,
+      maxPduSend: querySettings.maxPduSend,
+      responseTimeout: querySettings.responseTimeout,
+      status: "done"
+    });
    },
   render: function() {
     return (<Modal {...this.props} bsStyle='primary' title='Query Retrieve - Advanced Settings' animation>

--- a/dicoogle/src/main/resources/webapp/js/components/management/servicesView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/management/servicesView.js
@@ -27,7 +27,7 @@ const ServicesView = React.createClass({
     },
 
     componentWillMount () {
-      ServicesStore.listen(this._onChange);
+      this.unsubscribe = ServicesStore.listen(this._onChange);
       Webcore.fetchPlugins('settings', (packages) => {
         Webcore.fetchModules(packages);
         this.setState({plugins: packages.map(pkg => ({
@@ -35,6 +35,9 @@ const ServicesView = React.createClass({
           caption: pkg.dicoogle.caption || pkg.name
         }))});
       });
+    },
+    componentWillUnmount() {
+      this.unsubscribe();
     },
 
     componentDidMount () {
@@ -44,8 +47,7 @@ const ServicesView = React.createClass({
 
     _onChange (data) {
       console.log(data);
-      if(this.isMounted()) {
-        this.setState({
+      this.setState({
         storageRunning: data.storageRunning,
         storagePort: data.storagePort,
         storageAutostart: data.storageAutostart,
@@ -55,10 +57,9 @@ const ServicesView = React.createClass({
         status: "done",
         storageLoading: false,
         queryLoading: false
-        });
+      });
 
-        console.log("Service data update: ", data);
-      }
+      console.log("Service data update: ", data);
     },
 
     render () {

--- a/dicoogle/src/main/resources/webapp/js/components/management/transferOptionsView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/management/transferOptionsView.js
@@ -24,13 +24,14 @@ const TransferOptionsView = React.createClass({
       componentWillMount() {
          // Subscribe to the store.
          console.log("subscribe listener");
-         TransferStore.listen(this._onChange);
+         this.unsubscribe = TransferStore.listen(this._onChange);
+      },
+      componentWillUnmount() {
+        this.unsubscribe();
       },
       _onChange (data){
-        if (this.isMounted()){
-          console.log(data);
-          this.setState({data: data, status: "done"});
-        }
+        console.log(data);
+        this.setState({data: data, status: "done"});
       },
       render () {
         if(this.state.status === "loading")

--- a/dicoogle/src/main/resources/webapp/js/components/search/advancedSearch.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/advancedSearch.js
@@ -115,15 +115,14 @@ const AdvancedSearch = React.createClass({
     },
     componentWillMount: function() {
     // Subscribe to the store.
-        SearchStore.listen(this._onChange);
-
+        this.unsubscribe = SearchStore.listen(this._onChange);
     },
-
+    componentWillUnmount() {
+        this.unsubscribe();
+    },
     _onChange: function(data){
         console.log(data);
-     //    if (this.isMounted())
-     // this.setState({label:data});
-   },
+    },
    onSearchClicked: function(){
      console.log("SEARCH CLICKED");
        //NAME

--- a/dicoogle/src/main/resources/webapp/js/components/search/exportView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/exportView.js
@@ -17,13 +17,13 @@ const ExportView = React.createClass({
 	componentWillMount: function() {
 		// Subscribe to the store.
 		console.log("subscribe listener");
-		ExportStore.listen(this._onChange);
+		this.unsubscribe = ExportStore.listen(this._onChange);
 	},
+  componentWillUnmount() {
+    this.unsubscribe();
+  },
 	_onChange: function(data){
-		if (this.isMounted()){
-
-			this.setState({data: data.data, status: "done"});
-		}
+		this.setState({data: data.data, status: "done"});
 	},
 
 	render: function(){

--- a/dicoogle/src/main/resources/webapp/js/components/search/result/imageView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/imageView.js
@@ -14,23 +14,25 @@ import ResultSelectActions from '../../../actions/resultSelectAction';
 import UserStore from '../../../stores/userStore';
 
 const ImageView = React.createClass({
-    getInitialState: function() {
-      // We need this because refs are not updated in BootstrapTable.
-      this.refsClone = {};
-      return {data: [],
-        image: null,
-        dump: null,
-        status: "loading",
-        unindexSelected: null,
-        removeSelected: null
-      };
-    },
+  getInitialState: function() {
+    // We need this because refs are not updated in BootstrapTable.
+    this.refsClone = {};
+    return {data: [],
+      image: null,
+      dump: null,
+      status: "loading",
+      unindexSelected: null,
+      removeSelected: null
+    };
+  },
 
-    componentWillMount: function() {
-      // Subscribe to the store.
-      SearchStore.listen(this._onChange);
-      ResultSelectActions.clear();
-    },
+  componentWillMount: function() {
+    this.unsubscribe = SearchStore.listen(this._onChange);
+    ResultSelectActions.clear();
+  },
+  componentWillUnmount() {
+    this.unsubscribe();
+  },
 
 
   /**
@@ -207,42 +209,34 @@ const ImageView = React.createClass({
       );
 	},
   onHideDump() {
-    if (this.isMounted())
-      this.setState({dump: null});
+    this.setState({dump: null});
   },
   onHideImage() {
-    if (this.isMounted())
-      this.setState({image: null});
+    this.setState({image: null});
   },
   showDump(uid) {
-    if (this.isMounted())
-      this.setState({dump: uid, image: null, unindexSelected: null});
-      DumpActions.get(uid);
+    this.setState({dump: uid, image: null, unindexSelected: null});
+    DumpActions.get(uid);
   },
   showImage(uid) {
-    if (this.isMounted())
-      this.setState({dump: null, image: uid, unindexSelected: null});
+    this.setState({dump: null, image: uid, unindexSelected: null});
   },
   hideUnindex() {
-    if (this.isMounted())
-      this.setState({
-        unindexSelected: null
-      });
+    this.setState({
+      unindexSelected: null
+    });
   },
   showUnindex(item) {
-    if (this.isMounted())
-      this.setState({
-        unindexSelected: item, dump: null, image: null
-      });
+    this.setState({
+      unindexSelected: item, dump: null, image: null
+    });
   },
   hideRemove() {
-    if (this.isMounted())
-      this.setState({
-        removeSelected: null
-      });
+    this.setState({
+      removeSelected: null
+    });
   },
   showRemove(item) {
-      if (this.isMounted())
     this.setState({
       removeSelected: item, dump: null, image: null
     });
@@ -260,13 +254,10 @@ const ImageView = React.createClass({
     ActionCreators.remove(uris);
   },
     _onChange: function(data){
-      if (this.isMounted())
-      {
-        this.setState({data: data.data,
-          status: "stopped",
-          success: data.success
-        });
-      }
+      this.setState({data: data.data,
+        status: "stopped",
+        success: data.success
+      });
     }
 });
 
@@ -279,13 +270,14 @@ var PopOverView = React.createClass({
   },
   componentWillMount: function() {
     // Subscribe to the store.
-    DumpStore.listen(this._onChange);
+    this.unsubscribe = DumpStore.listen(this._onChange);
+  },
+  componentWillUnmount() {
+    this.unsubscribe();
   },
 
   _onChange: function(data){
-    if (this.isMounted()) {
-      this.setState({data, status: "stopped"});
-    }
+    this.setState({data, status: "stopped"});
   },
 
   onHide () {

--- a/dicoogle/src/main/resources/webapp/js/components/search/result/patientView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/patientView.js
@@ -37,8 +37,11 @@ const PatientView = React.createClass({
 
   componentWillMount: function() {
     // Subscribe to the store.
-    SearchStore.listen(this._onChange);
+    this.unsubscribe = SearchStore.listen(this._onChange);
     ResultSelectActions.clear();
+  },
+  componentWillUnmount() {
+    this.unsubscribe();
   },
 
   /**
@@ -200,10 +203,9 @@ const PatientView = React.createClass({
     });
   },
   hideRemove () {
-    if (this.isMounted())
-        this.setState({
-            removeSelected: null
-        });
+    this.setState({
+        removeSelected: null
+    });
   },
   showRemove (index) {
       this.setState({
@@ -212,12 +214,11 @@ const PatientView = React.createClass({
       });
   },
   _onChange: function(data){
-    if (this.isMounted())
-    {
-      this.setState({data: data.data,
+    this.setState({
+      data: data.data,
       status: "stopped",
-      success: data.success});
-    }
+      success: data.success
+    });
   }
 });
 

--- a/dicoogle/src/main/resources/webapp/js/components/search/result/serieView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/serieView.js
@@ -23,8 +23,11 @@ const SeriesView = React.createClass({
 
   componentWillMount: function() {
     // Subscribe to the store.
-    SearchStore.listen(this._onChange);
+    this.unsubscribe = SearchStore.listen(this._onChange);
     ResultSelectActions.clear();
+  },
+  componentWillUnmount() {
+    this.unsubscribe();
   },
 
   /**
@@ -169,28 +172,24 @@ const SeriesView = React.createClass({
 		);
 	},
   hideUnindex () {
-    if (this.isMounted())
-      this.setState({
-        unindexSelected: null
-      });
+    this.setState({
+      unindexSelected: null
+    });
   },
   showUnindex (item) {
-    if (this.isMounted())
-      this.setState({
-        unindexSelected: item
-      });
+    this.setState({
+      unindexSelected: item
+    });
   },
   hideRemove () {
-    if (this.isMounted())
-      this.setState({
-        removeSelected: null
-      });
+    this.setState({
+      removeSelected: null
+    });
   },
   showRemove (item) {
-    if (this.isMounted())
-      this.setState({
-        removeSelected: item
-      });
+    this.setState({
+      removeSelected: item
+    });
   },
 	extractURISFromData: function(item){
 		let uris = [];
@@ -210,14 +209,12 @@ const SeriesView = React.createClass({
 	},
 
   _onChange: function(data){
-
-    if (this.isMounted())
-    {
-      this.setState({data: data.data,
+    this.setState({
+      data: data.data,
       status: "stopped",
       success: data.success,
-      enableAdvancedSearch: data.data.advancedOptions});
-    }
+      enableAdvancedSearch: data.data.advancedOptions
+    });
   }
 });
 

--- a/dicoogle/src/main/resources/webapp/js/components/search/result/studyView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/studyView.js
@@ -24,11 +24,12 @@ const StudyView = React.createClass({
 
   componentWillMount: function() {
     // Subscribe to the store.
-    SearchStore.listen(this._onChange);
+    this.unsubscribe = SearchStore.listen(this._onChange);
     ResultSelectActions.clear();
   },
   componentWillUnmount: function() {
     console.log("Study Component will umount. ");
+    this.unsubscribe();
   },
 
   /**
@@ -151,26 +152,22 @@ const StudyView = React.createClass({
       );
 	},
   hideUnindex () {
-      if (this.isMounted())
     this.setState({
       unindexSelected: null
     });
   },
   showUnindex (item) {
-      if (this.isMounted())
     this.setState({
       unindexSelected: item,
       removeSelected: null
     });
   },
   hideRemove () {
-      if (this.isMounted())
     this.setState({
       removeSelected: null
     });
   },
   showRemove (item) {
-      if (this.isMounted())
     this.setState({
       removeSelected: item,
       unindexSelected: null
@@ -201,14 +198,12 @@ const StudyView = React.createClass({
     this.props.onItemClick(row);
   },
   _onChange: function(data){
-
-    if (this.isMounted())
-    {
-      this.setState({data: data.data,
+    this.setState({
+      data: data.data,
       status: "stopped",
       success: data.success,
-      enableAdvancedSearch: data.data.advancedOptions});
-    }
+      enableAdvancedSearch: data.data.advancedOptions
+    });
   }
 });
 

--- a/dicoogle/src/main/resources/webapp/js/components/search/searchResult.jsx
+++ b/dicoogle/src/main/resources/webapp/js/components/search/searchResult.jsx
@@ -56,7 +56,11 @@ const SearchResult = React.createClass({
         caption: pkg.dicoogle.caption || pkg.name
       }))});
     });
-    SearchStore.listen(this._onSearchResult);
+    this.unsubscribe = SearchStore.listen(this._onSearchResult);
+  },
+
+  componentWillUnmount() {
+    this.unsubscribe();
   },
 
   componentWillUpdate(nextProps) {
@@ -67,11 +71,8 @@ const SearchResult = React.createClass({
         this.onStepClicked(0);
     }
   },
-_onSearchResult: function(outcome) {
-      if (this.isMounted())
-      {
-        this.onStepClicked(0);
-      }
+  _onSearchResult: function(outcome) {
+    this.onStepClicked(0);
   },
   handleClickExport() {
     this.setState({showExport: true, currentPlugin: null});

--- a/dicoogle/src/main/resources/webapp/js/components/search/searchResultView.jsx
+++ b/dicoogle/src/main/resources/webapp/js/components/search/searchResultView.jsx
@@ -42,8 +42,7 @@ const SearchResultView = React.createClass({
   },
 
   componentWillMount: function() {
-    // Subscribe to the store.
-    SearchStore.listen(this._onChange);
+    this.unsubscribe = SearchStore.listen(this._onChange);
     Webcore.fetchPlugins('result-batch', (packages) => {
       Webcore.fetchModules(packages);
       this.setState({batchPlugins: packages.map(pkg => ({
@@ -51,6 +50,10 @@ const SearchResultView = React.createClass({
         caption: pkg.dicoogle.caption || pkg.name
       }))});
     });
+  },
+
+  componentWillUnmount() {
+    this.unsubscribe();
   },
 
 	initSearch: function(props){
@@ -67,8 +70,6 @@ const SearchResultView = React.createClass({
 	},
 
   _onChange: function(outcome) {
-    if (this.isMounted())
-    {
       console.log('outcome:', outcome);
 
       this.setState({
@@ -76,7 +77,6 @@ const SearchResultView = React.createClass({
         status: "stopped",
         success: outcome.success
       });
-    }
   }
 });
 

--- a/dicoogle/src/main/resources/webapp/js/components/search/searchView.jsx
+++ b/dicoogle/src/main/resources/webapp/js/components/search/searchView.jsx
@@ -36,8 +36,9 @@ const Search = React.createClass({
     },
 
     componentWillMount: function(){
-      ProvidersStore.listen(this._onProvidersChange);
-      SearchStore.listen(this._onSearchResult);
+      const u1 = ProvidersStore.listen(this._onProvidersChange);
+      const u2 = SearchStore.listen(this._onSearchResult);
+      this.unsubscribe = () => { u2(); u1(); };
     },
 
     componentDidMount: function(){
@@ -52,6 +53,7 @@ const Search = React.createClass({
     },
     componentWillUnmount: function(){
       $( "#free_text" ).unbind();
+      this.unsubscribe();
     },
     componentWillUpdate: function() {
 
@@ -63,9 +65,6 @@ const Search = React.createClass({
             });
         }
         this.keyHash = getUrlVars()['_k'];
-    },
-    componentDidUpdate: function(){
-      
     },
 
     onReturn(error) {
@@ -144,28 +143,24 @@ const Search = React.createClass({
        }
     },
     _onProvidersChange: function(data) {
-        if (this.isMounted())
-        this.setState({providers: data.data});
+      this.setState({providers: data.data});
     },
     _onSearchResult: function(outcome) {
-      if (this.isMounted())
-      {
-        console.log('outcome:', outcome);
+      console.log('outcome:', outcome);
 
-        let error = null;
-        if (!outcome.success) {
-          error = "An error occurred. Please contact your system administrator.";
-        } else if (outcome.data.numResults === 0) {
-          error = "No studies were found for that search.";
-        }
-        this.setState({
-          data: outcome.data,
-          status: "stopped",
-          success: outcome.success,
-          requestedQuery: error ? null : this.state.requestedQuery,
-          error
-        });
+      let error = null;
+      if (!outcome.success) {
+        error = "An error occurred. Please contact your system administrator.";
+      } else if (outcome.data.numResults === 0) {
+        error = "No studies were found for that search.";
       }
+      this.setState({
+        data: outcome.data,
+        status: "stopped",
+        success: outcome.success,
+        requestedQuery: error ? null : this.state.requestedQuery,
+        error
+      });
     },
     renderFilter: function(){
       var switchState;


### PR DESCRIPTION
Remove all uses of `isMounted()`, by making sure that reflux stores are properly unsubscribed when the components are unmounted. This is also required in order to upgrade React.