### PR TITLE
Do not require Node.js 15 and npm 7 to pass in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ matrix:
       env: NODE_VERSION=lts/*
     - jdk: openjdk11
       env: NODE_VERSION=lts/*
+  allow_failures:
+    - jdk: oraclejdk8
+      env: NODE_VERSION=stable WEBAPP_ONLY=1
 
 before_install:
   - if [ $TRAVIS_JDK_VERSION == "oraclejdk8" ] || [ $TRAVIS_JDK_VERSION == "openjdk8" ]; then

--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ Before building, please make sure that your system contains the following tools:
 
  - Java JDK, either Oracle or OpenJDK (at least version 8);
  - Maven 3;
- - [Node.js](https://nodejs.org/en/download/) (at least version 10; latest LTS or Stable versions are recommended);
- - npm (at least version 5; version 6 is recommended), often installed alongside Node.js.
+ - [Node.js](https://nodejs.org/en/download/) (at least version 10; latest LTS version is recommended);
+ - npm (version 6 is recommended), often installed alongside Node.js.
 
  1. Retrieve the full source code from this repository: `git clone https://github.com/bioinformatics-ua/dicoogle.git`
  2. Navigate to the project's base directory, and build the parent Maven project by calling `mvn install`.


### PR DESCRIPTION
Should make our CI pass again.

My concern here is that Node.js 15 also introduces npm 7, a version which also introduces a few changes in behavior, as well as in the package lock format. As such, I propose we not guarantee these version to work for now, while recommending to always stick to the latest LTS, to be reiterated on a later stage.