### PR TITLE
Improve Travis CI configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ matrix:
       env: NODE_VERSION=lts/*
     - jdk: openjdk11
       env: NODE_VERSION=lts/*
+  allow_failures:
+    - jdk: openjdk11
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,17 +12,20 @@ cache:
 matrix:
   include:
     - jdk: oraclejdk8
-      env: NODE_VERSION=6
+      env: NODE_VERSION=6 WEBAPP_ONLY=1
     - jdk: oraclejdk8
       env: NODE_VERSION=lts/*
     - jdk: oraclejdk8
-      env: NODE_VERSION=stable
+      env: NODE_VERSION=stable WEBAPP_ONLY=1
     - jdk: openjdk8
       env: NODE_VERSION=lts/*
     - jdk: oraclejdk9
       env: NODE_VERSION=lts/*
+    - jdk: oraclejdk10
+      env: NODE_VERSION=lts/*
   allow_failures:
     - jdk: oraclejdk9
+    - jdk: oraclejdk10
 
 addons:
   apt:
@@ -33,8 +36,10 @@ addons:
       - g++-4.8
 
 before_install:
-  - wget https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.der;
-    sudo keytool -importcert -trustcacerts -alias lets-encrypt-x3-cross-signed -file lets-encrypt-x3-cross-signed.der -storepass changeit -keystore $JAVA_HOME/jre/lib/security/cacerts
+  - if [ $TRAVIS_JDK_VERSION == "oraclejdk8" ] || [ $TRAVIS_JDK_VERSION == "openjdk8" ]; then
+      wget https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.der;
+      sudo keytool -importcert -trustcacerts -alias lets-encrypt-x3-cross-signed -file lets-encrypt-x3-cross-signed.der -storepass changeit -keystore $JAVA_HOME/jre/lib/security/cacerts;
+    fi
   - nvm install $NODE_VERSION
   - if [ $TRAVIS_OS_NAME == "linux" ]; then
       export CC="gcc-4.8";
@@ -48,4 +53,7 @@ before_install:
 install: true
 
 script:
-  - cd dicoogle/src/main/resources/webapp && npm install && cd ../../../../.. && mvn install -Dskip.installnodenpm -Dskip.npm -Dmaven.javadoc.skip=true -B -V
+  - cd dicoogle/src/main/resources/webapp && npm install 
+  - if [ -z "$WEBAPP_ONLY" ]; then
+      cd ../../../../.. && mvn install -Dskip.installnodenpm -Dskip.npm -Dmaven.javadoc.skip=true -B -V;
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,10 @@ matrix:
       env: NODE_VERSION=stable WEBAPP_ONLY=1
     - jdk: openjdk8
       env: NODE_VERSION=lts/*
-    - jdk: oraclejdk9
+    - jdk: openjdk10
       env: NODE_VERSION=lts/*
-    - jdk: oraclejdk10
+    - jdk: openjdk11
       env: NODE_VERSION=lts/*
-  allow_failures:
-    - jdk: oraclejdk9
-    - jdk: oraclejdk10
 
 addons:
   apt:


### PR DESCRIPTION
- add `openjdk10` and `openjdk11` target
- remove `jdk9`, since it's no longer maintained (users are advised to move to jdk10 ASAP)
- configure Node.js variants 6 and Stable to only build the webapp (slightly faster builds)
- fix Travis CI builds on jdk 10 and 11 (only install extra cacerts on jdk 8)
- only allow build failures on JDK 11

All builds on Travis CI now pass except for JDK 11 due to the decoupling of certain `javax` modules from the standard library. Fixing the issues in this version is currently in low priority.