### PR TITLE
Docker support for dicoogle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu
+
+WORKDIR /root
+
+RUN apt-get update && \
+    apt-get install apt-utils -y && \
+    apt-get upgrade -y
+
+RUN apt-get install -y software-properties-common build-essential openjdk-8-jre git maven curl
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && apt-get install -y nodejs
+
+RUN git clone https://github.com/bioinformatics-ua/dicoogle
+RUN ( cd dicoogle && mvn install && ln -s /root/dicoogle/dicoogle/target/dicoogle.jar /root/ )
+
+CMD ["java","-jar","dicoogle.jar","-s"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ RUN apt-get update && \
     apt-get install apt-utils -y && \
     apt-get upgrade -y
 
-RUN apt-get install -y software-properties-common build-essential openjdk-8-jre git maven curl
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && apt-get install -y nodejs
+RUN apt-get install -y software-properties-common build-essential openjdk-8-jre git maven
 
 RUN git clone https://github.com/bioinformatics-ua/dicoogle
 RUN ( cd dicoogle && mvn install && ln -s /root/dicoogle/dicoogle/target/dicoogle.jar /root/ )


### PR DESCRIPTION
Simple Dockerfile to allow the creation of a docker image for dicoogle. 

The docker image is based in the latest ubuntu image and will allow both build and run of dicoogle from inside the container.
 - Build :   docker build -t bioinformatics-ua/dicoogle .
 - Run :    docker run -t bioinformatics-ua/dicoogle
 - Access container :    docker run -it bioinformatics-ua/dicoogle bash