### PR TITLE
Add LetsEncrypt CA certificate import to Travis Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 language: java
 dist: trusty
-sudo: false
+sudo: true
+
+before_cache:
+ - rm -rf $HOME/.m2/repository/pt/ua/ieeta/dicoogle*
+
+cache:
+  directories:
+    - $HOME/.m2
+
 matrix:
   include:
     - jdk: oraclejdk8
@@ -25,6 +33,8 @@ addons:
       - g++-4.7
 
 before_install:
+  - wget https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.der;
+    sudo keytool -importcert -trustcacerts -alias lets-encrypt-x3-cross-signed -file lets-encrypt-x3-cross-signed.der -storepass changeit -keystore $JAVA_HOME/jre/lib/security/cacerts
   - nvm install $NODE_VERSION
   - if [ $TRAVIS_OS_NAME == "linux" ]; then
       export CC="gcc-4.7";

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -28,13 +28,6 @@
             </snapshots>
         </repository>
         <repository>
-            <id>dcm4che</id>
-            <url>http://www.dcm4che.org/maven2/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-        <repository>
             <id>mi</id>
             <url>http://bioinformatics.ua.pt/maven/content/repositories/mi</url>
             <snapshots>
@@ -45,6 +38,14 @@
             <id>maven-restlet</id>
             <name>Public online Restlet repository</name>
             <url>http://maven.restlet.org</url>
+        </repository>
+        <repository>
+            <id>dcm4che</id>
+            <url>http://www.dcm4che.org/maven2/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            
         </repository>
     </repositories>
 


### PR DESCRIPTION
As the dcm4che Maven repository is behind HTTPS since recently, the CA certificate has to be added manually with `keytool`.
This also sorts the Maven repositories in `dicoogle-sdk` and adds caching of the local Maven repository, which avoids the intermittent hic-ups of the dcm4che server.