### PR TITLE
Add error handling to query interface

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/search/SearchServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/search/SearchServlet.java
@@ -46,6 +46,7 @@ import pt.ua.dicoogle.plugins.PluginController;
 import pt.ua.dicoogle.sdk.datastructs.SearchResult;
 import pt.ua.dicoogle.sdk.task.JointQueryTask;
 import pt.ua.dicoogle.sdk.task.Task;
+import pt.ua.dicoogle.sdk.utils.QueryParseException;
 
 /**
  * Search the DICOM metadata, perform queries on images. Returns the data in JSON.
@@ -228,6 +229,9 @@ public class SearchServlet extends HttpServlet {
                 this.writeResponse(response, results, elapsedTime, offset, psize);
             }
 
+        } catch (QueryParseException ex) {
+            sendError(response, 400, ex.getMessage());
+            return;
         } catch (InterruptedException | ExecutionException | RuntimeException ex) {
             logger.error("Failed to retrieve results", ex);
             sendError(response, 500, "Could not generate results");

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/QueryInterface.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/QueryInterface.java
@@ -19,6 +19,9 @@
 package pt.ua.dicoogle.sdk;
 
 import pt.ua.dicoogle.sdk.datastructs.SearchResult;
+import pt.ua.dicoogle.sdk.utils.QueryException;
+import pt.ua.dicoogle.sdk.utils.QueryParseException;
+import pt.ua.dicoogle.sdk.utils.RetrievalException;
 
 /**
  * Query Interface Plugin. Query plugins provide a means of handling queries and obtaining search results.
@@ -41,7 +44,10 @@ public interface QueryInterface extends DicooglePlugin
      * @param parameters A variable list of parameters of the query. The plugin can use them to establish
      * their own API's, which may require more complex data structures (e.g. images).
      * 
-     * @return the results of the query as a (possibly lazy) iterable
+     * @return the results of the query as a (possibly lazy) iterable. The consumption of its iterator can
+     * result in a {@link RetrievalException} being throw in the event of a failure in the retrieval process.
+     * @throws QueryException if the provider could not perform the query. An example of this is when the
+     * query text parser encountered a syntax error (see {@link QueryParseException}).
      */
-    public Iterable<SearchResult> query(String query, Object ... parameters);
+    public Iterable<SearchResult> query(String query, Object ... parameters) throws QueryException;
 }

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/utils/QueryException.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/utils/QueryException.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2014  Universidade de Aveiro, DETI/IEETA, Bioinformatics Group - http://bioinformatics.ua.pt/
+ *
+ * This file is part of Dicoogle/dicoogle-sdk.
+ *
+ * Dicoogle/dicoogle-sdk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Dicoogle/dicoogle-sdk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Dicoogle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package pt.ua.dicoogle.sdk.utils;
+
+/**
+ * Thrown to indicate that a query attempt to a provider has failed.
+ */
+public class QueryException extends RuntimeException {
+    private static final long serialVersionUID = 450205731642750093L;
+
+	public QueryException() {
+        super();
+    }
+
+    public QueryException(String message) {
+        super(message);
+    }
+
+    public QueryException(Exception cause) {
+        super(cause);
+    }
+
+    public QueryException(String message, Exception cause) {
+        super(message, cause);
+    }
+}

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/utils/QueryParseException.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/utils/QueryParseException.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2014  Universidade de Aveiro, DETI/IEETA, Bioinformatics Group - http://bioinformatics.ua.pt/
+ *
+ * This file is part of Dicoogle/dicoogle-sdk.
+ *
+ * Dicoogle/dicoogle-sdk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Dicoogle/dicoogle-sdk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Dicoogle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package pt.ua.dicoogle.sdk.utils;
+
+/**
+ * Thrown to indicate that the given query text and parameters could not be
+ * properly interpreted as a query. This is made into its own class in order to
+ * distinguish client-sided issues from server-sided issues.
+ * 
+ * When possible, it is recommended that the message argument provides an
+ * explanation to why the query is not valid (e.g. "unexpected token
+ * '}' at position 13").
+ */
+public class QueryParseException extends QueryException {
+    private static final long serialVersionUID = 2082328278641651574L;
+
+	public QueryParseException() {
+        super();
+    }
+
+    public QueryParseException(String message) {
+        super(message);
+    }
+
+    public QueryParseException(Exception cause) {
+        super(cause);
+    }
+
+    public QueryParseException(String message, Exception cause) {
+        super(message, cause);
+    }
+}

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/utils/RetrievalException.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/utils/RetrievalException.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2014  Universidade de Aveiro, DETI/IEETA, Bioinformatics Group - http://bioinformatics.ua.pt/
+ *
+ * This file is part of Dicoogle/dicoogle-sdk.
+ *
+ * Dicoogle/dicoogle-sdk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Dicoogle/dicoogle-sdk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Dicoogle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package pt.ua.dicoogle.sdk.utils;
+
+/**
+ * Thrown to indicate that an error occurred during the retrieval of search
+ * results from a query provider. Unlike {@link QueryException}, this
+ * exception only emerges after the initial query method is successful, and
+ * will usually be thrown upon consumption of the search result iterator.
+ */
+public class RetrievalException extends RuntimeException {
+    private static final long serialVersionUID = -1186512939075390164L;
+
+	public RetrievalException() {
+        super();
+    }
+
+    public RetrievalException(String message) {
+        super(message);
+    }
+
+    public RetrievalException(Exception cause) {
+        super(cause);
+    }
+
+    public RetrievalException(String message, Exception cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
Resolves #216. As discussed there, this includes two new exception types in the SDK: `QueryException` and `RetrievalException`. However, I found it useful to include a sub-class `QueryParseException` for distinguishing issues in the given query from other issues in the provider when performing the query.

This also adapts the image and search services for the API. Malformed queries may now result in error code 400, rather than an error code 500 or an empty result list. Of course, this assumes that the plugins are modified to throw these exceptions.