### PR TITLE
Support for guest credentials

### DIFF
--- a/dicoogle/src/main/resources/webapp/js/components/login/loginView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/login/loginView.js
@@ -50,6 +50,11 @@ const LoginView = React.createClass({
   },
 
   render: function() {
+    const guestCredentials = process.env.GUEST_USERNAME && ([<hr/>, <div>
+      Guest credentials: <br/>
+      <b>username:</b> {process.env.GUEST_USERNAME} <br/>
+      <b>password:</b> {process.env.GUEST_PASSWORD}
+    </div>])
     return (
       <div id="loginwrapper" style={{position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', zIndex: 10000}}>
         <div className="loginbody">
@@ -75,6 +80,7 @@ const LoginView = React.createClass({
                 <input ref="pass" type="password" id="password" name="password" placeholder="Password" className="loginInputPassword form-control" />
                   {this.state.failed ? (<p style={{color: 'red'}}> Login Failed. Please try again. </p>) : ''}
                 <button type="button" className="btn submit btn_dicoogle" onClick={this.onLoginClick}>Login</button>
+                {guestCredentials}
               </form>
 
             </div>

--- a/dicoogle/src/main/resources/webapp/js/stores/userStore.js
+++ b/dicoogle/src/main/resources/webapp/js/stores/userStore.js
@@ -31,42 +31,42 @@ const UserStore = Reflux.createStore({
         if (localStorage.token) {
             console.log("loadLocalStore");
             let user = JSON.parse(localStorage.getItem("user"));
-            this._isAdmin = user.isAdmin;
-            this._username = user.username;
-            this._roles = user.roles;
-            this._token = user.token;
-            this._isLoggedIn = true;
-            this.trigger({
-                isLoggedIn: this._isLoggedIn,
-                success: true
-            });
+            if (user) {
+                this._isAdmin = user.isAdmin;
+                this._username = user.username;
+                this._roles = user.roles;
+                this._token = user.token;
+                this._isLoggedIn = true;
+                this.trigger({
+                    isLoggedIn: this._isLoggedIn,
+                    success: true
+                });
+            }
         }
     },
     onLogin: function(user, pass){
       console.log("onLogin");
-      const self = this;
 
       let Dicoogle = dicoogleClient(Endpoints.base);
 
-      Dicoogle.login(user, pass, function(errorCallBack, data){
-          if (!data.token)
-          {
-              self.trigger({
+      Dicoogle.login(user, pass, (error, data) => {
+          if (error) {
+              this.trigger({
                 failed: true
               });
               return;
           }
-          self._username = data.user;
-          self._isAdmin = data.admin;
-          self._token = data.token;
-          self._roles = data.roles;
-          self._isLoggedIn = true;
-          localStorage.token = self._token;
-          self.saveLocalStore();
+          this._username = data.user;
+          this._isAdmin = data.admin;
+          this._token = data.token;
+          this._roles = data.roles;
+          this._isLoggedIn = true;
+          localStorage.token = this._token;
+          this.saveLocalStore();
 
-          console.log("Localstorage token: " + localStorage.token);
-          self.trigger({
-              isLoggedIn: self._isLoggedIn,
+          console.log("Localstorage token:", localStorage.token);
+          this.trigger({
+              isLoggedIn: this._isLoggedIn,
               success: true
           });
       });


### PR DESCRIPTION
This adds build-time configured guest credentials. Use the environment variables `GUEST_USERNAME` and `GUEST_PASSWORD` to define credentials which will be automatically used in some circumstances and publicly visible. E.g. in bash:

```bash
GUEST_USERNAME=dicoogle GUEST_PASSWORD=dicoogle npm run build
```

If the user chooses to log out, these credentials are also shown below the login form:

![screenshot_2017-06-14_15-33-13](https://user-images.githubusercontent.com/4738426/31389915-5ea6cd4e-adca-11e7-803e-5366a709b1e8.png)
