### PR TITLE
Update Travis badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="https://user-images.githubusercontent.com/4738426/33545371-e652d482-d8d5-11e7-9ea5-c676d9313378.png" height="50"/>
 
-[![Build Status](https://travis-ci.org/bioinformatics-ua/dicoogle.svg?branch=dev)](https://travis-ci.org/bioinformatics-ua/dicoogle)
+[![Build Status](https://travis-ci.com/bioinformatics-ua/dicoogle.svg?branch=dev)](https://travis-ci.com/bioinformatics-ua/dicoogle)
 
 Dicoogle is an extensible, platform-independent and open-source PACS archive software that replaces the traditional centralized database with a more agile indexing and retrieval mechanism. It was designed to support automatic extraction, indexing and storage of all meta-data detected in medical images, including private DICOM attribute tags, without re-engineering or reconfiguration requirements.
 


### PR DESCRIPTION
As required by the migration from travis-ci.org to travis-ci.com.