### PR TITLE
Always use temporary directory when exporting to CSV

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/DicoogleWeb.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/DicoogleWeb.java
@@ -50,8 +50,9 @@ import pt.ua.dicoogle.server.web.servlets.management.ServerStorageServlet;
 import pt.ua.dicoogle.server.web.servlets.management.ServicesServlet;
 import pt.ua.dicoogle.server.web.servlets.management.TransferOptionsServlet;
 
-import java.io.File;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.EnumSet;
 
 import org.eclipse.jetty.server.Handler;
@@ -140,7 +141,7 @@ public class DicoogleWeb {
 
         // setup the Export to CSV Servlet
         final ServletContextHandler csvServletHolder = createServletHandler(new ExportToCSVServlet(), "/export");
-        File tempDir = new File(ServerSettings.getInstance().getPath());
+        Path tempDir = Files.createTempDirectory("dicoogle");
         csvServletHolder.addServlet(new ServletHolder(new ExportCSVToFILEServlet(tempDir)), "/exportFile");
 
         // setup the search (DIMSE-service-user C-FIND ?!?) servlet

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/ExportCSVToFILEServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/ExportCSVToFILEServlet.java
@@ -24,8 +24,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicLong;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -46,8 +46,8 @@ import pt.ua.dicoogle.plugins.PluginController;
 public class ExportCSVToFILEServlet extends HttpServlet {
 	private static final Logger logger = LoggerFactory.getLogger(ExportCSVToFILEServlet.class);
 
-	private File tempDirectory;
-	public ExportCSVToFILEServlet(File tempDirectory) {
+	private final Path tempDirectory;
+	public ExportCSVToFILEServlet(Path tempDirectory) {
 		super();
 		this.tempDirectory = tempDirectory;
 	}
@@ -63,7 +63,7 @@ public class ExportCSVToFILEServlet extends HttpServlet {
 			return;
 		}
 		
-		File tmpFile = new File(tempDirectory, "QueryResultsExport-"+uid);
+		File tmpFile = this.getCsvFile(uid);
 		if(!tmpFile.exists()){
 			resp.sendError(402, "The file for the given uid was not found. Please try again...");
 			return; 
@@ -128,29 +128,29 @@ public class ExportCSVToFILEServlet extends HttpServlet {
 
 		String uid = UUID.randomUUID().toString();
 		//File tempFile = File.createTempFile("QueryResultsExport-", uid, tempDirectory);
-		File tempFile = new File(tempDirectory, "QueryResultsExport-"+uid);
+		
+		File tempFile = this.getCsvFile(uid);
 		tempFile.deleteOnExit();
 		logger.debug("UID: {}", uid);
 		logger.debug("FilePath: {}", tempFile.getAbsolutePath());
 		
-		FileOutputStream outStream = new FileOutputStream(tempFile);
-		BufferedOutputStream bos = new BufferedOutputStream(outStream);
-		
-		ExportToCSVQueryTask task = new ExportToCSVQueryTask(orderedFields,
-				bos);
-		
-		if (arr == null || arr.length ==0) {
-			PluginController.getInstance().queryAll(task, queryString, fields);
-		} else {
-			List<String> providers = new ArrayList<>();
-			for (Object f : arr) {
-				providers.add(f.toString());
+		try (BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(tempFile))) {
+			ExportToCSVQueryTask task = new ExportToCSVQueryTask(orderedFields,
+					bos);
+			
+			if (arr == null || arr.length ==0) {
+				PluginController.getInstance().queryAll(task, queryString, fields);
+			} else {
+				List<String> providers = new ArrayList<>();
+				for (Object f : arr) {
+					providers.add(f.toString());
+				}
+				PluginController.getInstance().query(task, providers, queryString,
+						fields);
 			}
-			PluginController.getInstance().query(task, providers, queryString,
-					fields);
-		}
 
-		task.await();
+			task.await();
+		}
 		
 		JSONObject obj = new JSONObject();
 		obj.put("uid", uid);
@@ -158,4 +158,7 @@ public class ExportCSVToFILEServlet extends HttpServlet {
 		resp.getWriter().flush();
 	}
 
+	private File getCsvFile(String uid) {
+		return this.tempDirectory.resolve("QueryResultsExport-" + uid).toFile();
+	}
 }


### PR DESCRIPTION
This is a recently discovered bug which could potentially affect everyone using the export to CSV functionality. The server's `Path` configuration was being used as the base folder for keeping temporary csv outputs (so that they can be subsequently downloaded), rather than a system's temporary folder. If the folder specified in `Path` did not exist, the operation would fail with an HTTP error code 500.