### PR TITLE
Update gulp-sass to 3.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - gcc-4.7
-      - g++-4.7
+      - gcc-4.9
+      - g++-4.9
 
 before_install:
   - wget https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.der;

--- a/dicoogle/src/main/resources/webapp/package.json
+++ b/dicoogle/src/main/resources/webapp/package.json
@@ -73,7 +73,7 @@
     "gulp-processhtml": "^1.1.0",
     "gulp-rename": "^1.2.2",
     "gulp-rm": "^1.0.0",
-    "gulp-sass": "^2.1.1",
+    "gulp-sass": "^3.2.1",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-uglify": "^1.5.1",
     "gulp-util": "^3.0.7",


### PR DESCRIPTION
This makes Travis CI build again on all tested Node.js versions.