### PR TITLE
Fix StackOverflowError and users settings folder issues

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
@@ -522,7 +522,8 @@ public class PluginController {
 
 
     public JointQueryTask queryAll(JointQueryTask holder, final String query, final Object... parameters) {
-        return queryAll(holder, query, parameters);
+        List<String> providers = this.getQueryProvidersName(true);
+        return query(holder, providers, query, parameters);
     }
 
     public JointQueryTask queryAll(JointQueryTask holder, final String query, final DimLevel level,

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/users/UserExportPresets.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/users/UserExportPresets.java
@@ -50,7 +50,7 @@ public class UserExportPresets {
         Files.createDirectories(presetsDir);
 
         try (ObjectOutputStream out =
-                     new ObjectOutputStream(Files.newOutputStream(Paths.get(presetsDir.toString(), presetName)))) {
+                     new ObjectOutputStream(Files.newOutputStream(presetsDir.resolve(presetName)))) {
             out.writeObject(fields);
         } catch (IOException e) {
             logger.error("Could not save preset.", e.getMessage());

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/users/UserExportPresets.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/users/UserExportPresets.java
@@ -21,7 +21,6 @@ package pt.ua.dicoogle.server.users;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pt.ua.dicoogle.sdk.Utils.Platform;
-import pt.ua.dicoogle.server.web.DicoogleWeb;
 
 import java.io.*;
 import java.nio.file.*;

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/users/UserExportPresets.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/users/UserExportPresets.java
@@ -49,12 +49,7 @@ public class UserExportPresets {
 
         Files.createDirectories(presetsDir);
 
-        try (ObjectOutputStream out =
-                     new ObjectOutputStream(Files.newOutputStream(presetsDir.resolve(presetName)))) {
-            out.writeObject(fields);
-        } catch (IOException e) {
-            logger.error("Could not save preset.", e.getMessage());
-        }
+        Files.write(presetsDir.resolve(presetName), Arrays.asList(fields));
     }
 
     /**
@@ -74,15 +69,14 @@ public class UserExportPresets {
         }
 
         Stream<Path> fileList = Files.list(presetsDir);
-        fileList.filter(file -> !Files.isDirectory(file))
-                .forEach(file -> {
-                    try (ObjectInputStream in = new ObjectInputStream(Files.newInputStream(file))) {
-                        String[] preset = (String[]) in.readObject();
-                        presets.put(file.getFileName().toString(), preset);
-                    } catch (IOException | ClassNotFoundException e) {
-                        logger.error("Could not read preset.", e.getMessage());
-                    }
-                });
+        fileList.filter(file -> !Files.isDirectory(file)).forEach(file -> {
+            try {
+                String[] preset = Files.readAllLines(file).toArray(new String[0]);
+                presets.put(file.getFileName().toString(), preset);
+            } catch (IOException e) {
+                logger.error("Could not read preset.", e);
+            }
+        });
 
         return presets;
     }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/users/UserExportPresets.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/users/UserExportPresets.java
@@ -75,7 +75,7 @@ public class UserExportPresets {
                 String presetName = fileName.substring(0, fileName.lastIndexOf('.'));
                 presets.put(presetName, preset);
             } catch (IOException e) {
-                logger.error("Could not read preset.", e);
+                logger.error("Could not read preset from `{}`", file.getFileName(), e);
             }
         });
 

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/users/UserExportPresets.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/users/UserExportPresets.java
@@ -45,8 +45,8 @@ public class UserExportPresets {
      */
     public static void savePreset(String username, String presetName, String[] fields) throws IOException {
         Path presetsDir = Paths.get(Platform.homePath(), "userdata", username, "presets");
-
         Files.createDirectories(presetsDir);
+        presetName = presetName.endsWith(".txt") ? presetName : presetName.concat(".txt");
 
         Files.write(presetsDir.resolve(presetName), Arrays.asList(fields));
     }
@@ -71,7 +71,9 @@ public class UserExportPresets {
         fileList.filter(file -> !Files.isDirectory(file)).forEach(file -> {
             try {
                 String[] preset = Files.readAllLines(file).toArray(new String[0]);
-                presets.put(file.getFileName().toString(), preset);
+                String fileName = file.getFileName().toString();
+                String presetName = fileName.substring(0, fileName.lastIndexOf('.'));
+                presets.put(presetName, preset);
             } catch (IOException e) {
                 logger.error("Could not read preset.", e);
             }


### PR DESCRIPTION
This PR introduces fixes to two distinct bugs related to the ExportToCSV modal.
The export of the Search Result to a CSV is originating a StackOverflow exception in the PluginController. This is caused because the queryAll method is invoking itself infinitely. This was fixed by getting the list of providers and query each one.

The second part fixes the saving of presets into files. Changes introduced in #388 creates a file named "users" in the dicoogle folder. This name was used to organize and store preset data - was previously saved in users/<username>/presets/<presetname>. This PR changes the saving directory name to userdata/<username/presets/<presetname>. I also abolish the dependencies of apache StringUtils.