### PR TITLE
Fix a bug while deleting a study with too many images

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/DicoogleWeb.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/DicoogleWeb.java
@@ -222,7 +222,10 @@ public class DicoogleWeb {
         this.contextHandlers = new ContextHandlerCollection();
         this.contextHandlers.setHandlers(handlers);
         server.setHandler(this.contextHandlers);
-        
+
+        // Increase maxFormContentSize to avoid issues with big forms
+        server.setAttribute("org.eclipse.jetty.server.Request.maxFormContentSize", 3325000);
+
         // and then start the server
         server.start();
     }


### PR DESCRIPTION
This change increases the default maxFormContentSize to allow operations such as unindex/delete over large studies (with >3k image).