### PR TITLE
DicomStorage handling priority improvement

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/DicomStorage.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/DicomStorage.java
@@ -20,11 +20,9 @@ package pt.ua.dicoogle.server;
 
 import pt.ua.dicoogle.core.settings.ServerSettingsManager;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.util.*;
-import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -36,8 +34,6 @@ import org.dcm4che2.net.CommandUtils;
 import org.dcm4che2.net.Device;
 import org.dcm4che2.net.DicomServiceException;
 
-///import org.dcm4che2.net.Executor;
-/** dcm4che doesn't support Executor anymore, so now import from java.util */
 import org.slf4j.LoggerFactory;
 
 import org.dcm4che2.net.NetworkApplicationEntity;
@@ -53,7 +49,6 @@ import org.dcm4che2.net.service.VerificationService;
 import pt.ua.dicoogle.plugins.PluginController;
 import pt.ua.dicoogle.sdk.IndexerInterface;
 import pt.ua.dicoogle.sdk.StorageInterface;
-import pt.ua.dicoogle.sdk.datastructs.Report;
 import pt.ua.dicoogle.sdk.settings.server.ServerSettings;
 
 
@@ -75,10 +70,6 @@ public class DicomStorage extends StorageService {
     private NetworkConnection nc = new NetworkConnection();
 
     private String path;
-
-    private int threadPoolSize = 10;
-
-    private ExecutorService pool = Executors.newFixedThreadPool(threadPoolSize);
 
     private Set<String> alternativeAETs = new HashSet<>();
     private Set<String> priorityAETs = new HashSet<>();
@@ -142,8 +133,6 @@ public class DicomStorage extends StorageService {
         int maxPDULengthReceive =
                 settings.getDicomServicesSettings().getQueryRetrieveSettings().getMaxPDULengthReceive();
         int maxPDULengthSend = settings.getDicomServicesSettings().getQueryRetrieveSettings().getMaxPDULengthSend();
-
-        ServerSettings s = ServerSettingsManager.getSettings();
 
         this.nae.setDimseRspTimeout(
                 Integer.parseInt(System.getProperty("dicoogle.cstore.dimseRspTimeout", "18000000")));
@@ -364,7 +353,7 @@ public class DicomStorage extends StorageService {
                     // Fetch an element by the queue taking into account the priorities.
                     ImageElement element = queue.take();
                     URI exam = element.getUri();
-                    List<Report> reports = PluginController.getInstance().indexBlocking(exam);
+                    PluginController.getInstance().indexBlocking(exam);
                 } catch (InterruptedException ex) {
                     LoggerFactory.getLogger(DicomStorage.class).error("Could not take instance to index", ex);
                 }
@@ -374,93 +363,6 @@ public class DicomStorage extends StorageService {
         }
     }
 
-
-    private String getFullPath(DicomObject d) {
-
-        return getDirectory(d) + File.separator + getBaseName(d);
-
-    }
-
-
-    private String getFullPathCache(String dir, DicomObject d) {
-        return dir + File.separator + getBaseName(d);
-
-    }
-
-
-    private String getBaseName(DicomObject d) {
-        String result = "UNKNOWN.dcm";
-        String sopInstanceUID = d.getString(Tag.SOPInstanceUID);
-        return sopInstanceUID + ".dcm";
-    }
-
-
-    private String getDirectory(DicomObject d) {
-
-        String result = "UN";
-
-        String institutionName = d.getString(Tag.InstitutionName);
-        String modality = d.getString(Tag.Modality);
-        String studyDate = d.getString(Tag.StudyDate);
-        String accessionNumber = d.getString(Tag.AccessionNumber);
-        String studyInstanceUID = d.getString(Tag.StudyInstanceUID);
-        String patientName = d.getString(Tag.PatientName);
-
-        if (institutionName == null || institutionName.equals("")) {
-            institutionName = "UN_IN";
-        }
-        institutionName = institutionName.trim();
-        institutionName = institutionName.replace(" ", "");
-        institutionName = institutionName.replace(".", "");
-        institutionName = institutionName.replace("&", "");
-
-
-        if (modality == null || modality.equals("")) {
-            modality = "UN_MODALITY";
-        }
-
-        if (studyDate == null || studyDate.equals("")) {
-            studyDate = "UN_DATE";
-        } else {
-            try {
-                String year = studyDate.substring(0, 4);
-                String month = studyDate.substring(4, 6);
-                String day = studyDate.substring(6, 8);
-
-                studyDate = year + File.separator + month + File.separator + day;
-
-            } catch (Exception e) {
-                e.printStackTrace();
-                studyDate = "UN_DATE";
-            }
-        }
-
-        if (accessionNumber == null || accessionNumber.equals("")) {
-            patientName = patientName.trim();
-            patientName = patientName.replace(" ", "");
-            patientName = patientName.replace(".", "");
-            patientName = patientName.replace("&", "");
-
-            if (patientName == null || patientName.equals("")) {
-                if (studyInstanceUID == null || studyInstanceUID.equals("")) {
-                    accessionNumber = "UN_ACC";
-                } else {
-                    accessionNumber = studyInstanceUID;
-                }
-            } else {
-                accessionNumber = patientName;
-
-            }
-
-        }
-
-        result = path + File.separator + institutionName + File.separator + modality + File.separator + studyDate
-                + File.separator + accessionNumber;
-
-        return result;
-
-    }
-
     private Indexer indexer = new Indexer();
 
     /*
@@ -468,26 +370,14 @@ public class DicomStorage extends StorageService {
      * @throws java.io.IOException
      */
     public void start() throws IOException {
-        // dirc = new DicomDirCreator(path, "Dicoogle");
-        pool = Executors.newFixedThreadPool(threadPoolSize);
         device.startListening(executor);
         indexer.start();
-
-
     }
 
     /**
      * Stop the storage service 
      */
     public void stop() {
-        this.pool.shutdown();
-        try {
-            pool.awaitTermination(6, TimeUnit.DAYS);
-        } catch (InterruptedException ex) {
-            LoggerFactory.getLogger(DicomStorage.class).error(ex.getMessage(), ex);
-        }
         device.stopListening();
-
-        // dirc.dicomdir_close();
     }
 }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/DicomStorage.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/DicomStorage.java
@@ -111,7 +111,7 @@ public class DicomStorage extends StorageService {
         }
 
         this.priorityAETs = new HashSet<>(settings.getDicomServicesSettings().getPriorityAETitles());
-        LoggerFactory.getLogger(DicomStorage.class).debug("Priority C-STORE: " + this.priorityAETs);
+        LoggerFactory.getLogger(DicomStorage.class).debug("Priority C-STORE: {}", this.priorityAETs);
 
         device.setNetworkApplicationEntity(nae);
 
@@ -258,7 +258,7 @@ public class DicomStorage extends StorageService {
 
         if (!permited) {
             // DebugManager.getSettings().debug("Client association NOT permited: " + as.getCallingAET() + "!");
-            System.err.println("Client association NOT permited: " + as.getCallingAET() + "!");
+            LoggerFactory.getLogger(DicomStorage.class).warn("Client association with {} NOT permitted!", as.getCallingAET());
             as.abort();
 
             return;


### PR DESCRIPTION
This PR provides several enhancements to the archive's DICOM storage implementation, the major one being a better criteria when entry fetching for indexing.

The problem with the old algorithm is that it was not anti-symmetrical (`a < b` did not necessarily mean that `!(b < a)`), which could bring odd outcomes and starve other entries. Instead, the comparison function was rewritten to have two criteria, in this order:

- whether the calling AE title is listed as a priority AE title;
- the earliest sequence number, counted by the DicomStorage instance.

Also other changes:

- remove unused things, such as old methods and variable declarations
   - While there may be interest in bringing back the thread pool eventually, we should not allocate resources which are never used, much less threads.
 - refactor log lines