### PR TITLE
DICOM services - bring patches from 2.5.X releases to main stream 

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/DicomStorage.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/DicomStorage.java
@@ -101,7 +101,7 @@ public class DicomStorage extends StorageService {
         settings = ServerSettingsManager.getSettings();
 
         // Added default alternative AETitle.
-        // alternativeAETs.add(ServerSettingsManager.getSettings().getNodeName());
+        alternativeAETs.add(ServerSettingsManager.getSettings().getArchiveSettings().getNodeName());
 
         path = settings.getArchiveSettings().getMainDirectory();
         if (path == null) {
@@ -130,6 +130,10 @@ public class DicomStorage extends StorageService {
 
 
         this.nae.setInstalled(true);
+        this.nc.setMaxScpAssociations(Integer.parseInt(System.getProperty("dicoogle.cstore.maxScpAssociations", "50")));
+        this.nc.setAcceptTimeout(Integer.parseInt(System.getProperty("dicoogle.cstore.acceptTimeout", "5000")));
+        this.nc.setConnectTimeout(Integer.parseInt(System.getProperty("dicoogle.cstore.connectTimeout", "5000")));
+
         this.nae.setAssociationAcceptor(true);
         this.nae.setAssociationInitiator(false);
 
@@ -138,11 +142,16 @@ public class DicomStorage extends StorageService {
         int maxPDULengthSend = settings.getDicomServicesSettings().getQueryRetrieveSettings().getMaxPDULengthSend();
 
         ServerSettings s = ServerSettingsManager.getSettings();
-        this.nae.setDimseRspTimeout(60000 * 300);
-        this.nae.setIdleTimeout(60000 * 300);
-        this.nae.setMaxPDULengthReceive(maxPDULengthReceive + 1000);
-        this.nae.setMaxPDULengthSend(maxPDULengthSend + 1000);
-        this.nae.setRetrieveRspTimeout(60000 * 300);
+
+        this.nae.setDimseRspTimeout(
+                Integer.parseInt(System.getProperty("dicoogle.cstore.dimseRspTimeout", "18000000")));
+        this.nae.setIdleTimeout(Integer.parseInt(System.getProperty("dicoogle.cstore.idleTimeout", "18000000")));
+        this.nae.setMaxPDULengthReceive(
+                maxPDULengthReceive + Integer.parseInt(System.getProperty("dicoogle.cstore.appendMaxPDU", "1000")));
+        this.nae.setMaxPDULengthSend(
+                maxPDULengthSend + Integer.parseInt(System.getProperty("dicoogle.cstore.appendMaxPDU", "1000")));
+        this.nae.setRetrieveRspTimeout(
+                Integer.parseInt(System.getProperty("dicoogle.cstore.retrieveRspTimeout", "18000000")));
 
 
         // Added alternative AETitles.
@@ -156,11 +165,16 @@ public class DicomStorage extends StorageService {
         for (String alternativeAET : alternativeAETs) {
             NetworkApplicationEntity nae2 = new NetworkApplicationEntity();
             nae2.setNetworkConnection(nc);
-            nae2.setDimseRspTimeout(60000 * 300);
-            nae2.setIdleTimeout(60000 * 300);
-            nae2.setMaxPDULengthReceive(maxPDULengthReceive + 1000);
-            nae2.setMaxPDULengthSend(maxPDULengthSend + 1000);
-            nae2.setRetrieveRspTimeout(60000 * 300);
+            nae2.setDimseRspTimeout(
+                    Integer.parseInt(System.getProperty("dicoogle.cstore.dimseRspTimeout", "18000000")));
+            nae2.setIdleTimeout(Integer.parseInt(System.getProperty("dicoogle.cstore.idleTimeout", "18000000")));
+            nae2.setMaxPDULengthReceive(
+                    maxPDULengthReceive + Integer.parseInt(System.getProperty("dicoogle.cstore.appendMaxPDU", "1000")));
+            nae2.setMaxPDULengthSend(
+                    maxPDULengthSend + Integer.parseInt(System.getProperty("dicoogle.cstore.appendMaxPDU", "1000")));
+            nae2.setRetrieveRspTimeout(
+                    Integer.parseInt(System.getProperty("dicoogle.cstore.retrieveRspTimeout", "18000000")));
+
             // we accept assoociations, this is a server
             nae2.setAssociationAcceptor(true);
             // we support the VerificationServiceSOP

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/queryretrieve/CallDCMSend.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/queryretrieve/CallDCMSend.java
@@ -38,7 +38,7 @@ import pt.ua.dicoogle.sdk.StorageInterface;
  * @author Luís A. Bastião Silva <bastiao@ua.pt>
  */
 public class CallDCMSend {
-    private static final Logger logger = LoggerFactory.getLogger(CMoveServiceSCP.class);
+    private static final Logger logger = LoggerFactory.getLogger(CallDCMSend.class);
 
 
     public CallDCMSend(ArrayList<File> files, int port, String hostname, String AETitle, String cmoveID)

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/queryretrieve/CallDCMSend.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/queryretrieve/CallDCMSend.java
@@ -27,6 +27,8 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import org.dcm4che2.io.DicomInputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import pt.ua.dicoogle.plugins.PluginController;
 import pt.ua.dicoogle.sdk.StorageInputStream;
 import pt.ua.dicoogle.sdk.StorageInterface;
@@ -36,6 +38,8 @@ import pt.ua.dicoogle.sdk.StorageInterface;
  * @author Luís A. Bastião Silva <bastiao@ua.pt>
  */
 public class CallDCMSend {
+    private static final Logger logger = LoggerFactory.getLogger(CMoveServiceSCP.class);
+
 
     public CallDCMSend(ArrayList<File> files, int port, String hostname, String AETitle, String cmoveID)
             throws Exception {
@@ -49,17 +53,11 @@ public class CallDCMSend {
         for (File fx : files) {
             File f = fx;
             dcmsnd.addFile(f);
+
         }
         dcmsnd.setCalledAET(AETitle);
 
         dcmsnd.configureTransferCapability();
-        // try {
-        // dcmsnd.initTLS();
-        // } catch (Exception e) {
-        // System.err.println("ERROR: Failed to initialize TLS context:"
-        // + e.getMessage());
-        // System.exit(2);
-        // }
 
         dcmsnd.setMoveOriginatorMessageID(cmoveID);
         dcmsnd.start();
@@ -74,7 +72,6 @@ public class CallDCMSend {
 
         DcmSndV2 dcmsnd = new DcmSndV2();
 
-
         dcmsnd.setRemoteHost(hostname);
         dcmsnd.setRemotePort(port);
 
@@ -86,7 +83,7 @@ public class CallDCMSend {
 
 
             if (plugin != null) {
-                System.out.println("Retrieving: " + rui.toString());
+                logger.debug("Retrieving: {}", rui);
                 try {
                     System.out.println("Retrieving: " + rui.toString());
                     Iterable<StorageInputStream> it = plugin.at(rui);
@@ -94,28 +91,18 @@ public class CallDCMSend {
                     for (StorageInputStream iStream : it) {
                         byte[] byteArr = ByteStreams.toByteArray(new DicomInputStream(iStream.getInputStream()));
                         dcmsnd.addFile(ByteBuffer.wrap(byteArr));
-                        System.out.println("Added NewFile: " + rui.toString());
+                        logger.debug("Added NewFile: {}", rui);
                     }
 
-                    /*InputStream retrievedFile = plugin.retrieve(rui); 
-                    byte[] byteArr = ByteStreams.toByteArray(retrievedFile);
-                    dcmsnd.addFile(ByteBuffer.wrap(byteArr));
-                    System.out.println("Added NewFile: "+rui.toString());*/
                 } catch (IOException ex) {
                     ex.printStackTrace();
                 }
             }
+
         }
         dcmsnd.setCalledAET(AETitle);
 
         dcmsnd.configureTransferCapability();
-        // try {
-        // dcmsnd.initTLS();
-        // } catch (Exception e) {
-        // System.err.println("ERROR: Failed to initialize TLS context:"
-        // + e.getMessage());
-        // System.exit(2);
-        // }
 
         dcmsnd.setMoveOriginatorMessageID(cmoveID);
         dcmsnd.start();


### PR DESCRIPTION
Bringing two patches to the mainstream:

- Applying the allow to change DICOM C-STORE SCP parameters #446
- Improve logging of C-MOVE SCP to better troubleshoot potential issues. #452

