### PR TITLE
Use HTTPS URLs to Maven repositories

### DIFF
--- a/dicoogle/pom.xml
+++ b/dicoogle/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>dicoogle</artifactId>
     <packaging>jar</packaging>
     <name>dicoogle</name>
-    <url>http://www.dicoogle.com</url>
+    <url>https://www.dicoogle.com</url>
 
     <parent>
         <groupId>pt.ua.ieeta</groupId>
@@ -32,7 +32,7 @@
 
         <repository>
             <id>dcm4che</id>
-            <url>http://www.dcm4che.org/maven2/</url>
+            <url>https://www.dcm4che.org/maven2/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -40,7 +40,7 @@
 
         <repository>
             <id>mi</id>
-            <url>http://bioinformatics.ua.pt/maven/content/repositories/mi</url>
+            <url>https://bioinformatics.ua.pt/maven/content/repositories/mi</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -48,7 +48,7 @@
 
         <repository>
             <id>mi-snapshots</id>
-            <url>http://bioinformatics.ua.pt/maven/content/repositories/mi-snapshots</url>
+            <url>https://bioinformatics.ua.pt/maven/content/repositories/mi-snapshots</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -63,7 +63,7 @@
         <repository>
             <id>maven-restlet</id>
             <name>Public online Restlet repository</name>
-            <url>http://maven.restlet.org</url>
+            <url>https://maven.restlet.com</url>
         </repository>
 
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -89,13 +89,13 @@
                 <!-- Versioned releases are published to the releases repository -->
                 <repository>
                     <id>mi</id>
-                    <url>http://bioinformatics.ua.pt/maven/content/repositories/mi</url>
+                    <url>https://bioinformatics.ua.pt/maven/content/repositories/mi</url>
                 </repository>
 
                 <!-- Snapshot releases are published to the snapshots repository -->
                 <snapshotRepository>
                     <id>mi</id>
-                    <url>http://bioinformatics.ua.pt/maven/content/repositories/mi-snapshots</url>
+                    <url>https://bioinformatics.ua.pt/maven/content/repositories/mi-snapshots</url>
                 </snapshotRepository>
             </distributionManagement>
         </profile>

--- a/sdk-ext/pom.xml
+++ b/sdk-ext/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>dicoogle-sdk-ext</artifactId>
     <packaging>jar</packaging>
     <name>dicoogle-sdk-ext</name>
-    <url>http://www.dicoogle.com</url>
+    <url>https://www.dicoogle.com</url>
 
     <parent>
         <groupId>pt.ua.ieeta</groupId>
@@ -21,7 +21,7 @@
     <repositories>
         <repository>
             <id>mavencentral</id>
-            <url>http://repo1.maven.org/maven2/</url>
+            <url>https://repo1.maven.org/maven2/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -172,13 +172,13 @@
         <!-- Versioned releases are published to the releases repository -->
         <repository>
             <id>mi</id>
-            <url>http://bioinformatics.ua.pt/maven/content/repositories/mi</url>
+            <url>https://bioinformatics.ua.pt/maven/content/repositories/mi</url>
         </repository>
 
         <!-- Snapshot releases are published to the snapshots repository -->
         <snapshotRepository>
             <id>mi</id>
-            <url>http://bioinformatics.ua.pt/maven/content/repositories/mi-snapshots</url>
+            <url>https://bioinformatics.ua.pt/maven/content/repositories/mi-snapshots</url>
         </snapshotRepository>
     </distributionManagement>
 </project>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>dicoogle-sdk</artifactId>
     <packaging>jar</packaging>
     <name>dicoogle-sdk</name>
-    <url>http://www.dicoogle.com</url>
+    <url>https://www.dicoogle.com</url>
 
     <parent>
         <groupId>pt.ua.ieeta</groupId>
@@ -21,7 +21,7 @@
     <repositories>
         <repository>
             <id>mavencentral</id>
-            <url>http://repo1.maven.org/maven2/</url>
+            <url>https://repo1.maven.org/maven2/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -29,7 +29,7 @@
 
         <repository>
             <id>mi</id>
-            <url>http://bioinformatics.ua.pt/maven/content/repositories/mi</url>
+            <url>https://bioinformatics.ua.pt/maven/content/repositories/mi</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -38,12 +38,12 @@
         <repository>
             <id>maven-restlet</id>
             <name>Public online Restlet repository</name>
-            <url>http://maven.restlet.org</url>
+            <url>https://maven.restlet.com</url>
         </repository>
 
         <repository>
             <id>dcm4che</id>
-            <url>http://www.dcm4che.org/maven2/</url>
+            <url>https://www.dcm4che.org/maven2/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -234,13 +234,13 @@
         <!-- Versioned releases are published to the releases repository -->
         <repository>
             <id>mi</id>
-            <url>http://bioinformatics.ua.pt/maven/content/repositories/mi</url>
+            <url>https://bioinformatics.ua.pt/maven/content/repositories/mi</url>
         </repository>
 
         <!-- Snapshot releases are published to the snapshots repository -->
         <snapshotRepository>
             <id>mi</id>
-            <url>http://bioinformatics.ua.pt/maven/content/repositories/mi-snapshots</url>
+            <url>https://bioinformatics.ua.pt/maven/content/repositories/mi-snapshots</url>
         </snapshotRepository>
     </distributionManagement>
 </project>


### PR DESCRIPTION
- safer and appeases the security proxy on GH Actions
- also change URL to project