### PR TITLE
Validate UUID provided to /exportFile

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/utils/ResponseUtil.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/utils/ResponseUtil.java
@@ -60,6 +60,7 @@ public class ResponseUtil {
      * @throws IOException if an I/O error occurs
      */
     public static void sendError(HttpServletResponse resp, int code, String message) throws IOException {
+        resp.setContentType("application/json");
         resp.setStatus(code);
         JSONObject obj = new JSONObject();
         obj.put("error", message);


### PR DESCRIPTION
This checks whether the identifier to the exported CSV file is actually a UUID. It fixes a vulnerability on Windows systems which would allow a user to retrieve an arbitrary file from the server.

I took the liberty of adapting this endpoint to our JSON error output (#193), and ensuring that the content-type is JSON when sending an error with our utility function.