### PR TITLE
Unindex by DIM attribute

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/management/UnindexServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/management/UnindexServlet.java
@@ -23,7 +23,11 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -32,7 +36,14 @@ import javax.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import net.sf.json.JSONObject;
+import pt.ua.dicoogle.server.web.utils.ResponseUtil;
+import pt.ua.dicoogle.core.settings.ServerSettingsManager;
 import pt.ua.dicoogle.plugins.PluginController;
+import pt.ua.dicoogle.sdk.QueryInterface;
+import pt.ua.dicoogle.sdk.datastructs.SearchResult;
+import pt.ua.dicoogle.sdk.task.JointQueryTask;
+import pt.ua.dicoogle.sdk.task.Task;
 
 /** Unindexer servlet.
  * 
@@ -50,37 +61,106 @@ public class UnindexServlet extends HttpServlet {
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
 
         // Getting Parameters.
-        String[] uris = req.getParameterValues("uri");
+        String[] paramUri = req.getParameterValues("uri");
+        String[] paramSop = req.getParameterValues("SOPInstanceUID");
+        String[] paramSeries = req.getParameterValues("SeriesInstanceUID");
+        String[] paramStudy = req.getParameterValues("StudyInstanceUID");
         String[] providerArr = req.getParameterValues("provider");
 
         List<String> providers = providerArr != null ? Arrays.asList(providerArr) : null;
 
-        if (uris == null) {
-            resp.sendError(400, "No uri provided");
+        int paramCount = (paramUri != null ? 1 : 0)
+            + (paramSop != null ? 1 : 0)
+            + (paramSeries != null ? 1 : 0)
+            + (paramStudy != null ? 1 : 0);
+
+        if (paramCount == 0) {
+            ResponseUtil.sendError(
+                resp, 400, "No arguments provided; must include either one of `uri`, `SOPInstanceUID`, `SeriesInstanceUID` or `StudyInstanceUID`");
+            return;
+        } else if (paramCount > 1) {
+            ResponseUtil.sendError(
+                resp, 400, "No arguments provided; must include either one of `uri`, `SOPInstanceUID`, `SeriesInstanceUID` or `StudyInstanceUID`");
             return;
         }
 
-        URI[] effUris = new URI[uris.length];
-        try {
-            for (int i = 0 ; i < effUris.length ; i++) {
-                effUris[i] = new URI(uris[i]);
-            }
-        } catch (URISyntaxException ex) {
-            logger.info("Received bad URI", ex);
-            resp.sendError(400, "Bad URI: " + ex.getInput());
-            return;
-        }
+        long indexed = 0;
+        long failed = 0;
+
+        Collection<String> uris = resolveURIs(paramUri, paramSop, paramSeries, paramStudy);
 
         // unindex
-        for (URI uri : effUris) {
+        for (String strUri : uris) {
             try {
-                PluginController.getInstance().unindex(uri, providers);
-            } catch (RuntimeException ex) {
-                logger.error(ex.getMessage(), ex);
+                URI uri = new URI(strUri);
+                try {
+                    PluginController.getInstance().unindex(uri, providers);
+                    indexed += 1;
+                } catch (RuntimeException ex) {
+                    logger.error("Failed to unindex {}", uri, ex);
+                    failed += 1;
+                }
+            } catch (URISyntaxException ex) {
+                logger.warn("Received bad URI", ex);
+                failed += 1;
             }
         }
 
-        logger.info("Finished unindexing {}", Arrays.asList(uris));
+        logger.info("Finished unindexing {} out of {} files", indexed, uris.size());
+        resp.setContentType("application/json");
+        JSONObject obj = new JSONObject();
+        obj.put("indexed", indexed);
+        obj.put("failed", failed);
         resp.setStatus(200);
+        resp.getWriter().write(obj.toString());
+    }
+
+    /// Convert the given parameters into a list of URIs 
+    private static Collection<String> resolveURIs(String[] paramUri, String[] paramSop, String[] paramSeries, String[] paramStudy) {
+        if (paramUri != null) {
+            return Arrays.asList(paramUri);
+        }
+        String attribute = null;
+        if (paramSop != null) {
+            attribute = "SOPInstanceUID";
+        } else if (paramSeries != null) {
+            attribute = "SeriesInstanceUID";
+        } else if (paramStudy != null) {
+            attribute = "StudyInstanceUID";
+        }
+
+        final String dcmAttribute = attribute;
+        List<String> dicomProviders = ServerSettingsManager.getSettings().getArchiveSettings().getDIMProviders();
+        if (dicomProviders.isEmpty()) {
+            return Arrays.stream(paramSop)
+                .flatMap(uid -> {
+                    // translate to URIs
+                    JointQueryTask holder = new JointQueryTask(){
+                        @Override
+                        public void onReceive(Task<Iterable<SearchResult>> e) {}
+                        @Override
+                        public void onCompletion() {}
+                        };
+                        try {
+                            return StreamSupport.stream(PluginController.getInstance()
+                                    .queryAll(holder, dcmAttribute + ":" + uid).get().spliterator(), false);
+                        } catch (InterruptedException|ExecutionException ex) {
+                            throw new RuntimeException(ex);
+                        }
+                    })
+                .map(r -> r.getURI().toString())
+                .collect(Collectors.toList());
+
+        }
+        String dicomProvider = dicomProviders.iterator().next();
+        return Arrays.stream(paramSop)
+            .flatMap(uid -> {
+                // translate to URIs
+                QueryInterface dicom = PluginController.getInstance().getQueryProviderByName(dicomProvider, false);
+                
+                return StreamSupport.stream(dicom.query(dcmAttribute + ":" + uid).spliterator(), false);
+            })
+            .map(r -> r.getURI().toString())
+            .collect(Collectors.toList());
     }
 }

--- a/dicoogle_web_api.yaml
+++ b/dicoogle_web_api.yaml
@@ -638,8 +638,9 @@ paths:
       tags:
         - index
       summary: >-
-        Request that the file at the given URI is unindexed in the specified
-        indexers
+        Request that a list of entries is unindexed in the specified
+        indexers, or all of them if left unspecified. Exactly one of the
+        fields `uri`, `SOPInstanceUID` and `SeriesInstanceUID` must be given.
       consumes:
         - application/json
       produces:
@@ -649,11 +650,32 @@ paths:
           name: uri
           description: >-
             a URI or array of URIs representing the root resource of the files
-            to be indexed
+            to be unindexed
           type: string
-          required: true
+          required: false
         - in: query
-          name: plugin
+          name: SOPInstanceUID
+          description: >-
+            a UID or list of UIDs representing the DICOM instances to be
+            unindexed
+          type: string
+          required: false
+        - in: query
+          name: SeriesInstanceUID
+          description: >-
+            a UID or list of UIDs representing the DICOM series to be
+            unindexed
+          type: string
+          required: false
+        - in: query
+          name: StudyInstanceUID
+          description: >-
+            a UID or list of UIDs representing the DICOM studies to be
+            unindexed
+          type: string
+          required: false
+        - in: query
+          name: provider
           description: a list of provider plugins
           type: string
           required: false


### PR DESCRIPTION
This is part one of an improvement to Dicoogle's unindexing capabilities (see also #142). Makes it so that this service endpoint can receive a list of instance, series or studies from the user, thus allowing for significantly smaller HTTP requests when unindexing a lot of data.