### PR TITLE
Update dicoogle-client to version 4 and use it

### DIFF
--- a/dicoogle/src/main/resources/webapp/js/components/indexer/IndexStatusView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/indexer/IndexStatusView.js
@@ -51,15 +51,15 @@ const IndexStatusView = React.createClass({
         }
 
         let items;
-        if (this.state.data.results.length === 0) {
+        if (this.state.data.tasks.length === 0) {
           items = (<div>No tasks</div>);
         } else {
-          items = this.state.data.results.map(item => (
-            <TaskStatus key={item.taskUid} index={item.taskUid} item={item} onCloseStopClicked={this.onCloseStopClicked.bind(this, item.taskUid, item.complete)} />
+          items = this.state.data.tasks.map(item => (
+            <TaskStatus key={item.taskUid} index={item.taskUid} item={item} onCloseStopClicked={this.onCloseStopClicked.bind(this, item.taskUid, item.complete, item.canceled)} />
           ));
         }
         return (
-          <div className="">
+          <div>
             <div className="panel panel-primary topMargin">
               <div className="panel-heading">
                 <h3 className="panel-title">Start indexing</h3>
@@ -70,7 +70,7 @@ const IndexStatusView = React.createClass({
                     Index directory:
                   </div>
                   <div className="col-xs-6 col-sm-10">
-                    <input id="path" type="text" className="form-control" value={this.state.data.path} placeholder="/path/to/directory"/>
+                    <input id="path" type="text" className="form-control" placeholder="/path/to/directory"/>
                   </div>
                 </div>
                 <button className="btn btn_dicoogle" onClick={this.onStartClicked}>Start</button>
@@ -88,18 +88,20 @@ const IndexStatusView = React.createClass({
           </div>
         );
       },
-      onStartClicked: function(){
+
+      onStartClicked: function() {
         IndexStatusActions.start(document.getElementById("path").value);
       },
-      onCloseStopClicked: function(uid, type){
-        if(type){
+
+      onCloseStopClicked: function(uid, isComplete, isCanceled) {
+        if (isComplete || isCanceled) {
           IndexStatusActions.close(uid);
         }
-        else{
+        else {
           IndexStatusActions.stop(uid);
         }
       }
-      });
+});
 
 export {
   IndexStatusView

--- a/dicoogle/src/main/resources/webapp/js/components/management/transferOptionsView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/management/transferOptionsView.js
@@ -2,8 +2,6 @@ import React from 'react';
 
 import {TransferStore} from '../../stores/transferStore';
 import {TransferActions} from '../../actions/transferActions';
-import {Endpoints} from '../../constants/endpoints';
-import $ from 'jquery';
 import {Button} from 'react-bootstrap';
 
 const TransferOptionsView = React.createClass({
@@ -110,28 +108,17 @@ const TransferOptionsView = React.createClass({
           this.selectAllOn = !this.selectAllOn;
 
       },
+
       handleChange(id, index) {
-        TransferActions.set(this.state.selectedIndex, index, document.getElementById(id).checked);
-        this.request(id, document.getElementById(id).checked);
+        let uid = this.state.data.data[document.getElementById("sop_select").selectedIndex].uid;
+        let value = document.getElementById(id).checked;
+        TransferActions.set(this.state.selectedIndex, index, uid, id, value);
       },
 
       onSopSelected() {
         var selectedId = document.getElementById("sop_select").selectedIndex;
 
         this.setState({selectedIndex: selectedId});
-      },
-
-      request(id, value) {
-        var uid = this.state.data.data[document.getElementById("sop_select").selectedIndex].uid;
-        console.log("Selected uid:", uid);
-        $.post(Endpoints.base + "/management/settings/transfer", {
-          uid: uid,
-          option: id,
-          value: value
-        }, (data, status) => {
-          //Response
-          console.log("Data: " + data + "\nStatus: " + status);
-        });
       }
 });
 

--- a/dicoogle/src/main/resources/webapp/js/components/search/exportView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/exportView.js
@@ -1,18 +1,17 @@
 import React from 'react';
-import {Button, Modal} from 'react-bootstrap';
+import {Button, Modal, FormGroup, FormControl, ControlLabel} from 'react-bootstrap';
 
 import {ExportActions} from '../../actions/exportActions';
 import {ExportStore} from '../../stores/exportStore';
 
 const ExportView = React.createClass({
 	getInitialState: function() {
-      return {data: [],
-      status: "loading",
-      current: 0};
-    },
-    componentDidMount: function() {
-    },
-	componentDidUpdate: function() {
+		return {
+			data: [],
+			status: "loading",
+			fieldText: "",
+			current: 0
+		};
 	},
 	componentWillMount: function() {
 		// Subscribe to the store.
@@ -26,25 +25,41 @@ const ExportView = React.createClass({
 		}
 	},
 
-	render: function(){
+	render: function() {
     return (
-      <Modal {...this.props} bsStyle='primary' title='Export to CSV' animation>
-        <div className='modal-body'>
-            <textarea id="textFields" placeholder="Paste export fields here (one per line) ..." rows="10" className="exportlist form-control"></textarea>
-        </div>
-        <div id="hacked-modal-footer" className='modal-footer'>
-          <Button onClick={this.onExportClicked}>Export</Button>
-        </div>
-      </Modal>);
+			<Modal {...this.props} bsStyle='primary' animation>
+				<Modal.Header>
+					<Modal.Title>Export to CSV</Modal.Title>
+				</Modal.Header>
+				<Modal.Body>
+					<FormGroup>
+						<ControlLabel>Export Field List</ControlLabel>
+						<FormControl
+							componentClass="textarea"
+							placeholder="Paste export fields here (one per line) ..."
+							rows="10"
+							bsClass="exportlist"
+							onChange={this.handleTextChanged}
+							value={this.state.fieldText}
+						/>
+					</FormGroup>
+				</Modal.Body>
+				<Modal.Footer id="hacked-modal-footer-do-not-remove">
+					<Button bsStyle="primary" onClick={this.handleExportClicked}>Export</Button>
+				</Modal.Footer>
+			</Modal>)
 	},
 
-  onExportClicked: function(){
-    //console.log("onExportCLicked", document.getElementById("textFields").value);
-		var fields = document.getElementById("textFields").value.split("\n");
-		console.log(fields);
+	handleTextChanged: function(e) {
+		this.setState({fieldText: e.target.value});
+	},
 
-		var query = this.props.query;
-		ExportActions.exportCSV(query, fields);
+  handleExportClicked: function() {
+    const fields = this.state.fieldText.split("\n");
+    console.log(fields);
+
+    const query = this.props.query;
+    ExportActions.exportCSV(query, fields);
   }
 });
 

--- a/dicoogle/src/main/resources/webapp/js/handlers/requestHandler.js
+++ b/dicoogle/src/main/resources/webapp/js/handlers/requestHandler.js
@@ -1,136 +1,94 @@
-import {Endpoints} from '../constants/endpoints';
-import $ from 'jquery';
+import dicoogleClient from 'dicoogle-client';
 
-function getPatients(freetext, isKeyword, provider, callbackSucccess, callbackError){
-        console.log("store param: ", freetext);
-        // ??? use dicoogle client?
+const Dicoogle = dicoogleClient();
 
-        //'http://localhost:8080/search?query=wrix&keyword=false&provicer=lucene'
-        if(freetext.length === 0)
-        {
-          freetext = "*:*";
-          isKeyword = true;
-        }
-
-        var url = Endpoints.base + '/searchDIM?query=' + freetext + '&keyword=' + isKeyword;
-        if(provider !== "all")
-        {
-          provider = Array.prototype.concat.apply([], provider);
-          for (const p of provider) {
-            url += "&provider=" + p;
-          }
-        }
-        console.log("store url;", url);
-
-        $.ajax({
-
-          url: url,
-          dataType: 'json',
-          success: function(data) {
-
-            callbackSucccess(data);
-
-          },
-          error: function(xhr, status, err) {
-            callbackError(xhr);
-          }
-        });
+export function getDICOMFieldList(callback) {
+  Dicoogle.request('GET', 'export/list').end((err, resp) => {
+    if (err) callback(err);
+    else callback(null, resp.body);
+  });
 }
 
-function unindex(uri, provider, callbackSuccess, callbackError){
-    console.log("Unindex param: ", uri);
+export function getTransferSettings(callback) {
+  Dicoogle.getTransferSyntaxSettings(callback);
+}
 
-    var url = Endpoints.base + '/management/tasks/unindex';
-    var data = {'uri': uri}
-    if(provider !== 'all')
-      data['provider'] = provider;
+export function getIndexerSettings(callback) {
+  Dicoogle.getIndexerSettings(callback);
+}
 
-    // TODO use dicoogle client
-    $.ajax({
-      url: url,
-      data: data,
-      method: 'post',
-      traditional: true,
-      success: callbackSuccess,
-      error: function(xhr, status, err) {
-        callbackError(xhr);
+export function getPatients(freeText, isKeyword, provider, callbackSuccess, callbackError) {
+    console.log("getPatients: ", freeText);
+    if(freeText.length === 0)
+    {
+      freeText = "*:*";
+      isKeyword = true;
+    }
+
+    if (provider === 'all') {
+      provider = undefined;
+    }
+
+    const searchOptions = {
+      keyword: isKeyword,
+      provider
+    };
+
+    Dicoogle.searchDIM(freeText, searchOptions, (error, data) => {
+      if (error) {
+        callbackError(error);
+      } else {
+        callbackSuccess(data);
       }
     });
 }
 
-function remove(uri, callbackSucccess, callbackError){
+export function unindex(uri, provider, callbackSuccess, callbackError) {
     console.log("Unindex param: ", uri);
 
-    var url = Endpoints.base + '/management/tasks/remove';
-    var data = {'uri': uri}
+    if(provider === 'all') {
+      provider = undefined;
+    }
 
-    // TODO use dicoogle client
-    $.ajax({
-      url: url,
-      data: data,
-      method: 'post',
-      traditional: true,
-      success: function(data) {
-       callbackSucccess(data);
-      },
-      error: function(xhr, status, err) {
-        callbackError(xhr);
+    Dicoogle.unindex(uri, provider, function(error) {
+      if (error) {
+        callbackError(error);
+      } else {
+        callbackSuccess();
       }
     });
 }
 
-function getImageInfo(uid, callbackSucccess, callbackError){
-        console.log("getImageInfo: ", uid);
+export function remove(uri, callbackSuccess, callbackError) {
+    console.log("Unindex param: ", uri);
 
-        //'http://localhost:8080/search?query=wrix&keyword=false&provicer=lucene'
-        var url = Endpoints.base + '/dump?uid=' + uid;
-
-        // TODO use dicoogle client
-        $.ajax({
-          url: url,
-          method: 'get',
-          dataType: 'json',
-          success: function(data) {
-            callbackSucccess(data);
-          },
-          error: function(xhr, status, err) {
-            callbackError(xhr);
-          }
-        });
-}
-
-function getVersion(callbackSucccess, callbackError){
-
-    var url = Endpoints.base + '/ext/version';
-    // TODO use dicoogle client
-    $.ajax({
-        url: url,
-        method: 'get',
-        dataType: 'json',
-        success: function(data) {
-
-            callbackSucccess(data);
-
-        },
-        error: function(xhr, status, err) {
-            callbackError(xhr);
-        }
+    Dicoogle.remove(uri, function(error) {
+      if (error) {
+        callbackError(error);
+      } else {
+        callbackSuccess();
+      }
     });
 }
 
-function request(url, callbackSucccess, callbackError){
-    console.log("request: " + url);
-    $.ajax({
+export function getImageInfo(uid, callbackSuccess, callbackError) {
+    console.log("getImageInfo: ", uid);
 
-      url: url,
-      dataType: 'json',
-      success: function(data) {
+    Dicoogle.dump(uid, function(error, data){
+      if (error) {
+        callbackError(error);
+      } else {
+        callbackSuccess(data);
+      }
+    });
+}
 
-      callbackSucccess(data);
-
-      },
-      error: function(xhr, status, err) {
-        callbackError(xhr);
+export function getVersion(callbackSuccess, callbackError) {
+  Dicoogle.getVersion(function(error, data) {
+      if (error) {
+        callbackError(error);
+      } else {
+        callbackSuccess(data);
       }
     });
 }
@@ -138,74 +96,38 @@ function request(url, callbackSucccess, callbackError){
 /*
 INDEXER
 */
-function setWatcher(state){
-  console.log(state);
-  $.post(Endpoints.base + "/management/settings/index/watcher",
-  {
-    watcher: state
-  },
-    function(data, status){
-      //Response
-      console.log("Data: " + data + "\nStatus: " + status);
+export function setWatcher(state, callback) {
+    console.log("setWatcher:" + state);
+
+    const cb = callback ? callback : () => {};
+    Dicoogle.setIndexerSettings(Dicoogle.IndexerSettings.WATCHER, state, cb);
+}
+
+export function setZip(state, callback) {
+    console.log("setZip:" + state);
+
+    const cb = callback ? callback : () => {};
+    Dicoogle.setIndexerSettings(Dicoogle.IndexerSettings.ZIP, state, cb);
+}
+
+export function setSaveT(state, callback) {
+    console.log("setSaveThumbnail:" + state);
+
+    const cb = callback ? callback : () => {};
+    Dicoogle.setIndexerSettings(Dicoogle.IndexerSettings.INDEX_THUMBNAIL, state, cb);
+}
+
+export function saveIndexOptions(path, watcher, zip, thumbnail, effort, thumbnailSize) {
+    Dicoogle.setIndexerSettings({
+      path, watcher, zip, thumbnail, effort, thumbnailSize
+    }, (error) => {
+      if (error) console.error('Dicoogle service failure', error);
     });
-
 }
-function setZip(state){
-  console.log(state);
-  $.post(Endpoints.base + "/management/settings/index/zip",
-  {
-    zip: state
-  },
-    function(data, status){
-      //Response
-      console.log("Data: " + data + "\nStatus: " + status);
+
+export function forceIndex(uri, providers, callback) {
+    Dicoogle.index(uri, providers, (error) => {
+      if (error) console.error('Dicoogle service failure', error);
+      if (callback) callback(error);
     });
-
 }
-function setSaveT(state){
-  console.log(state);
-  $.post(Endpoints.base + "/management/settings/index/thumbnail",
-  {
-    thumbnail: state
-  },
-    function(data, status){
-      //Response
-      console.log("Data: " + data + "\nStatus: " + status);
-    });
-
-}
-
-function saveIndexOptions(path, watcher, zip, saveThumbnail, effort, thumbnailSize){
-  //console.log(state);
-  $.post(Endpoints.base + "/management/settings/index",
-  {
-    path: path,
-    watcher: watcher,
-    zip: zip,
-    saveThumbnail: saveThumbnail,
-    effort: effort,
-    thumbnailSize: thumbnailSize
-  },
-    function(data, status){
-      //Response
-      console.log("Data: " + data + "\nStatus: " + status);
-    });
-
-}
-
-function forceIndex(uri){
-  //console.log(state);
-  // TODO use dicoogle client
-  $.post(Endpoints.base + "/management/tasks/index",
-  {
-    uri: uri
-  },
-  function(data, status){
-    //Response
-    console.log("Status:", status);
-  });
-}
-
-export {
-  getPatients, unindex, remove, getImageInfo, request, setWatcher,
-  setZip, setSaveT, saveIndexOptions, forceIndex, getVersion};

--- a/dicoogle/src/main/resources/webapp/js/stores/indexStatusStore.js
+++ b/dicoogle/src/main/resources/webapp/js/stores/indexStatusStore.js
@@ -2,93 +2,80 @@
 
 import Reflux from 'reflux';
 import {IndexStatusActions} from '../actions/indexStatusAction';
-import {Endpoints} from '../constants/endpoints';
 import {forceIndex} from '../handlers/requestHandler';
-import $ from 'jquery';
+
+import dicoogleClient from 'dicoogle-client';
 
 const IndexStatusStore = Reflux.createStore({
     listenables: IndexStatusActions,
     init: function () {
-       this._contents = {};
+      this._contents = {};
+
+      this.dicoogle = dicoogleClient();
     },
 
-    onGet: function(data){
-      var self = this;
-
-      $.ajax({
-        url: Endpoints.base + "/index/task",
-        dataType: 'json',
-        success: function(data) {
-          self._contents = data;
-
-          self.trigger({
-            data: self._contents,
-            success: true
+    onGet: function() {
+      this.dicoogle.tasks.list((error, data) => {
+        if (error) {
+          this.trigger({
+            success: false,
+            status: error.status
           });
-
-        },
-        error: function(xhr, status, err) {
-          //FAILURE
-          self.trigger({
-              success: false,
-              status: xhr.status
-            });
+          return;
         }
-      });
 
-    },
-
-    onStart: function(uri){
-      var self = this;
-      forceIndex(uri);
-
-      self._contents.results.push({taskUid: "...", taskName: uri, taskProgress: -1})
-      self._contents.count = self._contents.count + 1;
-      self.trigger({
-        data: self._contents,
-        success: true
-      });
-
-      console.log(this._contents);
-    },
-
-    onClose: function(uid){
-
-      $.post(Endpoints.base + "/index/task",
-      {
-        uid: uid,
-        action: "delete",
-        type: "close"
-      },
-        function(data, status){
-          //Response
-          console.log("Data: ", data, " ; Status: ", status);
+        this._contents = data;
+        this.trigger({
+          data: this._contents,
+          success: true
         });
-
-      for (var i = 0; i < this._contents.results.length; i++)
-      {
-        if (this._contents.results[i].taskUid === uid) {
-          this._contents.results.splice(i, 1);
-          break;
-        }
-      }
-      this.trigger({
-        data: this._contents,
-        success: true
       });
     },
-    onStop: function(uid){
+
+    onStart: function(uri) {
+      forceIndex(uri, [], (error) => {
+        if (error) {
+          this.trigger({
+            success: false,
+            status: error.status
+          });
+          return;
+        }
+
+        this.onGet();
+      });
+    },
+
+    onClose: function(uid) {
+      this.dicoogle.tasks.close(uid, (error) => {
+        console.log("closeTask: ", error || 'ok');
+
+        if (error) {
+          this.trigger({
+            success: false,
+            status: error.status
+          });
+          return;
+        }
+
+        for (let i = 0; i < this._contents.tasks.length; i++) {
+          if (this._contents.tasks[i].taskUid === uid) {
+            this._contents.tasks.splice(i, 1);
+            break;
+          }
+        }
+        this.trigger({
+          data: this._contents,
+          success: true
+        });
+      });
+    },
+
+    onStop: function(uid) {
       console.log("Stop: ", uid);
-      $.post(Endpoints.base + "/index/task",
-      {
-        uid: uid,
-        action: "delete",
-        type: "stop"
-      },
-        function(data, status){
-          //Response
-          console.log("Data: ", data, " ; Status: ", status);
-        });
+      this.dicoogle.tasks.stop(uid, (error) => {
+        console.log("stopTask: ", error || 'ok');
+      });
     }
 
 });

--- a/dicoogle/src/main/resources/webapp/js/stores/indexerStore.js
+++ b/dicoogle/src/main/resources/webapp/js/stores/indexerStore.js
@@ -2,8 +2,7 @@
 
 import Reflux from 'reflux';
 import {IndexerActions} from '../actions/indexerActions';
-import {Endpoints} from '../constants/endpoints';
-import {request} from '../handlers/requestHandler';
+import {getIndexerSettings} from '../handlers/requestHandler';
 
 const IndexerStore = Reflux.createStore({
     listenables: IndexerActions,
@@ -11,30 +10,24 @@ const IndexerStore = Reflux.createStore({
        this._contents = {};
     },
 
-    onGet: function(){
+    onGet: function() {
       console.log("onGet");
-      var self = this;
-      var url = Endpoints.base + "/management/settings/index";
-      request(url,
-        function(data){
-          //SUCCESS
-          console.log("success", data);
-          self._contents = data;
-
-          self.trigger({
-            data: self._contents,
-            success: true
+      getIndexerSettings((error, data) => {
+        if (error) {
+          this.trigger({
+            success: false,
+            status: error.status
           });
-        },
-        function(xhr){
-          //FAILURE
-          self.trigger({
-              success: false,
-              status: xhr.status
-            });
+          return;
         }
-      );
 
+        console.log("success", data);
+        this._contents = data;
+        this.trigger({
+          data: this._contents,
+          success: true
+        });
+      });
     }
 });
 

--- a/dicoogle/src/main/resources/webapp/js/stores/loggerStore.js
+++ b/dicoogle/src/main/resources/webapp/js/stores/loggerStore.js
@@ -1,41 +1,33 @@
 'use strict';
 
 import Reflux from 'reflux';
-import $ from 'jquery';
 import {LoggerActions} from '../actions/loggerActions';
-import {Endpoints} from '../constants/endpoints';
+
+import dicoogleClient from 'dicoogle-client';
 
 const LoggerStore = Reflux.createStore({
     listenables: LoggerActions,
     init: function () {
-       this._contents = {};
+      this._contents = {};
+
+      this.dicoogle = dicoogleClient();
     },
 
-    onGet: function(data){
-      var self = this;
-
-      $.ajax({
-
-        url: Endpoints.base + "/logger",
-        dataType: 'text',
-        success: function(data) {
-          self._contents = data;
-
-          self.trigger({
-            data: self._contents,
-            success: true
+    onGet: function() {
+      this.dicoogle.getRawLog((error, log) => {
+        if (error) {
+          this.trigger({
+            success: false,
+            status: error.status
           });
-
-        },
-        error: function(xhr, status, err) {
-          //FAILURE
-          self.trigger({
-              success: false,
-              status: xhr.status
-            });
         }
-      });
 
+        this._contents = log;
+        this.trigger({
+          data: log,
+          success: true
+        });
+      });
     }
 });
 

--- a/dicoogle/src/main/resources/webapp/js/stores/storageStore.js
+++ b/dicoogle/src/main/resources/webapp/js/stores/storageStore.js
@@ -1,89 +1,84 @@
 import Reflux from 'reflux';
-import $ from 'jquery';
-
 import {StorageActions} from '../actions/storageActions';
-import {Endpoints} from '../constants/endpoints';
+
+import dicoogleClient from 'dicoogle-client';
 
 const StorageStore = Reflux.createStore({
     listenables: StorageActions,
     init() {
-       this._contents = [];
+      this._contents = [];
+
+      this.dicoogle = dicoogleClient();
     },
 
-    onGet(data){
-
-      $.ajax({
-        url: Endpoints.base + "/management/settings/storage/dicom",
-        dataType: 'json',
-        success: (data) => {
-          this._contents = data.map((store) => ({
-            aetitle: store.AETitle,
-            ip: store.ipAddrs,
-            port: store.port,
-            description: store.description,
-            public: store.isPublic
-          }));
+    onGet() {
+      this.dicoogle.storage.getRemoteServers((error, data) => {
+        if (error) {
+          console.log("onGet: failure", error);
           this.trigger({
-            data: this._contents,
-            success: true
+            success: false,
+            status: error.status
           });
-        },
-        error: (xhr, status, err) => {
-          //FAILURE
-          this.trigger({
-              success: false,
-              status: xhr.status
-            });
+          return;
         }
-      });
 
-    },
-    onAdd(aetitle, ip, port, description, isPublic) {
-      console.log("Onadd clicked 2");
-
-      $.post(Endpoints.base + "/management/settings/storage/dicom",
-      {
-        type: "add",
-        aetitle,
-        ip,
-        port,
-        description,
-        public: isPublic
-      },
-      (data, status) => {
-        this._contents.push({aetitle, ip, port, description, public: isPublic});
-        //Response
-        console.log("Data: " + data + "\nStatus: " + status);
+        this._contents = data;
         this.trigger({
           data: this._contents,
           success: true
         });
       });
     },
-    onRemove(index) {
-      const {aetitle, ip, port, description} = this._contents[index];
-      const isPublic = this._contents[index].public;
-      $.post(Endpoints.base + "/management/settings/storage/dicom",
-      {
-        type: "remove",
-        aetitle,
-        ip,
-        port,
-        description,
-        public: isPublic
-      },
-      (data, status) => {
-          //Response
-          console.log("Data: " + data + "\nStatus: " + status);
-          this._contents.splice(index, 1);
+
+    onAdd(aetitle, ip, port, description, isPublic) {
+      this.dicoogle.storage.addRemoteServer({
+          aetitle, ip, port, description, public: isPublic
+        }, (error) => {
+          if (error) {
+            console.log("onAdd: failure", error);
+            this.trigger({
+              success: false,
+              status: error.status
+            });
+            return;
+          }
+
+          this._contents.push({
+            aetitle, ip, port, description, public: isPublic
+          });
           this.trigger({
             data: this._contents,
             success: true
           });
+        }
+      );
+    },
+
+    onRemove(index) {
+      const {aetitle, ip, port, description} = this._contents[index];
+      const isPublic = this._contents[index].public;
+
+      this.dicoogle.storage.removeRemoteServer({
+        aetitle, ip, port, description, public: isPublic
+      }, (error, removed) => {
+        if (error) {
+          console.log("onRemove: failure", error);
+          this.trigger({
+            success: false,
+            status: error.status
+          });
+          return;
+        }
+
+        if (removed) {
+          this._contents.splice(index, 1);
+        }
+        this.trigger({
+          data: this._contents,
+          success: true
         });
-
+      });
     }
-
 });
 
 export {StorageStore};

--- a/dicoogle/src/main/resources/webapp/package.json
+++ b/dicoogle/src/main/resources/webapp/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "bootstrap": "^3.3.2",
     "core-js": "^2.0.3",
-    "dicoogle-client": "^3.6.0",
+    "dicoogle-client": "^4.1.2",
     "dicoogle-webcore": "file:../../../../../webcore",
     "history": "^3.0.0",
     "jquery": "^1.10.2",

--- a/webcore/package.json
+++ b/webcore/package.json
@@ -31,7 +31,7 @@
     "eslint-plugin-import": "^1.8.1"
   },
   "peerDependencies": {
-    "dicoogle-client": "^3.6.0"
+    "dicoogle-client": "^4.1.2"
   },
   "dependencies": {
     "document-register-element": "^0.5.4",


### PR DESCRIPTION
This targets #312. It depends on #301, that already handles login actions using `dicoogle-client` package. Also, this solves two minor bugs, that were caught along the refactoring:
* In IndexerStatusView, now tasks are being correctly stopped when this action is performed;
* In StorageView, now it allows to correctly add a storage server with no description.