### PR TITLE
Fix exportToCSV modal on webapp

### DIFF
--- a/dicoogle/src/main/resources/webapp/js/components/search/exportView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/exportView.js
@@ -2,7 +2,6 @@ import React from "react";
 import createReactClass from "create-react-class";
 import Select from "react-select";
 import {
-  Button,
   Modal,
   FormGroup,
   FormControl,
@@ -147,7 +146,7 @@ const ExportView = createReactClass({
             </div>
           </FormGroup>
         </Modal.Body>
-        <Modal.Footer id="hacked-modal-footer-do-not-remove">
+        <Modal.Footer id="hacked-modal-footer-do-not-remove" className="modal-dicoogle">
           <Form inline>
             <FormControl
               type="text"
@@ -157,20 +156,13 @@ const ExportView = createReactClass({
               maxLength="100"
             />
 
-            <Button
-              bsStyle="default"
-              onClick={this.handleSavePresetClicked}
-              disabled={!this.canExport()}
-            >
-              Save Preset
-            </Button>
-            <Button
-              bsStyle="primary"
-              onClick={this.handleExportClicked}
-              disabled={!this.canSave()}
-            >
+            <button className="btn btn_dicoogle btn-export" id="export-btn" onClick={this.handleExportClicked} disabled={!this.canSave()}>
               Export
-            </Button>
+            </button>
+
+            <button className="btn btn_dicoogle btn-export" id="save-preset-btn" onClick={this.handleSavePresetClicked} disabled={!this.canExport()}>
+              Save Preset
+            </button>
           </Form>
         </Modal.Footer>
         <ToastView

--- a/dicoogle/src/main/resources/webapp/js/components/search/exportView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/exportView.js
@@ -134,16 +134,14 @@ const ExportView = createReactClass({
           <FormGroup>
             <ControlLabel>Inline fields to export (optional):</ControlLabel>
 
-            <div className="modal-body">
-              <textarea
-                id="textFields"
-                placeholder="Paste export fields here (one per line)"
-                onChange={this.handleFieldSelectTextArea}
-                rows="10"
-                value={this.state.selectedFieldsAdditionals}
-                className="exportlist form-control"
-              />
-            </div>
+            <textarea
+              id="textFields"
+              placeholder="Paste export fields here (one per line)"
+              onChange={this.handleFieldSelectTextArea}
+              rows="10"
+              value={this.state.selectedFieldsAdditionals}
+              className="exportlist form-control"
+            />
           </FormGroup>
         </Modal.Body>
         <Modal.Footer id="hacked-modal-footer-do-not-remove" className="modal-dicoogle">

--- a/dicoogle/src/main/resources/webapp/sass/components/export.scss
+++ b/dicoogle/src/main/resources/webapp/sass/components/export.scss
@@ -2,3 +2,16 @@
   width: 100%;
   height: 400px;
 }
+
+.modal-dicoogle {
+  text-align: unset;
+  margin: auto 10px;
+}
+
+.btn-export {
+  float: right;
+
+  @media (max-width: 599px) {
+    margin-top: 5px;
+  }
+}


### PR DESCRIPTION
This PR fixes the Export to CSV modal issues.
The button styles were changed and now match the web app style. Mobile version is considered.
The input field to name the export preset was also fixed and the user can now change the name.

Before:
![Screenshot 2021-02-16 at 12 41 48](https://user-images.githubusercontent.com/8323694/108064293-5e80df80-7054-11eb-8556-eb8c7a121f06.png)

Now:
![now](https://user-images.githubusercontent.com/8323694/108063889-cd116d80-7053-11eb-8d8a-99e2c5e6c452.png)
