### PR TITLE
Remove org.eclipse.jetty.jetty-jsp dependency

### DIFF
--- a/dicoogle/pom.xml
+++ b/dicoogle/pom.xml
@@ -338,11 +338,6 @@
             <artifactId>jetty-servlets</artifactId>
             <version>${jetty.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-jsp</artifactId>
-            <version>${jetty.version}</version>
-        </dependency>
 
         <dependency>
             <groupId>org.restlet.jee</groupId>


### PR DESCRIPTION
It's been a long while since Dicoogle used Java Server Pages. Still, I would advise a bit of testing before merging this one.