### PR TITLE
WebUI Plugins: Fix the emit events for result-batch slot plugins

### DIFF
--- a/dicoogle/src/main/resources/webapp/js/components/plugin/pluginForm.jsx
+++ b/dicoogle/src/main/resources/webapp/js/components/plugin/pluginForm.jsx
@@ -1,8 +1,7 @@
 import React from "react";
 import * as PropTypes from "prop-types";
 import { ResultsSelected } from "../../stores/resultSelected";
-import dicoogleClient from "dicoogle-client";
-const Dicoogle = dicoogleClient();
+import Webcore from "dicoogle-webcore";
 
 export default class PluginForm extends React.Component {
   static get propTypes() {
@@ -38,7 +37,8 @@ export default class PluginForm extends React.Component {
       const node = component;
       node.data = this.props.data;
       node.addEventListener("hide", this.handleHideSignal);
-      Dicoogle.emitSlotSignal(
+
+      Webcore.emitSlotSignal(
         node,
         "result-selection-ready",
         ResultsSelected.get()

--- a/dicoogle/src/main/resources/webapp/js/components/search/result/imageView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/imageView.js
@@ -154,12 +154,9 @@ const ImageView = createReactClass({
   handleSelect(item) {
     let { sopInstanceUID } = item;
     // ResultSelectActions.select(item);
-    let value = this.refsClone[sopInstanceUID].getChecked();
+    let value = this.refsClone[sopInstanceUID].checked;
     if (value) ResultSelectActions.select(item, sopInstanceUID);
     else ResultSelectActions.unSelect(item, sopInstanceUID);
-  },
-  handleRefs: function(id, input) {
-    this.refsClone[id] = input;
   },
   formatSelect: function(cell, item) {
     let { sopInstanceUID } = item;
@@ -169,7 +166,7 @@ const ImageView = createReactClass({
         <Checkbox
           label=""
           onChange={this.handleSelect.bind(this, item)}
-          ref={this.handleRefs.bind(this, sopInstanceUID)}
+          inputRef={ref => this.refsClone[sopInstanceUID] = ref}
         />
       </div>
     );

--- a/dicoogle/src/main/resources/webapp/js/components/search/result/imageView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/imageView.js
@@ -150,12 +150,11 @@ const ImageView = createReactClass({
     }
     return <div />;
   },
-  handleRefs: function(id, input) {	
-    this.refsClone[id] = input;	
+  handleRefs: function(id, input) {
+    this.refsClone[id] = input;
   },
   handleSelect(item) {
     let { sopInstanceUID } = item;
-    // ResultSelectActions.select(item);
     let value = this.refsClone[sopInstanceUID].checked;
     if (value) ResultSelectActions.select(item, sopInstanceUID);
     else ResultSelectActions.unSelect(item, sopInstanceUID);

--- a/dicoogle/src/main/resources/webapp/js/components/search/result/imageView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/imageView.js
@@ -150,7 +150,9 @@ const ImageView = createReactClass({
     }
     return <div />;
   },
-
+  handleRefs: function(id, input) {	
+    this.refsClone[id] = input;	
+  },
   handleSelect(item) {
     let { sopInstanceUID } = item;
     // ResultSelectActions.select(item);
@@ -166,7 +168,7 @@ const ImageView = createReactClass({
         <Checkbox
           label=""
           onChange={this.handleSelect.bind(this, item)}
-          inputRef={ref => this.refsClone[sopInstanceUID] = ref}
+          inputRef={this.handleRefs.bind(this, sopInstanceUID)}
         />
       </div>
     );

--- a/dicoogle/src/main/resources/webapp/js/components/search/result/patientView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/patientView.js
@@ -122,10 +122,13 @@ const PatientView = createReactClass({
   },
   handleSelect(item) {
     let { id } = item;
-    ResultSelectActions.select(item);
+    // ResultSelectActions.select(item);
     let value = this.refsClone[id].checked;
     if (value) ResultSelectActions.select(item, id);
     else ResultSelectActions.unSelect(item, id);
+  },
+  handleRefs: function(id, input) {	
+    this.refsClone[id] = input;	
   },
   formatSelect: function(cell, item) {
     let { id } = item;
@@ -135,7 +138,7 @@ const PatientView = createReactClass({
         <Checkbox
           label=""
           onChange={this.handleSelect.bind(this, item)}
-          inputRef={ref => this.refsClone[id] = ref}
+          inputRef={this.handleRefs.bind(this, id)}
         />
       </div>
     );

--- a/dicoogle/src/main/resources/webapp/js/components/search/result/patientView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/patientView.js
@@ -122,13 +122,12 @@ const PatientView = createReactClass({
   },
   handleSelect(item) {
     let { id } = item;
-    // ResultSelectActions.select(item);
     let value = this.refsClone[id].checked;
     if (value) ResultSelectActions.select(item, id);
     else ResultSelectActions.unSelect(item, id);
   },
-  handleRefs: function(id, input) {	
-    this.refsClone[id] = input;	
+  handleRefs: function(id, input) {
+    this.refsClone[id] = input;
   },
   formatSelect: function(cell, item) {
     let { id } = item;

--- a/dicoogle/src/main/resources/webapp/js/components/search/result/patientView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/patientView.js
@@ -122,13 +122,10 @@ const PatientView = createReactClass({
   },
   handleSelect(item) {
     let { id } = item;
-    // ResultSelectActions.select(item);
-    let value = this.refsClone[id].getChecked();
+    ResultSelectActions.select(item);
+    let value = this.refsClone[id].checked;
     if (value) ResultSelectActions.select(item, id);
     else ResultSelectActions.unSelect(item, id);
-  },
-  handleRefs: function(id, input) {
-    this.refsClone[id] = input;
   },
   formatSelect: function(cell, item) {
     let { id } = item;
@@ -138,7 +135,7 @@ const PatientView = createReactClass({
         <Checkbox
           label=""
           onChange={this.handleSelect.bind(this, item)}
-          ref={this.handleRefs.bind(this, id)}
+          inputRef={ref => this.refsClone[id] = ref}
         />
       </div>
     );

--- a/dicoogle/src/main/resources/webapp/js/components/search/result/serieView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/serieView.js
@@ -122,12 +122,9 @@ const SeriesView = createReactClass({
   handleSelect(item) {
     let { serieInstanceUID } = item;
     // ResultSelectActions.select(item);
-    let value = this.refsClone[serieInstanceUID].getChecked();
+    let value = this.refsClone[serieInstanceUID].checked;
     if (value) ResultSelectActions.select(item, serieInstanceUID);
     else ResultSelectActions.unSelect(item, serieInstanceUID);
-  },
-  handleRefs: function(id, input) {
-    this.refsClone[id] = input;
   },
   formatSelect: function(cell, item) {
     let { serieInstanceUID } = item;
@@ -137,7 +134,7 @@ const SeriesView = createReactClass({
         <Checkbox
           label=""
           onChange={this.handleSelect.bind(this, item)}
-          ref={this.handleRefs.bind(this, serieInstanceUID)}
+          inputRef={ref => this.refsClone[serieInstanceUID] = ref}
         />
       </div>
     );

--- a/dicoogle/src/main/resources/webapp/js/components/search/result/serieView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/serieView.js
@@ -126,6 +126,9 @@ const SeriesView = createReactClass({
     if (value) ResultSelectActions.select(item, serieInstanceUID);
     else ResultSelectActions.unSelect(item, serieInstanceUID);
   },
+  handleRefs: function(id, input) {	
+    this.refsClone[id] = input;	
+  },
   formatSelect: function(cell, item) {
     let { serieInstanceUID } = item;
     let classNameForIt = "advancedOptions " + serieInstanceUID;
@@ -134,7 +137,7 @@ const SeriesView = createReactClass({
         <Checkbox
           label=""
           onChange={this.handleSelect.bind(this, item)}
-          inputRef={ref => this.refsClone[serieInstanceUID] = ref}
+          inputRef={this.handleRefs.bind(this, serieInstanceUID)}
         />
       </div>
     );

--- a/dicoogle/src/main/resources/webapp/js/components/search/result/serieView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/serieView.js
@@ -121,13 +121,12 @@ const SeriesView = createReactClass({
 
   handleSelect(item) {
     let { serieInstanceUID } = item;
-    // ResultSelectActions.select(item);
     let value = this.refsClone[serieInstanceUID].checked;
     if (value) ResultSelectActions.select(item, serieInstanceUID);
     else ResultSelectActions.unSelect(item, serieInstanceUID);
   },
-  handleRefs: function(id, input) {	
-    this.refsClone[id] = input;	
+  handleRefs: function(id, input) {
+    this.refsClone[id] = input;
   },
   formatSelect: function(cell, item) {
     let { serieInstanceUID } = item;

--- a/dicoogle/src/main/resources/webapp/js/components/search/result/studyView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/studyView.js
@@ -113,12 +113,9 @@ const StudyView = createReactClass({
   handleSelect(item) {
     let { studyInstanceUID } = item;
     // ResultSelectActions.select(item);
-    let value = this.refsClone[studyInstanceUID].getChecked();
+    let value = this.refsClone[studyInstanceUID].checked;
     if (value) ResultSelectActions.select(item, studyInstanceUID);
     else ResultSelectActions.unSelect(item, studyInstanceUID);
-  },
-  handleRefs: function(id, input) {
-    this.refsClone[id] = input;
   },
   formatSelect: function(cell, item) {
     let { studyInstanceUID } = item;
@@ -128,7 +125,7 @@ const StudyView = createReactClass({
         <Checkbox
           label=""
           onChange={this.handleSelect.bind(this, item)}
-          ref={this.handleRefs.bind(this, studyInstanceUID)}
+          inputRef={ref => this.refsClone[studyInstanceUID] = ref}
         />
       </div>
     );

--- a/dicoogle/src/main/resources/webapp/js/components/search/result/studyView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/studyView.js
@@ -112,13 +112,12 @@ const StudyView = createReactClass({
   },
   handleSelect(item) {
     let { studyInstanceUID } = item;
-    // ResultSelectActions.select(item);
     let value = this.refsClone[studyInstanceUID].checked;
     if (value) ResultSelectActions.select(item, studyInstanceUID);
     else ResultSelectActions.unSelect(item, studyInstanceUID);
   },
-  handleRefs: function(id, input) {	
-    this.refsClone[id] = input;	
+  handleRefs: function(id, input) {
+    this.refsClone[id] = input;
   },
   formatSelect: function(cell, item) {
     let { studyInstanceUID } = item;

--- a/dicoogle/src/main/resources/webapp/js/components/search/result/studyView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/studyView.js
@@ -117,6 +117,9 @@ const StudyView = createReactClass({
     if (value) ResultSelectActions.select(item, studyInstanceUID);
     else ResultSelectActions.unSelect(item, studyInstanceUID);
   },
+  handleRefs: function(id, input) {	
+    this.refsClone[id] = input;	
+  },
   formatSelect: function(cell, item) {
     let { studyInstanceUID } = item;
     let classNameForIt = "advancedOptions " + studyInstanceUID;
@@ -125,7 +128,7 @@ const StudyView = createReactClass({
         <Checkbox
           label=""
           onChange={this.handleSelect.bind(this, item)}
-          inputRef={ref => this.refsClone[studyInstanceUID] = ref}
+          inputRef={this.handleRefs.bind(this, studyInstanceUID)}
         />
       </div>
     );

--- a/webcore/src/dicoogle-webcore.js
+++ b/webcore/src/dicoogle-webcore.js
@@ -100,17 +100,6 @@ export const init = m.init;
     event_hub.emit(name, ...args);
   }
 
-  /** Emit a DOM custom event from the slot element.
-   * @param {HTMLDicoogleSlotElement} slotDOM the slot DOM element to emit the event from
-   * @param {string} name the event name
-   * @param {any} data the data to be transmitted as custom event detail
-   * @return {void}
-   */
-  function emitSlotSignal(slotDOM, name, data) {
-    if (process.env.NODE_ENV !== 'production' && !check_initialized()) return;
-    slotDOM.dispatchEvent(new CustomEvent(name, {detail: data}));
-  }
-  
   /** Add an event listener to the webcore's event emitter.
    * @param {string} eventName the name of the event (can be one of 'load','loadMenu','loadQuery','loadResult', or custom event names)
    * @param {function(...any)} fn the listener function
@@ -122,6 +111,19 @@ export const init = m.init;
     return m;
   };
 export const addEventListener = m.addEventListener;
+
+  /** Emit a DOM custom event from the slot element.
+   * @param {HTMLDicoogleSlotElement} slotDOM the slot DOM element to emit the event from
+   * @param {string} name the event name
+   * @param {any} data the data to be transmitted as custom event detail
+   * @return {void}
+   */
+  m.emitSlotSignal = function(slotDOM, name, data) {
+    if (process.env.NODE_ENV !== 'production' && !check_initialized()) return;
+    slotDOM.dispatchEvent(new CustomEvent(name, {detail: data}));
+  }
+
+export const emitSlotSignal = m.emitSlotSignal;
   
   /** Remove an event listener from the webcore's event emitter.
    * @param {string} eventName the name of the event


### PR DESCRIPTION
Currently, the result-batch plugins are not able to receive the list of (patients,studies, series, images) to apply actions. 
Actually it fails before to try to emit the proper values. There are two fixes:
- Webcore: allow to emit signals 
- Patient,Study.. Images: properly get a list of images, was probably failing due to dependency updates such as react, react-bootstrap and all these related matters. 