### PR TITLE
Imp/configurable aetitle 282

### DIFF
--- a/dicoogle/src/main/resources/webapp/js/actions/aetitleActions.js
+++ b/dicoogle/src/main/resources/webapp/js/actions/aetitleActions.js
@@ -1,0 +1,3 @@
+import Reflux from "reflux";
+export const getAETitle = Reflux.createAction();
+export const setAETitle = Reflux.createAction();

--- a/dicoogle/src/main/resources/webapp/js/components/management/aetitleForm.jsx
+++ b/dicoogle/src/main/resources/webapp/js/components/management/aetitleForm.jsx
@@ -62,16 +62,13 @@ export default class AETitleForm extends React.Component {
           </div>
         </div>
         <div className="col-xs-4">
-          <div className="data-table">
-            <button
-              type="button"
-              className="btn btn-danger"
-              style={{ marginTop: 20 }}
-              onClick={this.props.onSubmitAETitle}
-            >
-              Change
-            </button>
-          </div>
+          <button
+            type="button"
+            className="btn btn-danger"
+            onClick={this.props.onSubmitAETitle}
+          >
+            Save
+          </button>
           <div
             className="loader-inner ball-pulse"
             style={{ visibility: this.props.onhold ? "visible" : "hidden" }}

--- a/dicoogle/src/main/resources/webapp/js/components/management/aetitleForm.jsx
+++ b/dicoogle/src/main/resources/webapp/js/components/management/aetitleForm.jsx
@@ -4,7 +4,7 @@ import { FormGroup, FormControl } from "react-bootstrap";
 export default class AETitleForm extends React.Component {
   static get propTypes() {
     return {
-      aetitleText: PropTypes.string.isRequired,
+      aetitleText: PropTypes.string,
       dirtyValue: PropTypes.bool.isRequired, // aetitle value has unsaved changes
       onChangeAETitle: PropTypes.func.isRequired,
       onSubmitAETitle: PropTypes.func.isRequired

--- a/dicoogle/src/main/resources/webapp/js/components/management/aetitleForm.jsx
+++ b/dicoogle/src/main/resources/webapp/js/components/management/aetitleForm.jsx
@@ -5,7 +5,7 @@ export default class AETitleForm extends React.Component {
   static get propTypes() {
     return {
       aetitleText: PropTypes.string.isRequired,
-      dirtyValue: PropTypes.bool.isRequired,  // aetitle value has unsaved changes
+      dirtyValue: PropTypes.bool.isRequired, // aetitle value has unsaved changes
       onChangeAETitle: PropTypes.func.isRequired,
       onSubmitAETitle: PropTypes.func.isRequired
     };
@@ -26,19 +26,17 @@ export default class AETitleForm extends React.Component {
   }
 
   handleAETitleChange(e) {
-    console.log(e.target.value);
     this.props.onChangeAETitle(e.target.value);
   }
 
   handleAETitleKeyPress(e) {
-    console.log("handleAETitleKeyPress", e.target.value);
     if (e.keyCode === 13) {
       if (this.isAETitleValid()) {
         this.props.onSubmitAETitle(this.props.aetitleText);
       }
     }
   }
- render() {
+  render() {
     return (
       <div className="row">
         <div className="col-xs-4">

--- a/dicoogle/src/main/resources/webapp/js/components/management/aetitleForm.jsx
+++ b/dicoogle/src/main/resources/webapp/js/components/management/aetitleForm.jsx
@@ -48,7 +48,6 @@ export default class AETitleForm extends React.Component {
                 type="text"
                 value={this.props.aetitleText}
                 placeholder="Enter a valid AETitle"
-                disabled={this.props.disabledAETitle && "disabled"}
                 onChange={this.handleAETitleChange}
                 onKeyDown={this.handleAETitleKeyPress}
               />

--- a/dicoogle/src/main/resources/webapp/js/components/management/aetitleForm.jsx
+++ b/dicoogle/src/main/resources/webapp/js/components/management/aetitleForm.jsx
@@ -39,32 +39,27 @@ export default class AETitleForm extends React.Component {
   render() {
     return (
       <div className="row">
-        <div className="col-xs-4">
-          <p>AETitle</p>
-        </div>
-        <div className="col-xs-4">
+        <div className="col-xs-8">
           <div className="data-table">
-            <div className="inline_block" style={{ marginLeft: "1em" }}>
-              <FormGroup
-                validationState={this.isAETitleValid() ? "success" : "error"}
-              >
-                <FormControl
-                  type="text"
-                  value={this.props.aetitleText}
-                  placeholder="Enter a valid AETitle"
-                  disabled={this.props.disabledAETitle && "disabled"}
-                  onChange={this.handleAETitleChange}
-                  onKeyDown={this.handleAETitleKeyPress}
-                />
-                {this.props.dirtyValue && <FormControl.Feedback />}
-              </FormGroup>
-            </div>
+            <FormGroup
+              validationState={this.isAETitleValid() ? "success" : "error"}
+            >
+              <FormControl
+                type="text"
+                value={this.props.aetitleText}
+                placeholder="Enter a valid AETitle"
+                disabled={this.props.disabledAETitle && "disabled"}
+                onChange={this.handleAETitleChange}
+                onKeyDown={this.handleAETitleKeyPress}
+              />
+              {this.props.dirtyValue && <FormControl.Feedback />}
+            </FormGroup>
           </div>
         </div>
         <div className="col-xs-4">
           <button
             type="button"
-            className="btn btn-danger"
+            className="btn btn-success"
             onClick={this.props.onSubmitAETitle}
           >
             Save

--- a/dicoogle/src/main/resources/webapp/js/components/management/aetitleForm.jsx
+++ b/dicoogle/src/main/resources/webapp/js/components/management/aetitleForm.jsx
@@ -1,0 +1,85 @@
+import React, { PropTypes } from "react";
+import { FormGroup, FormControl } from "react-bootstrap";
+
+export default class AETitleForm extends React.Component {
+  static get propTypes() {
+    return {
+      aetitleText: PropTypes.string.isRequired,
+      dirtyValue: PropTypes.bool.isRequired,  // aetitle value has unsaved changes
+      onChangeAETitle: PropTypes.func.isRequired,
+      onSubmitAETitle: PropTypes.func.isRequired
+    };
+  }
+
+  constructor(props) {
+    super(props);
+    this.handleAETitleChange = this.handleAETitleChange.bind(this);
+    this.handleAETitleKeyPress = this.handleAETitleKeyPress.bind(this);
+  }
+
+  componentDidUpdate() {}
+
+  isAETitleValid() {
+    let regex = /^[ A-Za-z0-9_.+-]*$/;
+
+    return regex.test(this.props.aetitleText);
+  }
+
+  handleAETitleChange(e) {
+    console.log(e.target.value);
+    this.props.onChangeAETitle(e.target.value);
+  }
+
+  handleAETitleKeyPress(e) {
+    console.log("handleAETitleKeyPress", e.target.value);
+    if (e.keyCode === 13) {
+      if (this.isAETitleValid()) {
+        this.props.onSubmitAETitle(this.props.aetitleText);
+      }
+    }
+  }
+ render() {
+    return (
+      <div className="row">
+        <div className="col-xs-4">
+          <p>AETitle</p>
+        </div>
+        <div className="col-xs-4">
+          <div className="data-table">
+            <div className="inline_block" style={{ marginLeft: "1em" }}>
+              <FormGroup
+                validationState={this.isAETitleValid() ? "success" : "error"}
+              >
+                <FormControl
+                  type="text"
+                  value={this.props.aetitleText}
+                  placeholder="Enter a valid AETitle"
+                  disabled={this.props.disabledAETitle && "disabled"}
+                  onChange={this.handleAETitleChange}
+                  onKeyDown={this.handleAETitleKeyPress}
+                />
+                {this.props.dirtyValue && <FormControl.Feedback />}
+              </FormGroup>
+            </div>
+          </div>
+        </div>
+        <div className="col-xs-4">
+          <div className="data-table">
+            <button
+              type="button"
+              className="btn btn-danger"
+              style={{ marginTop: 20 }}
+              onClick={this.props.onSubmitAETitle}
+            >
+              Change
+            </button>
+          </div>
+          <div
+            className="loader-inner ball-pulse"
+            style={{ visibility: this.props.onhold ? "visible" : "hidden" }}
+          ></div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/dicoogle/src/main/resources/webapp/js/components/management/aetitleView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/management/aetitleView.js
@@ -1,0 +1,82 @@
+import React from "react";
+import AETitleForm from "./aetitleForm";
+import * as AETitleActions from "../../actions/aetitleActions";
+import AETitleStore from "../../stores/aetitleStore";
+import Webcore from "dicoogle-webcore";
+
+const AETitleView = React.createClass({
+    getInitialState() {
+        return {
+            aetitleText: "",
+            dirtyValue: false,  // aetitle value has unsaved changes
+            status: "done"
+        };
+    },
+
+    componentWillMount() {
+        this.unsubscribe = AETitleStore.listen(this._onChange);
+    },
+
+    componentWillUnmount() {
+        this.unsubscribe();
+    },
+
+    componentDidMount() {
+        AETitleActions.getAETitle();
+    },
+
+    _onChange(data) {
+        console.log(data);
+        this.setState({
+            aetitleText: data.aetitleText,
+            status: "done"
+        });
+    },
+
+    render() {
+        if (this.state.status === "loading") {
+            return (
+                <div className="loader-inner ball-pulse">
+                    <div />
+                    <div />
+                    <div />
+                </div>
+            );
+        }
+
+        return (
+            <div className="panel panel-primary topMargin">
+                <div className="panel-heading">
+                    <h3 className="panel-title">AETitle</h3>
+                </div>
+                <div className="panel-body">
+                    <AETitleForm
+                        aetitleText=""
+                        onChangeAETitle={this.handleAETitleChange}
+                        onSubmitAETitle={this.handleSubmitAETitle}
+                        dirtyValue={this.state.dirtyValue}
+                    />
+                </div>
+            </div>
+        );
+    },
+
+    handleAETitleChange(aetitle) {
+        console.log("handleAETitleChange");
+        this.setState({
+            aetitleText: aetitle,
+            dirtyValue: true
+        });
+    },
+
+    handleSubmitAETitle(aetitle) {
+        console.log("handleSubmitAETitle", aetitle);
+        this.setState({
+            dirtyValue: false
+        });
+
+        AETitleActions.setAETitle(aetitle);
+    }
+});
+
+export { AETitleView };

--- a/dicoogle/src/main/resources/webapp/js/components/management/aetitleView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/management/aetitleView.js
@@ -9,7 +9,7 @@ const AETitleView = React.createClass({
         return {
             aetitleText: "",
             dirtyValue: false,  // aetitle value has unsaved changes
-            status: "done"
+            status: "loading"
         };
     },
 
@@ -23,10 +23,10 @@ const AETitleView = React.createClass({
 
     componentDidMount() {
         AETitleActions.getAETitle();
+        this.setState({ status: "done" });
     },
 
     _onChange(data) {
-        console.log(data);
         this.setState({
             aetitleText: data.aetitleText,
             status: "done"
@@ -51,7 +51,7 @@ const AETitleView = React.createClass({
                 </div>
                 <div className="panel-body">
                     <AETitleForm
-                        aetitleText=""
+                        aetitleText={this.state.aetitleText}
                         onChangeAETitle={this.handleAETitleChange}
                         onSubmitAETitle={this.handleSubmitAETitle}
                         dirtyValue={this.state.dirtyValue}
@@ -62,20 +62,18 @@ const AETitleView = React.createClass({
     },
 
     handleAETitleChange(aetitle) {
-        console.log("handleAETitleChange");
         this.setState({
             aetitleText: aetitle,
             dirtyValue: true
         });
     },
 
-    handleSubmitAETitle(aetitle) {
-        console.log("handleSubmitAETitle", aetitle);
+    handleSubmitAETitle() {
         this.setState({
             dirtyValue: false
         });
 
-        AETitleActions.setAETitle(aetitle);
+        AETitleActions.setAETitle(this.state.aetitleText);
     }
 });
 

--- a/dicoogle/src/main/resources/webapp/js/components/management/aetitleView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/management/aetitleView.js
@@ -2,6 +2,7 @@ import React from "react";
 import AETitleForm from "./aetitleForm";
 import * as AETitleActions from "../../actions/aetitleActions";
 import AETitleStore from "../../stores/aetitleStore";
+import $ from "jquery";
 
 const AETitleView = React.createClass({
     getInitialState() {
@@ -25,10 +26,27 @@ const AETitleView = React.createClass({
     },
 
     _onChange(data) {
-        this.setState({
-            aetitleText: data.aetitle,
-            status: "done"
-        });
+        let toastMessage = data.success ? "Saved." : data.message;
+
+        if (this.state.status === "done") {
+            $(".toast")
+                .stop()
+                .text(toastMessage)
+                .fadeIn(400)
+                .delay(3000)
+                .fadeOut(400); // fade out after 3 seconds
+        }
+
+        if (!data.success) {
+            this.setState({
+                dirtyValue: true
+            });
+        } else {
+            this.setState({
+                aetitleText: data.message,
+                status: "done"
+            });
+        }
     },
 
     render() {
@@ -55,7 +73,9 @@ const AETitleView = React.createClass({
                         dirtyValue={this.state.dirtyValue}
                     />
                 </div>
+                <div className="toast">Saved</div>
             </div>
+
         );
     },
 

--- a/dicoogle/src/main/resources/webapp/js/components/management/aetitleView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/management/aetitleView.js
@@ -2,7 +2,6 @@ import React from "react";
 import AETitleForm from "./aetitleForm";
 import * as AETitleActions from "../../actions/aetitleActions";
 import AETitleStore from "../../stores/aetitleStore";
-import Webcore from "dicoogle-webcore";
 
 const AETitleView = React.createClass({
     getInitialState() {
@@ -23,12 +22,11 @@ const AETitleView = React.createClass({
 
     componentDidMount() {
         AETitleActions.getAETitle();
-        this.setState({ status: "done" });
     },
 
     _onChange(data) {
         this.setState({
-            aetitleText: data.aetitleText,
+            aetitleText: data.aetitle,
             status: "done"
         });
     },

--- a/dicoogle/src/main/resources/webapp/js/components/management/servicesAndPluginsView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/management/servicesAndPluginsView.js
@@ -1,11 +1,13 @@
 import React from "react";
 import { ServicesView } from "./servicesView";
 import { PluginsView } from "./pluginsView";
+import { AETitleView } from "./aetitleView";
 
 const ServicesAndPluginsView = React.createClass({
   render() {
     return (
       <div>
+        <AETitleView />
         <ServicesView />
         <PluginsView />
       </div>

--- a/dicoogle/src/main/resources/webapp/js/stores/aetitleStore.js
+++ b/dicoogle/src/main/resources/webapp/js/stores/aetitleStore.js
@@ -1,0 +1,55 @@
+import Reflux from "reflux";
+import { Endpoints } from "../constants/endpoints";
+import * as AETitleActions from "../actions/aetitleActions";
+
+import dicoogleClient from "dicoogle-client";
+const Dicoogle = dicoogleClient(Endpoints.base);
+
+const AETitleStore = Reflux.createStore({
+  listenables: AETitleActions,
+  init: function () {
+    this._contents = {};
+  },
+
+  onGetAETitle: function () {
+    console.log("aetitleStore - onGetAETitle");
+    return true;
+    // Dicoogle.request("GET", ["plugins", type], (error, data) => {
+    //   if (!error) {
+    //     self._contents[type] = data.plugins;
+    //     self.trigger({
+    //       data: self._contents[type],
+    //       success: true
+    //     });
+    //   } else {
+    //     self.trigger({
+    //       success: false,
+    //       status: error.status
+    //     });
+    //   }
+    // });
+  },
+
+  onSetAETitle: function (name) {
+    console.log("aetitleStore - onSetAETitle -> " + name);
+    return true;
+    // Dicoogle.request("POST", ["plugins", type, name, action], (error, data) => {
+    //   if (!error) {
+    //     self._contents[type].find(plugin => plugin.name === name).enabled =
+    //       action === "enable";
+    //     self.trigger({
+    //       data: self._contents[type],
+    //       success: true
+    //     });
+    //   } else {
+    //     self.trigger({
+    //       success: false,
+    //       status: error.status,
+    //       error: "Could not " + action + " the plugin."
+    //     });
+    //   }
+    // });
+  }
+});
+
+export default AETitleStore;

--- a/dicoogle/src/main/resources/webapp/js/stores/aetitleStore.js
+++ b/dicoogle/src/main/resources/webapp/js/stores/aetitleStore.js
@@ -12,43 +12,27 @@ const AETitleStore = Reflux.createStore({
   },
 
   onGetAETitle: function () {
-    console.log("aetitleStore - onGetAETitle");
-    return true;
-    // Dicoogle.request("GET", ["plugins", type], (error, data) => {
-    //   if (!error) {
-    //     self._contents[type] = data.plugins;
-    //     self.trigger({
-    //       data: self._contents[type],
-    //       success: true
-    //     });
-    //   } else {
-    //     self.trigger({
-    //       success: false,
-    //       status: error.status
-    //     });
-    //   }
-    // });
+    const self = this;
+
+    Dicoogle.getAETitle((err, data) => {
+      if (err) {
+        console.error("Service failure", err);
+        return;
+      }
+
+      self.trigger({
+        aetitle: data
+      });
+    });
   },
 
   onSetAETitle: function (name) {
-    console.log("aetitleStore - onSetAETitle -> " + name);
-    return true;
-    // Dicoogle.request("POST", ["plugins", type, name, action], (error, data) => {
-    //   if (!error) {
-    //     self._contents[type].find(plugin => plugin.name === name).enabled =
-    //       action === "enable";
-    //     self.trigger({
-    //       data: self._contents[type],
-    //       success: true
-    //     });
-    //   } else {
-    //     self.trigger({
-    //       success: false,
-    //       status: error.status,
-    //       error: "Could not " + action + " the plugin."
-    //     });
-    //   }
-    // });
+    Dicoogle.setAETitle(name, (err) => {
+      if (err) {
+        console.error("Service failure", err);
+        return;
+      }
+    });
   }
 });
 

--- a/dicoogle/src/main/resources/webapp/js/stores/aetitleStore.js
+++ b/dicoogle/src/main/resources/webapp/js/stores/aetitleStore.js
@@ -17,21 +17,47 @@ const AETitleStore = Reflux.createStore({
     Dicoogle.getAETitle((err, data) => {
       if (err) {
         console.error("Service failure", err);
+
+        self.trigger({
+          success: false,
+          message: err
+        });
+
         return;
       }
 
       self.trigger({
-        aetitle: data
+        success: true,
+        message: data
       });
     });
   },
 
   onSetAETitle: function (name) {
+    const self = this;
+
+    if (! /^[ A-Za-z0-9_.+-]*$/.test(name)) {
+      self.trigger({
+        success: false,
+        message: "Invalid AETitle provided"
+      });
+      return;
+    }
+
     Dicoogle.setAETitle(name, (err) => {
       if (err) {
         console.error("Service failure", err);
-        return;
+
+        self.trigger({
+          success: false,
+          message: err
+        });
       }
+
+      self.trigger({
+        success: true,
+        message: name
+      });
     });
   }
 });

--- a/dicoogle/src/main/resources/webapp/sass/core/_global.scss
+++ b/dicoogle/src/main/resources/webapp/sass/core/_global.scss
@@ -53,6 +53,7 @@ input {
 }
 
 .toast {
+  display: none;
   min-width: 200px;
   height: auto;
   position: fixed;


### PR DESCRIPTION
This PR solves #282 

Implemented aetitle component in Management > Services & Plugins.

The AETitle is validated matching the ^[ A-Za-z0-9_.+-]*$ regex (only alphanumeric and _.+- characters are allowed) and a toast giving the status is shown whether the Save action is successful or not.

<img width="1680" alt="Screenshot 2019-12-19 at 12 17 08" src="https://user-images.githubusercontent.com/8323694/71172997-865e9280-2259-11ea-9e00-cdfe54faffdd.png">
