### PR TITLE
Revamp user file handling and cryptographic code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: true
 
 before_cache:
  - rm -rf $HOME/.m2/repository/pt/ua/ieeta/dicoogle*
+ - rm -rf $HOME/.cache/JNA/temp/
 
 cache:
   directories:
@@ -26,28 +27,15 @@ matrix:
   allow_failures:
     - jdk: openjdk11
 
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - gcc-4.8
-      - g++-4.8
-
 before_install:
+  - ldd --version
+  - sudo apt-get update -y && apt-cache policy libc6 && sudo apt-get install -y libc6
   - if [ $TRAVIS_JDK_VERSION == "oraclejdk8" ] || [ $TRAVIS_JDK_VERSION == "openjdk8" ]; then
       wget https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.der;
       sudo keytool -importcert -trustcacerts -alias lets-encrypt-x3-cross-signed -file lets-encrypt-x3-cross-signed.der -storepass changeit -keystore $JAVA_HOME/jre/lib/security/cacerts;
     fi
   - nvm install $NODE_VERSION
-  - if [ $TRAVIS_OS_NAME == "linux" ]; then
-      export CC="gcc-4.8";
-      export CXX="g++-4.8";
-      export LINK="gcc-4.8";
-      export LINKXX="g++-4.8";
-    fi
-  - gcc --version
-  - g++ --version
+  - ldd --version
 
 install: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,14 +28,11 @@ matrix:
     - jdk: openjdk11
 
 before_install:
-  - ldd --version
-  - sudo apt-get update -y && apt-cache policy libc6 && sudo apt-get install -y libc6
   - if [ $TRAVIS_JDK_VERSION == "oraclejdk8" ] || [ $TRAVIS_JDK_VERSION == "openjdk8" ]; then
       wget https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.der;
       sudo keytool -importcert -trustcacerts -alias lets-encrypt-x3-cross-signed -file lets-encrypt-x3-cross-signed.der -storepass changeit -keystore $JAVA_HOME/jre/lib/security/cacerts;
     fi
   - nvm install $NODE_VERSION
-  - ldd --version
 
 install: true
 

--- a/dicoogle/pom.xml
+++ b/dicoogle/pom.xml
@@ -25,7 +25,7 @@
     <repositories>
         <repository>
             <id>mavencentral</id>
-            <url>http://repo1.maven.org/maven2/</url>
+            <url>https://repo1.maven.org/maven2/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -269,6 +269,11 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>de.mkammerer</groupId>
+            <artifactId>argon2-jvm</artifactId>
+            <version>2.6</version>
+        </dependency>
         <dependency>
             <groupId>net.sf.json-lib</groupId>
             <artifactId>json-lib</artifactId>

--- a/dicoogle/pom.xml
+++ b/dicoogle/pom.xml
@@ -270,10 +270,11 @@
         </dependency>
 
         <dependency>
-            <groupId>de.mkammerer</groupId>
-            <artifactId>argon2-jvm</artifactId>
-            <version>2.6</version>
+            <groupId>at.favre.lib</groupId>
+            <artifactId>bcrypt</artifactId>
+            <version>0.9.0</version>
         </dependency>
+
         <dependency>
             <groupId>net.sf.json-lib</groupId>
             <artifactId>json-lib</artifactId>

--- a/dicoogle/src/main/java/pt/ua/dicoogle/core/settings/ClientSettings.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/core/settings/ClientSettings.java
@@ -63,7 +63,7 @@ public class ClientSettings {
         defaultServerHost = "localhost";
         defaultServerPort = 9014;
         defaultUserName = "dicoogle";
-        defaultPassword = HashService.getSHA1Hash("dicoogle");
+        defaultPassword = HashService.getSHA256Hash("dicoogle");
     }
 
     public void setExtV(String EV)

--- a/dicoogle/src/main/java/pt/ua/dicoogle/core/settings/ClientSettings.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/core/settings/ClientSettings.java
@@ -63,7 +63,7 @@ public class ClientSettings {
         defaultServerHost = "localhost";
         defaultServerPort = 9014;
         defaultUserName = "dicoogle";
-        defaultPassword = HashService.getSHA256Hash("dicoogle");
+        defaultPassword = HashService.hashPassword("dicoogle");
     }
 
     public void setExtV(String EV)

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/users/HashService.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/users/HashService.java
@@ -27,20 +27,20 @@ import org.apache.commons.codec.binary.Base64;
 import org.slf4j.LoggerFactory;
 
 /**
- * This class provides hashing service to passwords with SHA-1 algoritm
+ * This class provides hashing service to passwords with the SHA-256 algoritm
  *
  * @author Samuel Campos <samuelcampos@ua.pt>
  */
 public class HashService {
     /**
-     * Encrypt one password with SHA-1 algorithm
+     * Encrypt one password with the SHA-256 algorithm
      *
      * @param plaintext
      * @return the hash of the password
      */
-    public static String getSHA1Hash(String plaintext) {
+    public static String getSHA256Hash(String plaintext) {
         try {
-            MessageDigest md = MessageDigest.getInstance("SHA-1");
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
             md.update(plaintext.getBytes("UTF-8"));
             byte[] raw = md.digest();
             byte[] asbase64 = Base64.encodeBase64(raw);

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/users/HashService.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/users/HashService.java
@@ -25,19 +25,23 @@ import java.security.NoSuchAlgorithmException;
 
 import org.apache.commons.codec.binary.Base64;
 import org.slf4j.LoggerFactory;
-import de.mkammerer.argon2.Argon2;
-import de.mkammerer.argon2.Argon2Factory;
+import at.favre.lib.crypto.bcrypt.BCrypt;
+import at.favre.lib.crypto.bcrypt.LongPasswordStrategies;
 
 /**
- * This class provides hashing service to passwords with the SHA-256 algoritm
- *
- * @author Samuel Campos <samuelcampos@ua.pt>
+ * This class provides a password hashing service.
  */
 public class HashService {
 
     /**
+     * Hardcoded cost for the password hashing algorithm.
+     */
+    private static final int HASH_STRENGTH = 10;
+
+    /**
      * Hash a password.
      *
+     * @param password the password in plain text
      * @return the hash of the password
      */
     public static String hashPassword(String password) {
@@ -47,24 +51,28 @@ public class HashService {
     /**
      * Hash a password.
      *
+     * @param password the password in plain text as an array of characters,
+     * filled with `'\0'`s automatically.
      * @return the hash of the password
      */
     public static String hashPassword(char[] password) {
-        // Use Argon2 hashing algorithm
-        Argon2 argon2 = Argon2Factory.create();
         try {
-            return argon2.hash(
-                10, // nr of iterations
-                65536, // nr of kiBs of memory
-                1, // nr of threads
-                password);
+            return BCrypt
+                    .with(LongPasswordStrategies.hashSha512(BCrypt.Version.VERSION_2B))
+                    .hashToString(HASH_STRENGTH, password);
         } finally {
-            argon2.wipeArray(password);
+            for (int i = 0; i < password.length; i++) {
+                password[i] = '\0';
+            }
         }
     }
 
     /**
      * Verify whether the password matches the hash.
+     * 
+     * @param hash the stored password hash
+     * @param password the password in plain text
+     * @return true iff the password is successfully verified
      */
     public static boolean verifyPassword(String hash, String password) {
         return verifyPassword(hash, password.toCharArray());
@@ -72,13 +80,20 @@ public class HashService {
 
     /**
      * Verify whether the password matches the hash.
+     * 
+     * @param hash the stored password hash
+     * @param password the password in plain text as an array of characters,
+     * filled with `'\0'`s automatically.
+     * @return true iff the password is successfully verified
      */
     public static boolean verifyPassword(String hash, char[] password) {
-        Argon2 argon2 = Argon2Factory.create();
         try {
-            return argon2.verify(hash, password);
+            BCrypt.Result result = BCrypt.verifyer().verify(password, hash);
+            return result.verified;
         } finally {
-            argon2.wipeArray(password);
+            for (int i = 0; i < password.length; i++) {
+                password[i] = '\0';
+            }
         }
     }
 }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/users/HashService.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/users/HashService.java
@@ -25,6 +25,8 @@ import java.security.NoSuchAlgorithmException;
 
 import org.apache.commons.codec.binary.Base64;
 import org.slf4j.LoggerFactory;
+import de.mkammerer.argon2.Argon2;
+import de.mkammerer.argon2.Argon2Factory;
 
 /**
  * This class provides hashing service to passwords with the SHA-256 algoritm
@@ -32,26 +34,51 @@ import org.slf4j.LoggerFactory;
  * @author Samuel Campos <samuelcampos@ua.pt>
  */
 public class HashService {
+
     /**
-     * Encrypt one password with the SHA-256 algorithm
+     * Hash a password.
      *
-     * @param plaintext
      * @return the hash of the password
      */
-    public static String getSHA256Hash(String plaintext) {
-        try {
-            MessageDigest md = MessageDigest.getInstance("SHA-256");
-            md.update(plaintext.getBytes("UTF-8"));
-            byte[] raw = md.digest();
-            byte[] asbase64 = Base64.encodeBase64(raw);
-            String hash = new String(asbase64, Charset.forName("UTF-8"));
-            return hash;
-
-        } catch (UnsupportedEncodingException|NoSuchAlgorithmException ex) {
-            LoggerFactory.getLogger(HashService.class).error("Failed to encode text", ex);
-        }
-
-        return null;
+    public static String hashPassword(String password) {
+        return hashPassword(password.toCharArray());
     }
 
+    /**
+     * Hash a password.
+     *
+     * @return the hash of the password
+     */
+    public static String hashPassword(char[] password) {
+        // Use Argon2 hashing algorithm
+        Argon2 argon2 = Argon2Factory.create();
+        try {
+            return argon2.hash(
+                10, // nr of iterations
+                65536, // nr of kiBs of memory
+                1, // nr of threads
+                password);
+        } finally {
+            argon2.wipeArray(password);
+        }
+    }
+
+    /**
+     * Verify whether the password matches the hash.
+     */
+    public static boolean verifyPassword(String hash, String password) {
+        return verifyPassword(hash, password.toCharArray());
+    }
+
+    /**
+     * Verify whether the password matches the hash.
+     */
+    public static boolean verifyPassword(String hash, char[] password) {
+        Argon2 argon2 = Argon2Factory.create();
+        try {
+            return argon2.verify(hash, password);
+        } finally {
+            argon2.wipeArray(password);
+        }
+    }
 }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/users/User.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/users/User.java
@@ -52,7 +52,7 @@ public class User implements UserRoleManager{
     }
 
     public boolean verifyPassword(String passwordHash){
-        String tempHash = HashService.getSHA1Hash(username + admin + passwordHash);
+        String tempHash = HashService.getSHA256Hash(username + admin + passwordHash);
 
         return this.hash.equals(tempHash);
     }
@@ -68,13 +68,13 @@ public class User implements UserRoleManager{
     }
 
     public boolean changePassword(String oldPassHash, String newPassHash){
-        String tempHash = HashService.getSHA1Hash(username + admin + oldPassHash);
+        String tempHash = HashService.getSHA256Hash(username + admin + oldPassHash);
 
         if(!hash.equals(tempHash))
             return false;
 
 
-        tempHash = HashService.getSHA1Hash(username + admin + newPassHash);
+        tempHash = HashService.getSHA256Hash(username + admin + newPassHash);
 
         hash = tempHash;
         return true;
@@ -88,7 +88,7 @@ public class User implements UserRoleManager{
         if(newPassHash == null || newPassHash.equals(""))
             return false;
 
-        String tempHash = HashService.getSHA1Hash(username + admin + newPassHash);
+        String tempHash = HashService.getSHA256Hash(username + admin + newPassHash);
 
         hash = tempHash;
 

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/users/User.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/users/User.java
@@ -37,10 +37,21 @@ public class User implements UserRoleManager{
 
     private List<Role> roles = new ArrayList<>();
 
-    public User(String username, String Hash, boolean admin){
+    public User(String username, String hash, boolean admin){
         this.username = username;
         this.admin = admin;
-        this.hash = Hash;
+        this.hash = hash;
+    }
+
+    public static User create(String username, boolean admin, char[] password) {
+        return new User(
+            username,
+            HashService.hashPassword(password),
+            admin);
+    }
+
+    public static User create(String username, boolean admin, String password) {
+        return User.create(username, admin, password.toCharArray());
     }
 
     public String getUsername(){
@@ -51,8 +62,20 @@ public class User implements UserRoleManager{
         return admin;
     }
 
-    public boolean verifyPassword(String passwordHash){
-        return HashService.verifyPassword(this.hash, username + admin + passwordHash);
+    /** Verify the given password agains the user's  password hash.
+     * @param password the password in plain text, cleared automatically
+     * @return whether the password is verified successfully
+     */
+    public boolean verifyPassword(char[] password) {
+        return HashService.verifyPassword(this.hash, password);
+    }
+
+    /** Verify the given password agains the user's  password hash.
+     * @param password the password in plain text
+     * @return whether the password is verified successfully
+     */
+    public boolean verifyPassword(String password) {
+        return this.verifyPassword(password.toCharArray());
     }
 
     public void addRole(Role r)
@@ -65,30 +88,53 @@ public class User implements UserRoleManager{
         return this.roles.contains(r);
     }
 
-    public boolean changePassword(String oldPassHash, String newPassHash){
-        if(!this.verifyPassword(oldPassHash))
+    /** Verify the current password and assign a new password to this user.
+     * @param oldPassword the current password as plain text, automatically
+     * cleared
+     * @param newPasssword the new password as plain text, automatically
+     * cleared; must not be empty
+     * @return whether the password was changed successfully
+     */
+    public boolean changePassword(char[] oldPassword, char[] newPassword) {
+        if(!this.verifyPassword(oldPassword))
             return false;
 
-
-        String tempHash = HashService.hashPassword(username + admin + newPassHash);
-
-        this.hash = tempHash;
-        return true;
+        return this.resetPassword(newPassword);
     }
 
-    protected String getPasswordHash(){
+    protected String getPasswordHash() {
         return hash;
     }
 
-    public boolean resetPassword(String newPassHash){
-        if(newPassHash == null || newPassHash.isEmpty())
+    /** Verify the current password and assign a new password to this user.
+     * @param oldPassword the current password as plain text, automatically
+     * cleared
+     * @param newPasssword the new password as plain text; must not be empty
+     * @return whether the password was changed successfully
+     */
+    public boolean changePassword(String oldPassword, String newPassword) {
+        return this.changePassword(oldPassword.toCharArray(), newPassword.toCharArray());
+    }
+
+    /** Assign a new password to this user.
+     * @param passsword the password as plain text, automatically cleared
+     * after the operation; must not be empty
+     * @return whether the password was changed successfully
+     */
+    public boolean resetPassword(char[] password){
+        if(password.length == 0)
             return false;
 
-        String tempHash = HashService.hashPassword(username + admin + newPassHash);
-
-        hash = tempHash;
-
+        this.hash = HashService.hashPassword(password);
         return true;
+    }
+
+    /** Assign a new password to this user.
+     * @param passsword the password as plain text
+     * @return whether the password was changed successfully
+     */
+    public boolean resetPassword(String password) {
+        return this.resetPassword(password.toCharArray());
     }
 
     @Override

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/users/User.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/users/User.java
@@ -52,9 +52,7 @@ public class User implements UserRoleManager{
     }
 
     public boolean verifyPassword(String passwordHash){
-        String tempHash = HashService.getSHA256Hash(username + admin + passwordHash);
-
-        return this.hash.equals(tempHash);
+        return HashService.verifyPassword(this.hash, username + admin + passwordHash);
     }
 
     public void addRole(Role r)
@@ -68,15 +66,13 @@ public class User implements UserRoleManager{
     }
 
     public boolean changePassword(String oldPassHash, String newPassHash){
-        String tempHash = HashService.getSHA256Hash(username + admin + oldPassHash);
-
-        if(!hash.equals(tempHash))
+        if(!this.verifyPassword(oldPassHash))
             return false;
 
 
-        tempHash = HashService.getSHA256Hash(username + admin + newPassHash);
+        String tempHash = HashService.hashPassword(username + admin + newPassHash);
 
-        hash = tempHash;
+        this.hash = tempHash;
         return true;
     }
 
@@ -85,10 +81,10 @@ public class User implements UserRoleManager{
     }
 
     public boolean resetPassword(String newPassHash){
-        if(newPassHash == null || newPassHash.equals(""))
+        if(newPassHash == null || newPassHash.isEmpty())
             return false;
 
-        String tempHash = HashService.getSHA256Hash(username + admin + newPassHash);
+        String tempHash = HashService.hashPassword(username + admin + newPassHash);
 
         hash = tempHash;
 

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/users/UserFileHandle.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/users/UserFileHandle.java
@@ -24,12 +24,18 @@ import org.slf4j.LoggerFactory;
 import javax.crypto.*;
 import java.io.*;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermission;
 import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.util.Collections;
+import java.util.Set;
 
 /**
  * This class provides encryption to the file that saves users information
@@ -41,39 +47,52 @@ public class UserFileHandle {
 
     private static final Logger logger = LoggerFactory.getLogger(UserFileHandle.class);
 
-    private final String filename;
-    private final String keyFile;
+    private final Path filename;
+    private final Path keyFile;
 
     private Key key;
     private final boolean encrypt;
 
     public UserFileHandle() throws IOException {
-        filename = "users.xml";
-        keyFile = "users.key";
-        encrypt = true; //ServerSettingsManager.getSettings().isEncryptUsersFile();
+        filename = Paths.get("users");
+        keyFile = Paths.get("users.key");
+        boolean doEncrypt = false;
+        // user file encryption is on by default. If the users file already exists, the program
+        // will not generate a new key. if there is no key file, or the creation of a new key
+        // fails, encryption is disabled.
         try {
-            if (encrypt) {
-
-                try (ObjectInputStream in = new ObjectInputStream(new FileInputStream(keyFile))) {
-                    key = (Key) in.readObject();
-                } catch (FileNotFoundException ex) {
+            try (ObjectInputStream in = new ObjectInputStream(Files.newInputStream(keyFile))) {
+                key = (Key) in.readObject();
+                // encryption key read succesfully, encryption is enabled
+                doEncrypt = true;
+            } catch (NoSuchFileException ex) {
+                if (!Files.exists(filename)) {
+                    logger.info("Generating new user credential encryption key...");
                     KeyGenerator gen = KeyGenerator.getInstance("AES");
 
                     gen.init(128, new SecureRandom());
                     key = gen.generateKey();
 
-                    try (ObjectOutputStream out = new ObjectOutputStream(new FileOutputStream(keyFile))) {
+                    try (ObjectOutputStream out = new ObjectOutputStream(Files.newOutputStream(keyFile, StandardOpenOption.CREATE_NEW))) {
                         out.writeObject(key);
                     }
+                    try {
+                        // set read-only permissions to owner for security reasons
+                        Set<PosixFilePermission> perms = Collections.singleton(PosixFilePermission.OWNER_READ);
+                        Files.setPosixFilePermissions(keyFile, perms);
+                    } catch (UnsupportedOperationException ex2) {
+                        logger.warn("Local file system does not support POSIX file attributes, leaving encryption key file with default permissions", ex2);
+                    }
+                    
+                    // a new key was successfully created
+                    doEncrypt = true;
                 }
-
-            } else {
-                key = null;
             }
-
-        } catch (NoSuchAlgorithmException | ClassNotFoundException ex) {
-            logger.error("Failed to get encryption key.", ex);
+        } catch (NoSuchAlgorithmException | ClassNotFoundException | ClassCastException ex) {
+            logger.error("Failed to get encryption key", ex);
+            key = null;
         }
+        this.encrypt = doEncrypt;
     }
 
     /**
@@ -113,26 +132,18 @@ public class UserFileHandle {
      * @throws IOException on a failed attempt to read the file
      */
     public byte[] getFileContent() {
-        try (FileInputStream fin = new FileInputStream(filename);
-                ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-            byte[] data = new byte[1024];
-            int bytesRead;
-
-            while ((bytesRead = fin.read(data)) != -1) {
-                out.write(data, 0, bytesRead);
-                out.flush();
-            }
+        try {
+            byte[] data = Files.readAllBytes(filename);
 
             if (encrypt) {
                 Cipher cipher = Cipher.getInstance("AES");
                 cipher.init(Cipher.DECRYPT_MODE, key);
-                byte[] Bytes = cipher.doFinal(out.toByteArray());
-                return Bytes;
+                data = cipher.doFinal(data);
             }
 
-            return out.toByteArray();
+            return data;
 
-        } catch (FileNotFoundException ex) {
+        } catch (NoSuchFileException ex) {
             logger.info("No such users file \"{}\", will create one with default settings.", filename);
         } catch (IllegalBlockSizeException ex) {
             logger.error("Users file \"{}\" is corrupted, will override it with default settings.", filename, ex);
@@ -153,7 +164,7 @@ public class UserFileHandle {
 
     private void printFileAux(byte[] bytes) throws IOException {
         try (InputStream in = new ByteArrayInputStream(bytes)) {
-            Files.copy(in, Paths.get(filename), StandardCopyOption.REPLACE_EXISTING);
+            Files.copy(in, filename, StandardCopyOption.REPLACE_EXISTING);
         }
     }
 }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/users/UsersStruct.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/users/UsersStruct.java
@@ -72,8 +72,8 @@ public class UsersStruct {
         boolean admin = true;
         String passPlainText = "dicoogle";
 
-        String passHash = HashService.getSHA1Hash(passPlainText);             //password Hash
-        String hash = HashService.getSHA1Hash(username + admin + passHash);   //user Hash
+        String passHash = HashService.getSHA256Hash(passPlainText);             //password Hash
+        String hash = HashService.getSHA256Hash(username + admin + passHash);   //user Hash
 
         return Collections.singleton(new User(username, hash, admin));
     }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/users/UsersStruct.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/users/UsersStruct.java
@@ -72,8 +72,8 @@ public class UsersStruct {
         boolean admin = true;
         String passPlainText = "dicoogle";
 
-        String passHash = HashService.getSHA256Hash(passPlainText);             //password Hash
-        String hash = HashService.getSHA256Hash(username + admin + passHash);   //user Hash
+        String passHash = HashService.hashPassword(passPlainText);             //password Hash
+        String hash = HashService.hashPassword(username + admin + passHash);   //user Hash
 
         return Collections.singleton(new User(username, hash, admin));
     }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/auth/Authentication.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/auth/Authentication.java
@@ -97,7 +97,7 @@ public class Authentication
 			return null;
 
 		// calculate the supplied passwords hash and see if it matches the users
-		String passwordHash = HashService.getSHA1Hash(password);
+		String passwordHash = HashService.getSHA256Hash(password);
 		if (! user.verifyPassword(passwordHash))
 			return null;
 		LoggedIn in = new LoggedIn(username, user.isAdmin());

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/auth/Authentication.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/auth/Authentication.java
@@ -97,7 +97,7 @@ public class Authentication
 			return null;
 
 		// calculate the supplied passwords hash and see if it matches the users
-		String passwordHash = HashService.getSHA256Hash(password);
+		String passwordHash = HashService.hashPassword(password);
 		if (! user.verifyPassword(passwordHash))
 			return null;
 		LoggedIn in = new LoggedIn(username, user.isAdmin());

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/accounts/UserServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/accounts/UserServlet.java
@@ -73,8 +73,8 @@ public class UserServlet extends HttpServlet {
         String pass = req.getParameter("password");
         boolean admin = Boolean.parseBoolean(req.getParameter("admin"));
 
-        String passHash = HashService.getSHA1Hash(pass);             //password Hash
-        String hash = HashService.getSHA1Hash(user + admin + passHash);   //user Hash
+        String passHash = HashService.getSHA256Hash(pass);             //password Hash
+        String hash = HashService.getSHA256Hash(user + admin + passHash);   //user Hash
 
         boolean wasAdded = UsersStruct.getInstance().addUser(new User(user, hash, admin));
 

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/accounts/UserServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/accounts/UserServlet.java
@@ -73,8 +73,8 @@ public class UserServlet extends HttpServlet {
         String pass = req.getParameter("password");
         boolean admin = Boolean.parseBoolean(req.getParameter("admin"));
 
-        String passHash = HashService.getSHA256Hash(pass);             //password Hash
-        String hash = HashService.getSHA256Hash(user + admin + passHash);   //user Hash
+        String passHash = HashService.hashPassword(pass);             //password Hash
+        String hash = HashService.hashPassword(user + admin + passHash);   //user Hash
 
         boolean wasAdded = UsersStruct.getInstance().addUser(new User(user, hash, admin));
 

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/utils/LocalImageCache.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/utils/LocalImageCache.java
@@ -246,7 +246,7 @@ public class LocalImageCache extends Thread implements ImageRetriever
     
     protected static String toFileName(String imageUri, int frameNumber, boolean thumbnail) {
         String filecode = imageUri + ':' + frameNumber + ':' + (thumbnail ? '1' : '0');
-        return DigestUtils.sha1Hex(filecode) + ".png";
+        return DigestUtils.sha256Hex(filecode) + ".png";
     }
     
     @Override

--- a/dicoogle/src/test/java/pt/ua/dicoogle/core/auth/TestUsers.java
+++ b/dicoogle/src/test/java/pt/ua/dicoogle/core/auth/TestUsers.java
@@ -58,8 +58,8 @@ public class TestUsers {
         String username = "nat";
         boolean admin = false;
         String passPlainText = "123";
-        String passHash = HashService.getSHA1Hash(passPlainText);             //password Hash
-        String hash = HashService.getSHA1Hash(username + admin + passHash);
+        String passHash = HashService.getSHA256Hash(passPlainText);             //password Hash
+        String hash = HashService.getSHA256Hash(username + admin + passHash);
         System.out.println(hash);
         System.out.println(passHash);
         User u = new User("nat",hash, admin);

--- a/dicoogle/src/test/java/pt/ua/dicoogle/core/auth/TestUsers.java
+++ b/dicoogle/src/test/java/pt/ua/dicoogle/core/auth/TestUsers.java
@@ -29,6 +29,7 @@ import pt.ua.dicoogle.server.web.auth.LoggedIn;
 import java.util.Collection;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static pt.ua.dicoogle.server.web.servlets.webui.WebUIServlet.camelize;
 
 /**
@@ -82,6 +83,21 @@ public class TestUsers {
             System.out.println("Error in the test");
         }
 
+    }
+
+    @Test
+    public void authentication() {
+        String passwd = "123";
+        User u = User.create("nat", false, passwd);
+        assertTrue(u.verifyPassword(passwd));
+        
+        passwd = "correctHorseBatteryStaple";
+        assertTrue(u.changePassword("123", passwd));
+        assertTrue(u.verifyPassword(passwd));
+
+        passwd = "VeryStrongPassword!!11";
+        assertTrue(u.resetPassword(passwd));
+        assertTrue(u.verifyPassword(passwd));
     }
 
 }

--- a/dicoogle/src/test/java/pt/ua/dicoogle/core/auth/TestUsers.java
+++ b/dicoogle/src/test/java/pt/ua/dicoogle/core/auth/TestUsers.java
@@ -52,39 +52,6 @@ public class TestUsers {
     public void tearDown() {
     }
 
-    //@Test
-    public void testUsers() {
-        UsersStruct usersStruct = UsersStruct.getInstance();
-
-        String username = "nat";
-        boolean admin = false;
-        String passPlainText = "123";
-        String passHash = HashService.hashPassword(passPlainText);             //password Hash
-        String hash = HashService.hashPassword(username + admin + passHash);
-        System.out.println(hash);
-        System.out.println(passHash);
-        User u = new User("nat",hash, admin);
-        usersStruct.addUser(u);
-
-
-        for (String uu : usersStruct.getUsernames())
-        {
-            System.out.println(usersStruct.getUser(uu));
-        }
-
-        Authentication auth = Authentication.getInstance();
-        try {
-            LoggedIn loggedIn = auth.login("nat", "123");
-            System.out.println(loggedIn.getUserName());
-            System.out.println(loggedIn.isAdmin());
-        }
-        catch(Exception e)
-        {
-            System.out.println("Error in the test");
-        }
-
-    }
-
     @Test
     public void authentication() {
         String passwd = "123";

--- a/dicoogle/src/test/java/pt/ua/dicoogle/core/auth/TestUsers.java
+++ b/dicoogle/src/test/java/pt/ua/dicoogle/core/auth/TestUsers.java
@@ -58,8 +58,8 @@ public class TestUsers {
         String username = "nat";
         boolean admin = false;
         String passPlainText = "123";
-        String passHash = HashService.getSHA256Hash(passPlainText);             //password Hash
-        String hash = HashService.getSHA256Hash(username + admin + passHash);
+        String passHash = HashService.hashPassword(passPlainText);             //password Hash
+        String hash = HashService.hashPassword(username + admin + passHash);
         System.out.println(hash);
         System.out.println(passHash);
         User u = new User("nat",hash, admin);


### PR DESCRIPTION
I believe it fully resolves #387.


- Replace all uses of the SHA-1 algorithm with BCrypt, a more suitable password hashing algorithm. It's still worth noting that this codebase was using SHA-1 far before the SHAttered attack was known.
- Make user file encryption actually work. This will happen by default unless a users file already exists without the respective key file.
- Try to set owner read-only permissions to users encryption key
- Refactor code around the `Cipher` API. I'm still not quite convinced that `Cipher` was being misused, though.
- Change user credentials file name to just "users" (since it might be encrypted, the .xml extension is misleading)

This is another breaking change for Dicoogle, each new deployment will have to create user credentials again.