### PR TITLE
Extend StorageInterface with `list`

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/DefaultFileStoragePlugin.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/DefaultFileStoragePlugin.java
@@ -24,10 +24,14 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Stream;
 
 import metal.utils.fileiterator.FileIterator;
 
@@ -44,7 +48,7 @@ public class DefaultFileStoragePlugin extends PluginBase implements StorageInter
 
 	private static final Logger logger = LoggerFactory.getLogger(DefaultFileStoragePlugin.class);
 	
-	private String defaultScheme = "file";
+	private final String defaultScheme = "file";
 	
 	public DefaultFileStoragePlugin() {
 		super();
@@ -127,6 +131,16 @@ public class DefaultFileStoragePlugin extends PluginBase implements StorageInter
 		if (f.exists()) {
 			f.delete();
 		}		
+	}
+
+	@Override
+	public Stream<URI> list(URI location) throws IOException {
+		if (!location.getScheme().equals(defaultScheme)) {
+			return Stream.empty();
+		}
+
+		Path base = Paths.get(location);
+		return Files.list(base).map(Path::toUri);
 	}
 
 	@Override

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/StorageInterface.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/StorageInterface.java
@@ -20,7 +20,10 @@ package pt.ua.dicoogle.sdk;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.NotDirectoryException;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 import org.dcm4che2.data.DicomObject;
 import org.dcm4che2.io.DicomInputStream;
@@ -53,8 +56,10 @@ public interface StorageInterface extends DicooglePlugin {
     }
     
     /**
-     * Provides a means of iteration over existing objects at a specified location.
+     * Provides a means of iteration over all existing objects at a specified location,
+     * including those in sub-directories.
      * This method is particularly nice for use in for-each loops.
+     * 
      * The provided scheme is not relevant at this point, but the developer must avoid calling this method
      * with a path of a different schema.
      * 
@@ -93,4 +98,29 @@ public interface StorageInterface extends DicooglePlugin {
      * @param location the URI of the stored data
      */
     public void remove(URI location);
+
+    /** Lists the elements at the given location in the storage's file tree.
+     * Unlike {@link StorageInterface#at}, this method is not recursive and
+     * can yield intermediate URIs representing other directories rather than
+     * objects.
+     * 
+     * The provided scheme is not relevant at this point, but the developer
+     * must avoid calling this method with a path of a different schema.
+     * 
+     * @param location the base storage location to list
+     * 
+     * @return a standard stream of URIs representing entries in the given base
+     * location
+     * @throws UnsupportedOperationException if this storage does not support
+     * listing directories
+     * @throws NoSuchFileException if the given location does not exist in the
+     * storage
+     * @throws NotDirectoryException if the given location does not refer to a
+     * listable entry (a directory)
+     * @throws IOException if some other I/O error occurs
+     */
+    public default Stream<URI> list(URI location) throws IOException {
+        throw new UnsupportedOperationException(
+            String.format("Storage %s does not support directory listing", this.getName()));
+    }
 }


### PR DESCRIPTION
Here's my quick proposal to address #261. It enables storage plugins to easily and efficiently provide directory listing. Please see the documentation for details. Support for listing is optional, but should be fairly easy to implement, so it won't make plugins harder to migrate.