### PR TITLE
Fixed toast component and standardized across webapp

### DIFF
--- a/dicoogle/src/main/resources/webapp/js/components/management/aetitleView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/management/aetitleView.js
@@ -2,14 +2,17 @@ import React from "react";
 import AETitleForm from "./aetitleForm";
 import * as AETitleActions from "../../actions/aetitleActions";
 import AETitleStore from "../../stores/aetitleStore";
-import $ from "jquery";
+import { ToastView } from "../mixins/toastView";
 
 const AETitleView = React.createClass({
     getInitialState() {
         return {
             aetitleText: "",
             dirtyValue: false,  // aetitle value has unsaved changes
-            status: "loading"
+            status: "loading",
+            showToast: false,
+            toastType: 'default',
+            toastMessage: {}
         };
     },
 
@@ -26,15 +29,28 @@ const AETitleView = React.createClass({
     },
 
     _onChange(data) {
-        let toastMessage = data.success ? "Saved." : data.message;
+        if (data.success) {
+            this.setState({
+                toastType: "default",
+                toastMessage: {
+                    title: "Saved"
+                }
+            });
+        } else {
+            this.setState({
+                toastType: "error",
+                toastMessage: {
+                    title: "Error",
+                    body: data.message
+                }
+            });
+        }
 
         if (this.state.status === "done") {
-            $(".toast")
-                .stop()
-                .text(toastMessage)
-                .fadeIn(400)
-                .delay(3000)
-                .fadeOut(400); // fade out after 3 seconds
+            this.setState(
+                { showToast: true },
+                () => setTimeout(() => this.setState({ showToast: false }), 3000)
+            );
         }
 
         if (!data.success) {
@@ -50,6 +66,8 @@ const AETitleView = React.createClass({
     },
 
     render() {
+        const { showToast, toastType, toastMessage } = this.state;
+
         if (this.state.status === "loading") {
             return (
                 <div className="loader-inner ball-pulse">
@@ -65,6 +83,7 @@ const AETitleView = React.createClass({
                 <div className="panel-heading">
                     <h3 className="panel-title">AETitle</h3>
                 </div>
+                
                 <div className="panel-body">
                     <AETitleForm
                         aetitleText={this.state.aetitleText}
@@ -73,9 +92,9 @@ const AETitleView = React.createClass({
                         dirtyValue={this.state.dirtyValue}
                     />
                 </div>
-                <div className="toast">Saved</div>
-            </div>
 
+                <ToastView show={showToast} message={toastMessage} toastType={toastType} />
+            </div>
         );
     },
 

--- a/dicoogle/src/main/resources/webapp/js/components/management/aetitleView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/management/aetitleView.js
@@ -9,10 +9,7 @@ const AETitleView = React.createClass({
         return {
             aetitleText: "",
             dirtyValue: false,  // aetitle value has unsaved changes
-            status: "loading",
-            showToast: false,
-            toastType: 'default',
-            toastMessage: {}
+            status: "loading"
         };
     },
 
@@ -29,45 +26,24 @@ const AETitleView = React.createClass({
     },
 
     _onChange(data) {
-        if (data.success) {
-            this.setState({
-                toastType: "default",
-                toastMessage: {
-                    title: "Saved"
-                }
-            });
-        } else {
-            this.setState({
-                toastType: "error",
-                toastMessage: {
-                    title: "Error",
-                    body: data.message
-                }
-            });
-        }
-
-        if (this.state.status === "done") {
-            this.setState(
-                { showToast: true },
-                () => setTimeout(() => this.setState({ showToast: false }), 3000)
-            );
-        }
-
-        if (!data.success) {
-            this.setState({
-                dirtyValue: true
-            });
-        } else {
+        if (data.success && this.state.status === "done") {
+            this.props.showToastMessage("success", { title: "Saved" });
+        } else if (data.success) {
             this.setState({
                 aetitleText: data.message,
                 status: "done"
             });
+
+        } else {
+            this.setState({
+                dirtyValue: true,
+            });
+
+            this.props.showToastMessage("error", { title: "Error", body: data.message });
         }
     },
 
     render() {
-        const { showToast, toastType, toastMessage } = this.state;
-
         if (this.state.status === "loading") {
             return (
                 <div className="loader-inner ball-pulse">
@@ -83,7 +59,7 @@ const AETitleView = React.createClass({
                 <div className="panel-heading">
                     <h3 className="panel-title">AETitle</h3>
                 </div>
-                
+
                 <div className="panel-body">
                     <AETitleForm
                         aetitleText={this.state.aetitleText}
@@ -92,8 +68,6 @@ const AETitleView = React.createClass({
                         dirtyValue={this.state.dirtyValue}
                     />
                 </div>
-
-                <ToastView show={showToast} message={toastMessage} toastType={toastType} />
             </div>
         );
     },

--- a/dicoogle/src/main/resources/webapp/js/components/management/indexerView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/management/indexerView.js
@@ -29,7 +29,6 @@ const IndexerView = React.createClass({
         thumbnailSize: 0,
         watcher: false
       },
-      showSaved: false,
       status: "loading",
       currentWatch: false
     };
@@ -135,7 +134,6 @@ const IndexerView = React.createClass({
             <button className="btn btn_dicoogle" onClick={this.onSaveClicked}>
               Save
             </button>
-            <ToastView show={this.state.showSaved} message={{ title: "Saved" }} />
           </div>
         </div>
       </div>
@@ -164,10 +162,7 @@ const IndexerView = React.createClass({
       document.getElementById("tsize").value
     );
 
-    this.setState(
-      { showSaved: true },
-      () => setTimeout(() => this.setState({ showSaved: false }), 3000)
-    );
+    this.props.showToastMessage("success", { title: "Saved" });
   }
 });
 

--- a/dicoogle/src/main/resources/webapp/js/components/management/indexerView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/management/indexerView.js
@@ -27,9 +27,9 @@ const IndexerView = React.createClass({
         effort: 0,
         thumbnail: false,
         thumbnailSize: 0,
-        watcher: false,
-        showSaved: false
+        watcher: false
       },
+      showSaved: false,
       status: "loading",
       currentWatch: false
     };
@@ -135,7 +135,7 @@ const IndexerView = React.createClass({
             <button className="btn btn_dicoogle" onClick={this.onSaveClicked}>
               Save
             </button>
-            <ToastView show={this.state.showSaved} />
+            <ToastView show={this.state.showSaved} message={{ title: "Saved" }} />
           </div>
         </div>
       </div>
@@ -155,7 +155,6 @@ const IndexerView = React.createClass({
     //console.log(document.getElementById(id).value);
   },
   onSaveClicked() {
-    console.log("onSaveClicked");
     saveIndexOptions(
       document.getElementById("mon_path").value,
       document.getElementById("watcher").checked,

--- a/dicoogle/src/main/resources/webapp/js/components/management/indexerView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/management/indexerView.js
@@ -165,10 +165,10 @@ const IndexerView = React.createClass({
       document.getElementById("tsize").value
     );
 
-    this.setState({ showSaved: true });
-    setTimeout(() => {
-      this.setState({ showSaved: false });
-    }, 3000);
+    this.setState(
+      { showSaved: true },
+      () => setTimeout(() => this.setState({ showSaved: false }), 3000)
+    );
   }
 });
 

--- a/dicoogle/src/main/resources/webapp/js/components/management/managementView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/management/managementView.js
@@ -4,19 +4,38 @@ import { ServicesAndPluginsView } from "../management/servicesAndPluginsView";
 import { LoggerView } from "../management/loggerView";
 import { IndexerView } from "../management/indexerView";
 import { StorageView } from "../management/storageView";
+import { ToastView } from "../mixins/toastView";
 
 const ManagementView = React.createClass({
-  getInitialState: function() {
-    return { selectedtab: 0 };
+  getInitialState: function () {
+    return {
+      selectedtab: 0,
+      showToast: false,
+      toastType: 'default',
+      toastMessage: {}
+    };
   },
-  render: function() {
+
+  showToastMessage: function (toastType, toastMessage) {
+    this.setState({
+      showToast: true,
+      toastType,
+      toastMessage
+    },
+      () => setTimeout(() => this.setState({ showToast: false }), 3000));
+  },
+
+  render: function () {
     var views = [
-      <IndexerView />,
+      <IndexerView showToastMessage={this.showToastMessage} />,
       <TransferOptionsView />,
-      <ServicesAndPluginsView />,
+      <ServicesAndPluginsView showToastMessage={this.showToastMessage} />,
       <StorageView />,
       <LoggerView />
     ];
+
+    const { showToast, toastType, toastMessage } = this.state;
+
     return (
       <div className="container-fluid content">
         <ul className="nav nav-pills">
@@ -69,11 +88,12 @@ const ManagementView = React.createClass({
         <div id="my-tab-content" className="tab-content">
           {views[this.state.selectedtab]}
         </div>
+
+        <ToastView show={showToast} message={toastMessage} toastType={toastType} />
       </div>
     );
   },
-  onTabClicked: function(index) {
-    console.log("tabSelected: ", index);
+  onTabClicked: function (index) {
     this.setState({ selectedtab: index });
   }
 });

--- a/dicoogle/src/main/resources/webapp/js/components/management/managementView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/management/managementView.js
@@ -28,7 +28,7 @@ const ManagementView = React.createClass({
   render: function () {
     var views = [
       <IndexerView showToastMessage={this.showToastMessage} />,
-      <TransferOptionsView />,
+      <TransferOptionsView showToastMessage={this.showToastMessage} />,
       <ServicesAndPluginsView showToastMessage={this.showToastMessage} />,
       <StorageView />,
       <LoggerView />

--- a/dicoogle/src/main/resources/webapp/js/components/management/managementView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/management/managementView.js
@@ -30,7 +30,7 @@ const ManagementView = React.createClass({
       <IndexerView showToastMessage={this.showToastMessage} />,
       <TransferOptionsView showToastMessage={this.showToastMessage} />,
       <ServicesAndPluginsView showToastMessage={this.showToastMessage} />,
-      <StorageView />,
+      <StorageView showToastMessage={this.showToastMessage} />,
       <LoggerView />
     ];
 

--- a/dicoogle/src/main/resources/webapp/js/components/management/pluginsView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/management/pluginsView.js
@@ -1,7 +1,6 @@
 import React from "react";
 import * as PluginActions from "../../actions/pluginActions";
 import PluginStore from "../../stores/pluginStore";
-import $ from "jquery";
 
 const PluginsView = React.createClass({
   getInitialState() {
@@ -36,13 +35,11 @@ const PluginsView = React.createClass({
         actionPerformed: false
       });
 
-      let toastMessage = this.state.error ? this.state.error : "Saved.";
-      $(".toast")
-        .stop()
-        .text(toastMessage)
-        .fadeIn(400)
-        .delay(3000)
-        .fadeOut(400); // fade out after 3 seconds
+      if (this.state.error) {
+        this.props.showToastMessage("error", { title: "Error", body: this.state.error });
+      } else {
+        this.props.showToastMessage("success", { title: "Saved" });
+      }
     }
 
     if (!data.success) {
@@ -162,7 +159,7 @@ const PluginsView = React.createClass({
         <div className="panel-body">
           <div className="row">{pluginPanels}</div>
         </div>
-        <div className="toast">Saved</div>
+        {/* <div className="toast">Saved</div> */}
       </div>
     );
   }

--- a/dicoogle/src/main/resources/webapp/js/components/management/servicesAndPluginsView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/management/servicesAndPluginsView.js
@@ -5,11 +5,13 @@ import { AETitleView } from "./aetitleView";
 
 const ServicesAndPluginsView = React.createClass({
   render() {
+    const { showToastMessage } = this.props;
+
     return (
       <div>
-        <AETitleView />
-        <ServicesView />
-        <PluginsView />
+        <AETitleView showToastMessage={showToastMessage} />
+        <ServicesView showToastMessage={showToastMessage} />
+        <PluginsView showToastMessage={showToastMessage} />
       </div>
     );
   }

--- a/dicoogle/src/main/resources/webapp/js/components/management/servicesView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/management/servicesView.js
@@ -47,7 +47,13 @@ const ServicesView = React.createClass({
   },
 
   _onChange(data) {
-    console.log(data);
+    if (data.error) {
+      this.props.showToastMessage("error", { title: "Error", body: data.error });
+      return;
+    } else if (!data.error && this.state.status === "done") {
+      this.props.showToastMessage("success", { title: "Success" });
+    }
+
     this.setState({
       storageRunning: data.storageRunning,
       storagePort: data.storagePort,

--- a/dicoogle/src/main/resources/webapp/js/components/management/storageView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/management/storageView.js
@@ -179,8 +179,14 @@ const StorageView = React.createClass({
   componentWillUnmount() {
     this.unsubscribe();
   },
-  _onChange: function(data) {
-    this.setState({ data: data.data });
+  _onChange: function (data) {
+    if (!data.success) {
+      this.props.showToastMessage("error", { title: "Error", body: data.status });
+    } else if (!data.error && this.state.status === "done") {
+      this.props.showToastMessage("success", { title: "Success" });
+    }
+    
+    this.setState({ data: data.data, status: "done" });
   },
 
   render: function() {

--- a/dicoogle/src/main/resources/webapp/js/components/management/transferOptionsView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/management/transferOptionsView.js
@@ -2,7 +2,6 @@ import React from "react";
 
 import { TransferStore } from "../../stores/transferStore";
 import { TransferActions } from "../../actions/transferActions";
-import { Button } from "react-bootstrap";
 
 const TransferOptionsView = React.createClass({
   getInitialState() {
@@ -27,7 +26,13 @@ const TransferOptionsView = React.createClass({
     this.unsubscribe();
   },
   _onChange(data) {
-    console.log(data);
+    //console.log(data);
+    if (!data.success) {
+      this.props.showToastMessage("error", { title: "Error", body: data.status });
+    } else if (data.success && this.state.status === "done") {
+      this.props.showToastMessage("success", { title: "Saved" });
+    }
+
     this.setState({ data: data, status: "done" });
   },
   render() {
@@ -102,9 +107,9 @@ const TransferOptionsView = React.createClass({
                 </li>
               </ul>
               <div>
-                <Button bsStyle="primary" onClick={this.handleSelectAll}>
+                <button className="btn btn_dicoogle" onClick={this.handleSelectAll}>
                   {this.selectAllOn ? "Select all" : "Unselect all"}
-                </Button>
+                </button>
               </div>
             </div>
           </div>

--- a/dicoogle/src/main/resources/webapp/js/components/mixins/toastView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/mixins/toastView.js
@@ -3,9 +3,11 @@ import { Transition } from "react-transition-group";
 
 const ToastView = React.createClass({
   render() {
-    const message = this.props.message ? this.props.message : "Saved.";
-    const duration = this.props.duration ? this.props.duration : 300;
-    const toastType = this.props.toastType ? this.props.toastType : "default";
+    let { message, duration, toastType } = this.props;
+
+    message = message && message.title ? message : { title: "Saved." };
+    duration = duration ? duration : 300;
+    toastType = toastType ? toastType : "default";
 
     const transitionStyles = {
       entering: {
@@ -28,7 +30,15 @@ const ToastView = React.createClass({
               ...transitionStyles[state]
             }}
           >
-            <div className={`toast toast-${toastType}`}>{message}</div>
+            <div className={`toast toast-${toastType}`}>
+              <h3 className="panel-title">{message.title}</h3>
+
+              {message.body &&
+                <div className="toast-body">
+                  {message.body}
+                </div>
+              }
+            </div>
           </div>
         )}
       </Transition>

--- a/dicoogle/src/main/resources/webapp/js/components/mixins/toastView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/mixins/toastView.js
@@ -5,6 +5,7 @@ const ToastView = React.createClass({
   render() {
     const message = this.props.message ? this.props.message : "Saved.";
     const duration = this.props.duration ? this.props.duration : 300;
+    const toastType = this.props.toastType ? this.props.toastType : "default";
 
     const transitionStyles = {
       entering: {
@@ -27,7 +28,7 @@ const ToastView = React.createClass({
               ...transitionStyles[state]
             }}
           >
-            <div className="toast">{message}</div>
+            <div className={`toast toast-${toastType}`}>{message}</div>
           </div>
         )}
       </Transition>

--- a/dicoogle/src/main/resources/webapp/js/components/mixins/toastView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/mixins/toastView.js
@@ -5,7 +5,7 @@ const ToastView = React.createClass({
   render() {
     let { message, duration, toastType } = this.props;
 
-    message = message && message.title ? message : { title: "Saved." };
+    message = message && message.title ? message : { title: "Saved" };
     duration = duration ? duration : 300;
     toastType = toastType ? toastType : "default";
 

--- a/dicoogle/src/main/resources/webapp/js/components/mixins/toastView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/mixins/toastView.js
@@ -3,15 +3,28 @@ import { Transition } from "react-transition-group";
 
 const ToastView = React.createClass({
   render() {
-    let message = this.props.message ? this.props.message : "Saved.";
+    const message = this.props.message ? this.props.message : "Saved.";
+    const duration = this.props.duration ? this.props.duration : 300;
+
+    const transitionStyles = {
+      entering: {
+        transition: `opacity 400ms ease-in-out`,
+      },
+      exiting: {
+        transition: `opacity 400ms ease-in-out`,
+        opacity: 0
+      },
+      exited: {
+        opacity: 0
+      }
+    };
 
     return (
-      <Transition in={this.props.show} timeout={0}>
-        {state => (
+      <Transition in={this.props.show} timeout={duration}>
+        {(state) => (
           <div
             style={{
-              transition: `opacity 400ms ease-in-out`,
-              opacity: state === "entered" ? 1 : 0
+              ...transitionStyles[state]
             }}
           >
             <div className="toast">{message}</div>

--- a/dicoogle/src/main/resources/webapp/js/components/search/exportView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/exportView.js
@@ -12,9 +12,10 @@ import {
 import { ExportActions } from "../../actions/exportActions";
 import { ExportStore } from "../../stores/exportStore";
 import $ from "jquery";
+import { ToastView } from "../mixins/toastView";
 
 const ExportView = React.createClass({
-  getInitialState: function() {
+  getInitialState: function () {
     return {
       fields: [],
       presets: [],
@@ -27,17 +28,21 @@ const ExportView = React.createClass({
 
       actionPerformed: false,
 
-      current: 0
+      current: 0,
+
+      showToast: false,
+      toastType: 'default',
+      toastMessage: {}
     };
   },
 
-  componentWillMount: function() {
+  componentWillMount: function () {
     // Subscribe to the store.
     console.log("subscribe listener");
     this.unsubscribe = ExportStore.listen(this._onChange);
   },
 
-  componentDidMount: function() {
+  componentDidMount: function () {
     ExportActions.getFieldList();
     ExportActions.getPresets();
   },
@@ -46,11 +51,21 @@ const ExportView = React.createClass({
     this.unsubscribe();
   },
 
-  _onChange: function(data) {
+  showToastMessage: function (toastType, toastMessage) {
+    this.setState({
+      showToast: true,
+      toastType,
+      toastMessage
+    },
+      () => setTimeout(() => this.setState({ showToast: false }), 3000));
+  },
+
+  _onChange: function (data) {
     if (!data.success) {
       this.setState({
         status: "failed"
       });
+      this.showToastMessage("error", { title: "Error" });
       return;
     }
 
@@ -75,13 +90,7 @@ const ExportView = React.createClass({
         actionPerformed: false
       });
 
-      let toastMessage = this.state.error ? this.state.error : "Saved.";
-      $(".toast")
-        .stop()
-        .text(toastMessage)
-        .fadeIn(400)
-        .delay(3000)
-        .fadeOut(400); // fade out after 3 seconds
+      this.showToastMessage("success", { title: "Success" });
     }
   },
 
@@ -91,90 +100,92 @@ const ExportView = React.createClass({
       label: preset.name
     }));
 
+    const { showToast, toastType, toastMessage } = this.state;
+
     return (
-      <Modal {...this.props} bsStyle="primary" animation>
-        <Modal.Header>
-          <Modal.Title>Export to CSV</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          <FormGroup>
-            <ControlLabel>Preset (optional):</ControlLabel>
-            <Select
-              simpleValue
-              id="selected-preset"
-              value={this.state.selectedPresetName}
-              options={presetNames}
-              placeholder="Choose a preset"
-              onChange={this.handlePresetSelect}
-            />
-          </FormGroup>
-          <FormGroup>
-            <ControlLabel>Fields to export:</ControlLabel>
-            <Select.AsyncCreatable
-              multi
-              id="selected-fields"
-              value={this.state.selectedFields}
-              loadOptions={this.loadOptionFields}
-              placeholder="Choose fields"
-              onChange={this.handleFieldSelect}
-            />
-          </FormGroup>
-          <FormGroup>
-            <ControlLabel>Inline fields to export (optional):</ControlLabel>
-
-            <div className="modal-body">
-              <textarea
-                id="textFields"
-                placeholder="Paste export fields here (one per line)"
-                onChange={this.handleFieldSelectTextArea}
-                rows="10"
-                value={this.state.selectedFieldsAdditionals}
-                className="exportlist form-control"
+        <Modal {...this.props} bsStyle="primary" animation>
+          <Modal.Header>
+            <Modal.Title>Export to CSV</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <FormGroup>
+              <ControlLabel>Preset (optional):</ControlLabel>
+              <Select
+                simpleValue
+                id="selected-preset"
+                value={this.state.selectedPresetName}
+                options={presetNames}
+                placeholder="Choose a preset"
+                onChange={this.handlePresetSelect}
               />
-            </div>
-          </FormGroup>
-        </Modal.Body>
-        <Modal.Footer id="hacked-modal-footer-do-not-remove">
-          <Form inline>
-            <FormControl
-              type="text"
-              value={this.state.exportPresetName}
-              placeholder="Name the preset"
-              onChange={this.handlePresetNameChange}
-              maxLength="100"
-            />
+            </FormGroup>
+            <FormGroup>
+              <ControlLabel>Fields to export:</ControlLabel>
+              <Select.AsyncCreatable
+                multi
+                id="selected-fields"
+                value={this.state.selectedFields}
+                loadOptions={this.loadOptionFields}
+                placeholder="Choose fields"
+                onChange={this.handleFieldSelect}
+              />
+            </FormGroup>
+            <FormGroup>
+              <ControlLabel>Inline fields to export (optional):</ControlLabel>
 
-            <Button
-              bsStyle="default"
-              onClick={this.handleSavePresetClicked}
-              disabled={!this.canExport()}
-            >
-              Save Preset
-            </Button>
-            <Button
-              bsStyle="primary"
-              onClick={this.handleExportClicked}
-              disabled={!this.canSave()}
-            >
-              Export
-            </Button>
-          </Form>
-          <div className="toast">Saved</div>
-        </Modal.Footer>
-      </Modal>
+              <div className="modal-body">
+                <textarea
+                  id="textFields"
+                  placeholder="Paste export fields here (one per line)"
+                  onChange={this.handleFieldSelectTextArea}
+                  rows="10"
+                  value={this.state.selectedFieldsAdditionals}
+                  className="exportlist form-control"
+                />
+              </div>
+            </FormGroup>
+          </Modal.Body>
+          <Modal.Footer id="hacked-modal-footer-do-not-remove">
+            <Form inline>
+              <FormControl
+                type="text"
+                value={this.state.exportPresetName}
+                placeholder="Name the preset"
+                onChange={this.handlePresetNameChange}
+                maxLength="100"
+              />
+
+              <Button
+                bsStyle="default"
+                onClick={this.handleSavePresetClicked}
+                disabled={!this.canExport()}
+              >
+                Save Preset
+              </Button>
+              <Button
+                bsStyle="primary"
+                onClick={this.handleExportClicked}
+                disabled={!this.canSave()}
+              >
+                Export
+              </Button>
+            </Form>
+          </Modal.Footer>
+          <ToastView show={showToast} message={toastMessage} toastType={toastType} />
+        </Modal>
     );
   },
 
-  loadOptionFields: function(input, callback) {
+  loadOptionFields: function (input, callback) {
     // display no options if the input is empty
     let options =
       input.length === 0
         ? []
         : this.state.fields.filter(
-            i =>
-              i.value.toLowerCase().substr(0, input.length) ===
-              input.toLowerCase()
-          );
+          i =>
+            i.value.toLowerCase().substr(0, input.length) ===
+            input.toLowerCase()
+        );
 
     let data = {
       options: options,
@@ -184,19 +195,19 @@ const ExportView = React.createClass({
     callback(null, data);
   },
 
-  handleFieldSelectTextArea: function(event) {
+  handleFieldSelectTextArea: function (event) {
     this.setState({
       selectedFieldsAdditionals: event.target.value
     });
   },
 
-  handleFieldSelect: function(selectedFields) {
+  handleFieldSelect: function (selectedFields) {
     this.setState({
       selectedFields: selectedFields
     });
   },
 
-  handlePresetSelect: function(name) {
+  handlePresetSelect: function (name) {
     // default values if no preset is selected
     let selectedFields = [];
     let exportPresetName = "default";
@@ -216,12 +227,12 @@ const ExportView = React.createClass({
     });
   },
 
-  handlePresetNameChange: function(e) {
+  handlePresetNameChange: function (e) {
     this.setState({
       exportPresetName: e.target.value
     });
   },
-  __getSelectedFields: function() {
+  __getSelectedFields: function () {
     let fields = this.state.selectedFields.map(i => i.value);
     if (this.state.selectedFieldsAdditionals !== "") {
       let fieldsInline = this.state.selectedFieldsAdditionals.split("\n");
@@ -230,7 +241,7 @@ const ExportView = React.createClass({
 
     return fields;
   },
-  handleSavePresetClicked: function() {
+  handleSavePresetClicked: function () {
     let fields = this.__getSelectedFields();
     ExportActions.savePresets(this.state.exportPresetName, fields);
 
@@ -240,17 +251,17 @@ const ExportView = React.createClass({
     });
   },
 
-  handleExportClicked: function() {
+  handleExportClicked: function () {
     let fields = this.__getSelectedFields();
     let query = this.props.query;
     ExportActions.exportCSV(query, fields);
   },
 
-  canSave: function() {
+  canSave: function () {
     return this.__getSelectedFields().length !== 0;
   },
 
-  canExport: function() {
+  canExport: function () {
     return this.state.exportPresetName && this.canSave();
   }
 });

--- a/dicoogle/src/main/resources/webapp/js/components/search/exportView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/exportView.js
@@ -11,7 +11,6 @@ import {
 
 import { ExportActions } from "../../actions/exportActions";
 import { ExportStore } from "../../stores/exportStore";
-import $ from "jquery";
 import { ToastView } from "../mixins/toastView";
 
 const ExportView = React.createClass({

--- a/dicoogle/src/main/resources/webapp/js/stores/exportStore.js
+++ b/dicoogle/src/main/resources/webapp/js/stores/exportStore.js
@@ -39,6 +39,8 @@ const ExportStore = Reflux.createStore({
 
   onExportCSV: function(data, fields) {
     let { text, keyword, provider } = data;
+    const self = this;
+
     if (text.length === 0) {
       text = "*:*";
       keyword = true;
@@ -51,6 +53,12 @@ const ExportStore = Reflux.createStore({
       (error, id) => {
         if (error) {
           console.error("Failed to issue the export:", error);
+
+          self.trigger({
+            success: false,
+            status: error.status
+          });
+
           return;
         }
 

--- a/dicoogle/src/main/resources/webapp/js/stores/servicesStore.js
+++ b/dicoogle/src/main/resources/webapp/js/stores/servicesStore.js
@@ -39,7 +39,8 @@ const ServicesStore = Reflux.createStore({
   onGetStorage: function() {
     this.dicoogle.storage.getStatus((error, data) => {
       if (error) {
-        console.log("onGetStorage: failure", error);
+        console.error("onGetStorage: failure", error);
+        this.trigger({ error: "Dicoogle service error" });
         return;
       }
 
@@ -53,7 +54,8 @@ const ServicesStore = Reflux.createStore({
   onGetQuery: function() {
     this.dicoogle.queryRetrieve.getStatus((error, data) => {
       if (error) {
-        console.log("onGetQuery: failure");
+        console.error("onGetQuery: failure");
+        this.trigger({ error: "Dicoogle service error" });
         return;
       }
 
@@ -68,6 +70,7 @@ const ServicesStore = Reflux.createStore({
     const callback = error => {
       if (error) {
         console.error("Dicoogle service error", error);
+        this.trigger({ error: "Dicoogle service error" });
         return;
       }
 
@@ -86,6 +89,7 @@ const ServicesStore = Reflux.createStore({
     this.dicoogle.storage.configure({ autostart: enabled }, error => {
       if (error) {
         console.error("Dicoogle service error", error);
+        this.trigger({ error: "Dicoogle service error" });
         return;
       }
 
@@ -98,6 +102,7 @@ const ServicesStore = Reflux.createStore({
     this.dicoogle.storage.configure({ port }, error => {
       if (error) {
         console.error("Dicoogle service error", error);
+        this.trigger({ error: "Dicoogle service error" });
         return;
       }
 
@@ -110,6 +115,7 @@ const ServicesStore = Reflux.createStore({
     const callback = error => {
       if (error) {
         console.error("Dicoogle service error", error);
+        this.trigger({ error: "Dicoogle service error" });
         return;
       }
 
@@ -128,6 +134,7 @@ const ServicesStore = Reflux.createStore({
     this.dicoogle.queryRetrieve.configure({ autostart: enabled }, error => {
       if (error) {
         console.error("Dicoogle service error", error);
+        this.trigger({ error: "Dicoogle service error" });
         return;
       }
 
@@ -140,6 +147,7 @@ const ServicesStore = Reflux.createStore({
     this.dicoogle.queryRetrieve.configure({ port }, error => {
       if (error) {
         console.error("Dicoogle service error", error);
+        this.trigger({ error: "Dicoogle service error" });
         return;
       }
 
@@ -152,6 +160,7 @@ const ServicesStore = Reflux.createStore({
     this.dicoogle.queryRetrieve.getDicomQuerySettings((error, data) => {
       if (error) {
         console.error("Dicoogle service error", error);
+        this.trigger({ error: "Dicoogle service error" });
         return;
       }
 
@@ -182,7 +191,9 @@ const ServicesStore = Reflux.createStore({
       },
       (error, data) => {
         if (error) {
+          this.trigger({ error: "Dicoogle service error" });
           console.error("Dicoogle service error", error);
+          return;
         }
       }
     );

--- a/dicoogle/src/main/resources/webapp/sass/core/_colors.scss
+++ b/dicoogle/src/main/resources/webapp/sass/core/_colors.scss
@@ -6,9 +6,12 @@ $blue3: #009ba8;
 $blue4: #4c97d8;
 $blue5: #4c97d8;
 $blue6: #cbe0f2;
-$red: #ff0000;
 
 $main_color: #cbe0f2;
 $hover_color: #4c97d8;
 $main_bg: #ffffff;
 $button_color: #fff;
+
+$error: #dc3545;
+$danger: #ffc107;
+$success: #28a745;

--- a/dicoogle/src/main/resources/webapp/sass/core/_global.scss
+++ b/dicoogle/src/main/resources/webapp/sass/core/_global.scss
@@ -53,7 +53,6 @@ input {
 }
 
 .toast {
-  display: none;
   min-width: 200px;
   height: auto;
   position: fixed;
@@ -69,9 +68,6 @@ input {
   -webkit-box-shadow: 0px 0px 24px -1px rgba(56, 56, 56, 1);
   -moz-box-shadow: 0px 0px 24px -1px rgba(56, 56, 56, 1);
   box-shadow: 0px 0px 24px -1px rgba(56, 56, 56, 1);
-}
-.testdapissa {
-  height: 400px;
 }
 
 .indexstatusprogress {

--- a/dicoogle/src/main/resources/webapp/sass/core/_global.scss
+++ b/dicoogle/src/main/resources/webapp/sass/core/_global.scss
@@ -60,7 +60,6 @@ input {
   margin-left: -100px;
   bottom: 20px;
   color: $button_color;
-  font-size: 20px;
   padding: 10px;
   text-align: center;
   border-radius: 4px;
@@ -82,6 +81,12 @@ input {
 
   &-error {
     background-color: $error;
+  }
+
+  &-body {
+    border-top: 1px solid $button_color;
+    margin: 5px;
+    padding-top: 5px;
   }
 }
 

--- a/dicoogle/src/main/resources/webapp/sass/core/_global.scss
+++ b/dicoogle/src/main/resources/webapp/sass/core/_global.scss
@@ -59,15 +59,30 @@ input {
   left: 50%;
   margin-left: -100px;
   bottom: 20px;
-  background-color: $blue5;
   color: $button_color;
   font-size: 20px;
   padding: 10px;
   text-align: center;
-  border-radius: 2px;
-  -webkit-box-shadow: 0px 0px 24px -1px rgba(56, 56, 56, 1);
-  -moz-box-shadow: 0px 0px 24px -1px rgba(56, 56, 56, 1);
-  box-shadow: 0px 0px 24px -1px rgba(56, 56, 56, 1);
+  border-radius: 4px;
+  -webkit-box-shadow: 0px 0px 10px -1px rgba(56, 56, 56, 1);
+  -moz-box-shadow: 0px 0px 10px -1px rgba(56, 56, 56, 1);
+  box-shadow: 0px 0px 10px -1px rgba(56, 56, 56, 1);
+
+  &-default {
+    background-color: $blue5;
+  }
+
+  &-success {
+    background-color: $success;
+  }
+
+  &-warning {
+    background-color: $danger;
+  }
+
+  &-error {
+    background-color: $error;
+  }
 }
 
 .indexstatusprogress {
@@ -136,5 +151,5 @@ input {
 }
 
 .form-control-date {
-    width: auto;
+  width: auto;
 }


### PR DESCRIPTION
This PR fixes the showing of the toastView mixin. It now allows the tweak of the color depending within 4 modes: default, success, danger, and error.
jQuery was removed from all components and the toast message triggered by it was replaced by the toastView.

Added also missing event triggers in Stores so the toast message may be launched upon triggering.

Examples:
![Screenshot 2020-05-19 at 20 03 36](https://user-images.githubusercontent.com/8323694/82367588-fab97f80-9a0b-11ea-985a-685104b88c80.png)
![Screenshot 2020-05-19 at 20 04 16](https://user-images.githubusercontent.com/8323694/82367593-fd1bd980-9a0b-11ea-88e6-71b917806326.png)
