### PR TITLE
Use OpenJDK parent for Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
-FROM ubuntu
+FROM openjdk:8
 
 WORKDIR /root
 
 RUN apt-get update && \
-    apt-get install apt-utils -y && \
-    apt-get upgrade -y
-
-RUN apt-get install -y software-properties-common build-essential openjdk-8-jre git maven
+    apt-get install -y software-properties-common build-essential git maven
 
 RUN git clone https://github.com/bioinformatics-ua/dicoogle
 RUN ( cd dicoogle && mvn install && ln -s /root/dicoogle/dicoogle/target/dicoogle.jar /root/ )


### PR DESCRIPTION
Official images exist for OpenJDK, so we might as well use them in our Dockerfile. This resolves #386.