### PR TITLE
Fix memory leak in the completed/failed indexing task.

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/RSIStorage.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/RSIStorage.java
@@ -264,9 +264,6 @@ public class RSIStorage extends StorageService
             as.abort();
             
             return;
-        } else {
-            //DebugManager.getInstance().debug("Client association permited: " + as.getCallingAET() + "!");
-            System.err.println("Client association permited: " + as.getCallingAET() + "!");
         }
 
         final DicomObject rsp = CommandUtils.mkRSP(rq, CommandUtils.SUCCESS);

--- a/dicoogle/src/main/java/pt/ua/dicoogle/taskManager/RunningIndexTasks.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/taskManager/RunningIndexTasks.java
@@ -40,7 +40,7 @@ public class RunningIndexTasks {
     private static final Logger logger = LoggerFactory.getLogger(RunningIndexTasks.class);
     private static Integer SOFT_MAX_RUNNINGTASKS = Integer.parseInt(System.getProperty("dicoogle.tasks.softRemoveTasks", "50000"));
     private static Integer NUMBER_RUNNINGTASKS_TO_CLEAN = Integer.parseInt(System.getProperty("dicoogle.tasks.numberTaskClean", "2000"));
-    private static Boolean ENABLE_HOOK = Boolean.getBoolean(System.getProperty("dicoogle.tasks.removedCompleted", "true"));
+    private static Boolean ENABLE_HOOK = Boolean.valueOf(System.getProperty("dicoogle.tasks.removedCompleted", "true"));
 	public static RunningIndexTasks instance;
 
 	private final Map<String, Task<Report>> taskRunningList;

--- a/dicoogle/src/main/java/pt/ua/dicoogle/taskManager/RunningIndexTasks.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/taskManager/RunningIndexTasks.java
@@ -18,14 +18,6 @@
  */
 package pt.ua.dicoogle.taskManager;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ExecutionException;
-
-import com.sun.org.apache.xpath.internal.operations.Bool;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.slf4j.Logger;
@@ -33,6 +25,10 @@ import org.slf4j.LoggerFactory;
 import pt.ua.dicoogle.sdk.datastructs.IndexReport;
 import pt.ua.dicoogle.sdk.datastructs.Report;
 import pt.ua.dicoogle.sdk.task.Task;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Singleton that contains all running index tasks

--- a/dicoogle/src/main/java/pt/ua/dicoogle/taskManager/RunningIndexTasks.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/taskManager/RunningIndexTasks.java
@@ -26,8 +26,8 @@ import pt.ua.dicoogle.sdk.datastructs.IndexReport;
 import pt.ua.dicoogle.sdk.datastructs.Report;
 import pt.ua.dicoogle.sdk.task.Task;
 
-import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
@@ -54,7 +54,7 @@ public class RunningIndexTasks {
 	}
 
 	public RunningIndexTasks() {
-		taskRunningList = new HashMap<>();
+		taskRunningList = new LinkedHashMap<>();
 	}
 
 	public void addTask(String taskUid, Task<Report> task) {

--- a/dicoogle/src/main/java/pt/ua/dicoogle/taskManager/RunningIndexTasks.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/taskManager/RunningIndexTasks.java
@@ -60,9 +60,8 @@ public class RunningIndexTasks {
 	public void addTask(String taskUid, Task<Report> task) {
 		taskRunningList.put(taskUid, task);
 		if (ENABLE_HOOK){
-            hookRemoveRunningTasks();
-        }
-
+		    hookRemoveRunningTasks();
+		}
 	}
 
 	public boolean removeTask(String taskUid) {
@@ -70,20 +69,20 @@ public class RunningIndexTasks {
 	}
 
 
-	public boolean hookRemoveRunningTasks(){
+	public void hookRemoveRunningTasks(){
+
 	    if (this.taskRunningList.size()>SOFT_MAX_RUNNINGTASKS){
 	        int removedTasks = 0 ;
 	        Iterator<String> iterator = this.taskRunningList.keySet().iterator();
 	        while(iterator.hasNext()&& removedTasks<NUMBER_RUNNINGTASKS_TO_CLEAN){
 	            String tId = iterator.next();
-                Task t =  this.taskRunningList.get(tId);
+                Task<?> t =  this.taskRunningList.get(tId);
                 if (t.isCancelled() || t.isDone()){
                     iterator.remove();
                     removedTasks++;
                 }
             }
         }
-	    return true;
     }
 
 	public boolean stopTask(String taskUid) {

--- a/dicoogle/src/main/java/pt/ua/dicoogle/taskManager/RunningIndexTasks.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/taskManager/RunningIndexTasks.java
@@ -27,6 +27,7 @@ import pt.ua.dicoogle.sdk.datastructs.Report;
 import pt.ua.dicoogle.sdk.task.Task;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
@@ -72,10 +73,12 @@ public class RunningIndexTasks {
 	public boolean hookRemoveRunningTasks(){
 	    if (this.taskRunningList.size()>SOFT_MAX_RUNNINGTASKS){
 	        int removedTasks = 0 ;
-	        for (String taskUid : this.taskRunningList.keySet()){
-                Task t = this.taskRunningList.get(taskUid);
-                if (removedTasks<NUMBER_RUNNINGTASKS_TO_CLEAN &&(t.isCancelled() || t.isDone())){
-                    this.removeTask(taskUid);
+	        Iterator<String> iterator = this.taskRunningList.keySet().iterator();
+	        while(iterator.hasNext()&& removedTasks<NUMBER_RUNNINGTASKS_TO_CLEAN){
+	            String tId = iterator.next();
+                Task t =  this.taskRunningList.get(tId);
+                if (t.isCancelled() || t.isDone()){
+                    iterator.remove();
                     removedTasks++;
                 }
             }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/taskManager/RunningIndexTasks.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/taskManager/RunningIndexTasks.java
@@ -39,9 +39,9 @@ import java.util.concurrent.ExecutionException;
  */
 public class RunningIndexTasks {
     private static final Logger logger = LoggerFactory.getLogger(RunningIndexTasks.class);
-    private static Integer SOFT_MAX_RUNNINGTASKS = Integer.parseInt(System.getProperty("dicoogle.tasks.softRemoveTasks", "50000"));
-    private static Integer NUMBER_RUNNINGTASKS_TO_CLEAN = Integer.parseInt(System.getProperty("dicoogle.tasks.numberTaskClean", "2000"));
-    private static Boolean ENABLE_HOOK = Boolean.valueOf(System.getProperty("dicoogle.tasks.removedCompleted", "true"));
+    private static int SOFT_MAX_RUNNINGTASKS = Integer.parseInt(System.getProperty("dicoogle.tasks.softRemoveTasks", "50000"));
+    private static int NUMBER_RUNNINGTASKS_TO_CLEAN = Integer.parseInt(System.getProperty("dicoogle.tasks.numberTaskClean", "2000"));
+    private static boolean ENABLE_HOOK = Boolean.valueOf(System.getProperty("dicoogle.tasks.removedCompleted", "true"));
 	public static RunningIndexTasks instance;
 
 	private final Map<String, Task<Report>> taskRunningList;


### PR DESCRIPTION
This PR avoids to keep all indexing tasks in memory.
The oldest not running tasks are cleaned, to guarantee a hooked memory cleaning process. 

Base is master, but planned to merge in dev as well.

Resolves #139.