### PR TITLE
Bump to 3.0.0-SNAPSHOT

### DIFF
--- a/dicoogle/pom.xml
+++ b/dicoogle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>pt.ua.ieeta</groupId>
         <artifactId>dicoogle-all</artifactId>
-        <version>2.5.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>pt.ua.ieeta</groupId>
   <artifactId>dicoogle-all</artifactId>
-  <version>2.5.0-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>dicoogle-all</name>
   

--- a/sdk-ext/pom.xml
+++ b/sdk-ext/pom.xml
@@ -10,7 +10,7 @@
         <parent>
             <groupId>pt.ua.ieeta</groupId>
             <artifactId>dicoogle-all</artifactId>
-            <version>2.5.0-SNAPSHOT</version>
+            <version>3.0.0-SNAPSHOT</version>
             <relativePath>../pom.xml</relativePath>
         </parent>
 

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>pt.ua.ieeta</groupId>
         <artifactId>dicoogle-all</artifactId>
-        <version>2.5.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
The `dev` branch is now targeted towards version 3.0.0, so we might as well bump all package versions. This will allow us to start testing our plugin implementations with the right SDK.