### PR TITLE
Webcore 0.15.0 - better data provision API

### DIFF
--- a/dicoogle/src/main/resources/webapp/js/components/management/servicesView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/management/servicesView.js
@@ -75,7 +75,7 @@ const ServicesView = React.createClass({
                 <p>{p.caption}</p>
               </div>
               <div className="col-xs-8">
-                <PluginView plugin={p.name} slotId="settings" />
+                <PluginView plugin={p.name} slotId="settings" data={{}} />
               </div>
             </div>
           </div>

--- a/dicoogle/src/main/resources/webapp/js/components/plugin/pluginForm.jsx
+++ b/dicoogle/src/main/resources/webapp/js/components/plugin/pluginForm.jsx
@@ -3,7 +3,7 @@ import {ResultsSelected} from '../../stores/resultSelected';
 import dicoogleClient from 'dicoogle-client';
 const Dicoogle = dicoogleClient();
 
-export default class PluginFormModal extends React.Component {
+export default class PluginForm extends React.Component {
 
   static get propTypes() {
     return {
@@ -12,7 +12,7 @@ export default class PluginFormModal extends React.Component {
         name: PropTypes.string.isRequired,
         caption: PropTypes.string
       }),
-      data: React.PropTypes.object,
+      data: React.PropTypes.object.isRequired,
       onHide: PropTypes.func.isRequired
     };
   }
@@ -30,6 +30,7 @@ export default class PluginFormModal extends React.Component {
   handleMounted(component) {
     if (component) {
       const node = component;
+      node.data = this.props.data;
       node.addEventListener('hide', this.handleHideSignal);
       Dicoogle.emitSlotSignal(node, 'result-selection-ready', ResultsSelected.get());
     }
@@ -44,15 +45,11 @@ export default class PluginFormModal extends React.Component {
   render() {
     const {plugin} = this.props;
     return (plugin &&
-      <div>
-
-          <dicoogle-slot {...this.props.data} ref={this.handleMounted} data-slot-id={this.props.slotId} data-plugin-name={plugin.name}>
-            {plugin.name && <div className="loader-inner ball-pulse">
-              <div/><div/><div/>
-            </div>}
-          </dicoogle-slot>
-
-      </div>
+      <dicoogle-slot {...this.props.data} ref={this.handleMounted} data-slot-id={this.props.slotId} data-plugin-name={plugin.name}>
+        {plugin.name && <div className="loader-inner ball-pulse">
+          <div/><div/><div/>
+        </div>}
+      </dicoogle-slot>
     );
   }
 }

--- a/dicoogle/src/main/resources/webapp/js/components/plugin/pluginView.jsx
+++ b/dicoogle/src/main/resources/webapp/js/components/plugin/pluginView.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-class PluginView extends React.Component {
+export default class PluginView extends React.Component {
 
   static get propTypes() {
     return {
@@ -9,7 +9,7 @@ class PluginView extends React.Component {
       // the plugin name
       plugin: React.PropTypes.string,
       slotId: React.PropTypes.string,
-      data: React.PropTypes.object
+      data: React.PropTypes.object.isRequired
     };
   }
 
@@ -37,6 +37,7 @@ class PluginView extends React.Component {
           this.handleLoaded(e.detail);
         }
       });
+      node.data = this.props.data;
     }
   }
 
@@ -72,5 +73,3 @@ class PluginView extends React.Component {
     );
   }
 }
-
-export default PluginView;

--- a/dicoogle/src/main/resources/webapp/js/components/search/result/imageView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/imageView.js
@@ -101,6 +101,10 @@ const ImageView = React.createClass({
 
                   {/* plugin-based result options*/}
                   <PluginView style={{display: 'inline-block'}} slotId="result-options" data={{
+                  type: 'image',
+                  uri: item.uri,
+                  uid: item.sopInstanceUID,
+                  // deprecated data properties
                   'data-result-type': 'image',
                   'data-result-uri': item.uri,
                   'data-result-uid': item.sopInstanceUID

--- a/dicoogle/src/main/resources/webapp/js/components/search/result/patientView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/patientView.js
@@ -87,6 +87,10 @@ const PatientView = React.createClass({
                     {removeFiles}
                 {/* plugin-based result options */}
                 <PluginView style={{display: 'inline-block'}} slotId="result-options" data={{
+                  type: 'patient',
+                  patientName: item.name,
+                  patientId: item.id,
+                  // deprecated data fields
                   'data-result-type': 'patient',
                   'data-result-patient': item.name,
                   'data-result-patientid': item.id

--- a/dicoogle/src/main/resources/webapp/js/components/search/result/serieView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/serieView.js
@@ -82,8 +82,11 @@ const SeriesView = React.createClass({
 
               {/* plugin-based result options */}
               <PluginView style={{display: 'inline-block'}} slotId="result-options" data={{
-          'data-result-type': 'series',
-          'data-result-uid': item.serieInstanceUID
+                type: 'series',
+                uid: item.serieInstanceUID,
+                // deprecated data fields
+                'data-result-type': 'series',
+                'data-result-uid': item.serieInstanceUID
          }} />
             </div>
         );

--- a/dicoogle/src/main/resources/webapp/js/components/search/result/studyView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/studyView.js
@@ -77,6 +77,9 @@ const StudyView = React.createClass({
               {removeFiles}
               {/* plugin-based result options */}
               <PluginView style={{display: 'inline-block'}} slotId="result-options" data={{
+                  'type': 'study',
+                  'uid': item.studyInstanceUID,
+                  // deprecated data fields
                   'data-result-type': 'study',
                   'data-result-uid': item.studyInstanceUID
                 }}/>

--- a/dicoogle/src/main/resources/webapp/js/components/search/searchResult.jsx
+++ b/dicoogle/src/main/resources/webapp/js/components/search/searchResult.jsx
@@ -61,7 +61,7 @@ const SearchResult = React.createClass({
 
   componentWillUpdate(nextProps) {
 
-    if (this.props.requestedQuery.queryText !== nextProps.requestedQuery.queryText) {
+    if (this.props.requestedQuery.text !== nextProps.requestedQuery.text) {
       //init StepView
       if(!this.state.current)
         this.onStepClicked(0);
@@ -163,7 +163,10 @@ _onSearchResult: function(outcome) {
         <ExportView show={this.state.showExport} onHide={this.handleHideExport} query={this.props.requestedQuery}/>
         <PluginForm show={!!this.state.currentPlugin} slotId="result-batch"
                     plugin={this.state.currentPlugin} onHide={this.handleHideBatchForm}
-                    data={{results: this.props.searchOutcome.data.results}} />
+                    data={{
+                      query: this.props.requestedQuery.text,
+                      queryProvider: this.props.requestedQuery.provider,
+                      results: this.props.searchOutcome.data.results}} />
       </div>);
 	},
 

--- a/webcore/README.md
+++ b/webcore/README.md
@@ -90,14 +90,28 @@ The exported module must be a single constructor function (or class), in which i
 
 ```javascript
 /** Render and attach the contents of a new plugin instance to the given DOM element.
- * @param {DOMElement} parent the parent element of the plugin component
- * @param {DOMElement} slot the DOM element of the Dicoogle slot
+ * @param {HTMLElement} parent the parent element of the plugin component, unique to this component.
+ * @param {SlotHTMLElement} slot the DOM element of the Dicoogle slot, containing a few additional properties:
+ `slotId`, `pluginName` and `data`.
  * @return Alternatively, return a React element while leaving `parent` intact. (Experimental, still unstable!)
  */
 function render(parent, slot) {
     // ...
 }
 ```
+
+Additional data is provided to the plugin through the `onReceiveData` method, which is called shortly after `render`. This `data` argument
+is always an object, and will be automatically attached to the `data` property of the slot HTML element.
+
+```javascript
+/** Obtain access to other pieces of information, which depend on the plugin's context.
+ * @param {PluginData} data the data provided to this plugin component
+ */
+function onReceiveData(data) {
+    // ...
+}
+```
+
 
 Furthermore, the `onResult` method must be implemented if the plugin is for a "result" slot:
 
@@ -129,25 +143,52 @@ module.exports = function() {
 
   this.render = function(parent, slot) {
     var e = document.create('span');
-    e.innerHTML = 'Hello Dicoogle!';
+    e.innerHTML = 'Hello Dicoogle! This is plugin ' + slot.pluginName;
     parent.appendChild(e);
+  };
+
+  this.onReceive = function(data) {
   };
 };
 ```
 
-Exporting a class in ECMAScript 6 also works (since classes are syntatic sugar for ES5 constructors).
-The code below can be converted to ES5 using Babel:
+Exporting a class in ECMAScript 2015+ also works (since classes are syntatic sugar for ES5 constructors).
+The code below can be converted to a more compatible ECMAScript version (e.g. ES5) using Babel:
 
 ```javascript
 export default class MyPluginModule() {
 
   render(parent) {
     let e = document.create('span');
-    e.innerHTML = 'Hello Dicoogle!';
+    e.innerHTML = `Hello Dicoogle! This is plugin ${slot.pluginName}`;
     parent.appendChild(e);
+  }
+
+  onReceive(data) {
   }
 };
 ```
+
+### Types of Web Plugins
+
+This section documents each possible type of web UI plugin. Note that not all of them are fully supported at the moment.
+
+- **menu**: Menu plugins are used to augment the main menu. A new entry is added to the side bar (named by the plugin's caption
+  property), and the component is created when the user navigates to that entry.
+- **result-option**: Result option plugins are used to provide advanced operations to a result entry. If the user activates
+  _"Advanced Options"_ in the search results view, these plugins will be attached into a new column, one for each visible result entry.
+- **result-batch**: Result batch plugins are used to provide advanced operations over an existing list of results. These plugins will
+  attach a button (named with the plugin's caption property), which will pop-up a division below the search result view.
+- **settings**: Settings plugins can be used to provide addition management information and control. These plugins will be attached to
+  the _"Plugins & Services"_ tab in the _Management_ menu.
+- **query**: _(currently unsupported)_ Create different query user interfaces. Once supported, they will be
+  attached in some way to the _Search_ menu, but only replace the query component (existing search result views will be reused).
+- **result**: _(currently unsupported)_ They are used to expose results of a search. Once supported, they will be attached
+  in some way to the _Search_ menu when the results of a search are successfully retrieved.
+- **search**: _(currently unsupported)_ Create different search user interfaces. Once supported, they will be
+  attached in some way to the _Search_ menu, as a complete substitute to the existing search interface. This type of plugin
+  is particularly useful for non-DICOM content, since other search result views may not be compatible with existing Dicoogle
+  data providers.
 
 ### Dicoogle Web API
 

--- a/webcore/package.json
+++ b/webcore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dicoogle-webcore",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "author": "Universidade de Aveiro, DETI/IEETA, Bioinformatics Group (http://bioinformatics.ua.pt/)",
   "maintainers": [

--- a/webcore/src/dicoogle-webcore.js
+++ b/webcore/src/dicoogle-webcore.js
@@ -520,6 +520,19 @@ const DicoogleWebcore = (function () {
             this._webUi = webUi;
           }
         },
+        data: {
+          get () {
+            return this._data;
+          },
+          set (data) {
+            this._data = data;
+            for (let i = 0; i < this.webUi.attachments.length; i++) {
+              if (isFunction(this.webUi.attachments[i].onReceiveData)) {
+                this.webUi.attachments[i].onReceiveData(data);
+              }
+            }
+          }
+        },
         createdCallback: { value () {
         }},
         attachedCallback: { value () {


### PR DESCRIPTION
This PR adds a feature that will be useful to some of our RSI students.

- Add optional `onReceiveData` as new plugin component callback for receiving data
- Deprecate using "data-" properties to retrieve information from plugins
- Add "query" and "queryProvider" to plugin data for type "result-batch"
- Refactor names of some "result-option" plugin data properties, deprecate previous ones
- Document existing web plugin types.

I will add more info on this soon.