### PR TITLE
Ensure server settings support for multiple providers

### DIFF
--- a/dicoogle/pom.xml
+++ b/dicoogle/pom.xml
@@ -279,25 +279,25 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.8.6</version>
+            <version>2.9.5</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.8.6</version>
+            <version>2.9.5</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.8.6</version>
+            <version>2.9.5</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
-            <version>2.8.6</version>
+            <version>2.9.5</version>
         </dependency>
 
         <dependency>

--- a/dicoogle/src/main/java/pt/ua/dicoogle/core/settings/part/ArchiveImpl.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/core/settings/part/ArchiveImpl.java
@@ -20,12 +20,9 @@ package pt.ua.dicoogle.core.settings.part;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import pt.ua.dicoogle.sdk.settings.server.ServerSettings;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -62,39 +59,13 @@ public class ArchiveImpl implements ServerSettings.Archive {
     @JsonProperty("indexer-effort")
     private int indexerEffort;
 
-    @JacksonXmlElementWrapper(useWrapping = false, localName = "dim-provider")
+    @JsonProperty("dim-provider")
+    @JacksonXmlElementWrapper(localName = "dim-providers")
     private List<String> dimProviders;
 
-    @JsonSetter("dim-provider")
-    protected void setDIMProviders_(Object o) {
-        if (o == null) {
-            this.dimProviders = Collections.EMPTY_LIST;
-        } else if (o instanceof Collection) {
-            this.dimProviders = new ArrayList<>();
-            for (Object e : (Collection) o) {
-                this.dimProviders.add(e.toString());
-            }
-        } else {
-            this.dimProviders = Collections.singletonList(o.toString());
-        }
-    }
-
-    @JacksonXmlElementWrapper(useWrapping = false, localName = "default-storage")
+    @JsonProperty("default-storage")
+    @JacksonXmlElementWrapper(localName = "default-storages")
     private List<String> defaultStorage;
-
-    @JsonSetter("default-storage")
-    protected void setDefaultStorage_(Object o) {
-        if (o == null) {
-            this.defaultStorage = Collections.EMPTY_LIST;
-        } else if (o instanceof Collection) {
-            this.defaultStorage = new ArrayList<>();
-            for (Object e : (Collection)o) {
-                this.defaultStorage.add(e.toString());
-            }
-        } else {
-            this.defaultStorage = Collections.singletonList(o.toString());
-        }
-    }
 
     @JsonProperty(value = "enable-watch-directory", defaultValue = "false")
     private boolean dirWatcherEnabled;

--- a/dicoogle/src/test/java/pt/ua/dicoogle/core/settings/ServerSettingsTest.java
+++ b/dicoogle/src/test/java/pt/ua/dicoogle/core/settings/ServerSettingsTest.java
@@ -42,11 +42,13 @@ import static org.junit.Assert.*;
 public class ServerSettingsTest {
 
     private URL testConfig;
+    private URL testConfigDIM;
     private URL legacyConfig;
 
     @Before
     public void init() {
         this.testConfig = this.getClass().getResource("test-config-new.xml");
+        this.testConfigDIM = this.getClass().getResource("test-config-multi-dim.xml");
         this.legacyConfig = this.getClass().getResource("test-config.xml");
     }
 
@@ -300,10 +302,22 @@ public class ServerSettingsTest {
         Files.delete(newconf);
     }
 
-    private static void assertSameContent(Collection o1, Collection o2) {
+    @Test
+    public void testMultiDim() throws IOException {
+        // read the settings from our test config file
+        ServerSettings settings = ServerSettingsManager.loadSettingsAt(this.testConfigDIM);
+        final ServerSettings.Archive ar = settings.getArchiveSettings();
+        assertTrue(settings instanceof ServerSettingsImpl);
+        // assertions follow
+        assertEquals("/opt/mydata", ar.getMainDirectory());
+        assertEquals(Arrays.asList("lucene", "postgres"), ar.getDIMProviders());
+        assertEquals(Arrays.asList("filestorage", "s3"), ar.getDefaultStorage());
+    }
+
+    private static void assertSameContent(Collection<?> o1, Collection<?> o2) {
         assertNotNull("left-hand collection is null", o1);
         assertNotNull("right-hand collection is null", o2);
-        assertEquals(o1.size(), o2.size());
+        assertEquals("Collection sizes do not match", o1.size(), o2.size());
         for (Object o : o1) {
             if (!o2.contains(o)) {
                 throw new ComparisonFailure("collection contents do not match", String.valueOf(o1), String.valueOf(o2));

--- a/dicoogle/src/test/resources/pt/ua/dicoogle/core/settings/test-config-multi-dim.xml
+++ b/dicoogle/src/test/resources/pt/ua/dicoogle/core/settings/test-config-multi-dim.xml
@@ -6,13 +6,15 @@
     <archive>
         <save-thumbnails>true</save-thumbnails>
         <thumbnail-size>128</thumbnail-size>
-        <main-directory>/opt/my-data</main-directory>
+        <main-directory>/opt/mydata</main-directory>
         <indexer-effort>98</indexer-effort>
         <dim-providers>
             <dim-provider>lucene</dim-provider>
+            <dim-provider>postgres</dim-provider>
         </dim-providers>
         <default-storages>
             <default-storage>filestorage</default-storage>
+            <default-storage>s3</default-storage>
         </default-storages>
         <enable-watch-directory>true</enable-watch-directory>
         <watch-directory>/opt/my-data/watched</watch-directory>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -130,14 +130,14 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.8.6</version>
+            <version>2.9.5</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
-            <version>2.8.6</version>
+            <version>2.9.5</version>
         </dependency>
 
         <dependency>

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/settings/server/ServerSettingsReader.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/settings/server/ServerSettingsReader.java
@@ -73,10 +73,12 @@ public interface ServerSettingsReader {
         @JsonGetter("watch-directory")
         String getWatchDirectory();
 
-        @JacksonXmlElementWrapper(useWrapping = false, localName = "dim-provider")
+        @JsonGetter("dim-provider")
+        @JacksonXmlElementWrapper(localName = "dim-providers")
         List<String> getDIMProviders();
 
-        @JacksonXmlElementWrapper(useWrapping = false, localName = "default-storage")
+        @JsonGetter("default-storage")
+        @JacksonXmlElementWrapper(localName = "default-storages")
         List<String> getDefaultStorage();
 
         @JsonGetter("node-name")


### PR DESCRIPTION
Although what we had before was less verbose, it wasn't working quite well for multiple providers due to some implementation quirks in Jackson (#342). So, this PR changes both DIM provider and default storage listings to be wrapped around XML elements, making the intent of supporting multiple providers clearer.

- wrap server settings XML elems `dim-provider` with `dim-providers`
- wrap server settings XML elems `default-storage` with `default-storages`
- update Jackson XML dependencies
- add respective tests