### PR TITLE
Update frontent development component versions: Node.js 10 + npm 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,10 @@ We also have programmatic APIs for interfacing with Dicoogle in [JavaScript](htt
 
 Before building, please make sure that your system contains the following tools:
 
- - Java JDK, either Oracle or OpenJDK (at least version 8)
- - Maven 3
- - [Node.js](https://nodejs.org/en/download/) (at least version 4; LTS or Stable versions are recommended) and npm (at least version 2)
+ - Java JDK, either Oracle or OpenJDK (at least version 8);
+ - Maven 3;
+ - [Node.js](https://nodejs.org/en/download/) (at least version 6; latest LTS or Stable versions are recommended);
+ - npm (at least version 4; version 6 is recommended), often installed alongside Node.js.
 
  1. Retrieve the full source code from this repository: `git clone https://github.com/bioinformatics-ua/dicoogle.git`
  2. Navigate to the project's base directory, and build the parent Maven project by calling `mvn install`.

--- a/dicoogle/pom.xml
+++ b/dicoogle/pom.xml
@@ -212,7 +212,7 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.6</version>
+                <version>1.7.5</version>
                 <executions>
                     <!-- Install Node and NPM -->
                     <execution>
@@ -238,8 +238,8 @@
 
                 </executions>
                 <configuration>
-                    <nodeVersion>v6.9.1</nodeVersion>
-                    <npmVersion>3.10.10</npmVersion>
+                    <nodeVersion>v10.15.3</nodeVersion>
+                    <npmVersion>6.4.1</npmVersion>
                     <installDirectory>target</installDirectory>
                     <!-- Defining webapp directory -->
                     <workingDirectory>src/main/resources/webapp</workingDirectory>

--- a/dicoogle/src/main/resources/webapp/README.md
+++ b/dicoogle/src/main/resources/webapp/README.md
@@ -2,7 +2,7 @@
 
 ## Building
 
-`npm` version 2 or earlier is required. To build everything for production (ready to be bundled for when creating dicoogle.jar):
+`npm` version 4 or earlier is required. To build everything for production (ready to be bundled for when creating dicoogle.jar):
 
     npm install
 

--- a/dicoogle/src/main/resources/webapp/package.json
+++ b/dicoogle/src/main/resources/webapp/package.json
@@ -35,7 +35,7 @@
   ],
   "engines": {
     "node": ">=6",
-    "npm": ">=2.0.0"
+    "npm": ">=4.0.0"
   },
   "dependencies": {
     "bootstrap": "^3.3.2",
@@ -88,7 +88,7 @@
     "watchify": "^3.7.0"
   },
   "scripts": {
-    "prepublish": "gulp production",
+    "prepare": "gulp production",
     "build": "gulp production",
     "js": "gulp js",
     "css": "gulp css",


### PR DESCRIPTION
- update frontend-maven-plugin to 1.7.5
- update Node.js minimum version to 6, recommend latest LTS or Stable
- make frontend plugin install Node.js 10.15.3 and npm 6.4.1
- update npm minimum to v4, recommend v6
- document changes in the README files

This is also an attempt to fix #381, as the latest version of the frontend plugin is more likely to have fixed this one.