### PR TITLE
RSIStorage (DicomStorage) file handling priority improvements

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/RSIStorage.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/RSIStorage.java
@@ -120,7 +120,7 @@ public class RSIStorage extends StorageService
             }
 
             this.priorityAETs = settings.getPriorityAETitles();
-            LoggerFactory.getLogger(RSIStorage.class).debug("Priority C-STORE: " + this.priorityAETs);
+            LoggerFactory.getLogger(RSIStorage.class).debug("Priority C-STORE: {}", this.priorityAETs);
 
             device.setNetworkApplicationEntity(nae);
 
@@ -264,8 +264,8 @@ public class RSIStorage extends StorageService
         }
 
         if (!permited) {
-            //DebugManager.getInstance().debug("Client association NOT permited: " + as.getCallingAET() + "!");
-            System.err.println("Client association NOT permited: " + as.getCallingAET() + "!");
+            // DebugManager.getSettings().debug("Client association NOT permited: " + as.getCallingAET() + "!");
+            LoggerFactory.getLogger(RSIStorage.class).warn("Client association with {} NOT permitted!", as.getCallingAET());
             as.abort();
             
             return;
@@ -378,7 +378,7 @@ public class RSIStorage extends StorageService
                     URI exam = element.getUri();
                     List <Report> reports = PluginController.getInstance().indexBlocking(exam);
                 } catch (InterruptedException ex) {
-                    LoggerFactory.getLogger(DicomStorage.class).error("Could not take instance to index", ex);
+                    LoggerFactory.getLogger(RSIStorage.class).error("Could not take instance to index", ex);
                 }
                  
             }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/RSIStorage.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/RSIStorage.java
@@ -27,6 +27,7 @@ import java.net.URI;
 import java.util.*;
 import java.util.List;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.dcm4che2.data.DicomObject;
 import org.dcm4che2.data.Tag;
@@ -89,8 +90,10 @@ public class RSIStorage extends StorageService
     private Set<String> priorityAETs = new HashSet<>();
 
     // Changed to support priority queue.
-    private BlockingQueue<ImageElement> queue = new PriorityBlockingQueue<ImageElement>();
+    private BlockingQueue<ImageElement> queue = new PriorityBlockingQueue<>();
     private NetworkApplicationEntity[] naeArr = null;
+    private AtomicLong seqNum = new AtomicLong(0L);
+
     
     /**
      * 
@@ -294,15 +297,11 @@ public class RSIStorage extends StorageService
             
             Iterable <StorageInterface> plugins = PluginController.getInstance().getStoragePlugins(true);
 
-            URI uri = null;
-            for (StorageInterface storage : plugins)
-            {
-                uri = storage.store(d);
-                if(uri != null) {
-                    // queue to index
-                    ImageElement element = new ImageElement();
-                    element.setCallingAET(as.getCallingAET());
-                    element.setUri(uri);
+            for (StorageInterface storage : plugins) {
+                URI uri = storage.store(d);
+                if (uri != null) {
+                    // enqueue to index
+                    ImageElement element = new ImageElement(uri, as.getCallingAET(), seqNum.getAndIncrement());
                     queue.add(element);
                 }
             }
@@ -313,41 +312,53 @@ public class RSIStorage extends StorageService
     }
 
     /**
-     * ImageElement is a entry of a C-STORE. For Each C-STORE RQ
-     * an ImageElement is created and are put in the queue to index.
+     * A C-STORE entry.
+     * For Each C-STORE RQ, an ImageElement is created
+     * and put in the storage service's priority queue for indexing.
+     * 
+     * The priority criteria are, in descending order of importance:
+     * 1. whether the calling AE title is in the list of priority AEs
+     * 2. earliest sequence number
      *
      * This only happens after the store in Storage Plugins.
-     *
-     * @param <E>
      */
-    class ImageElement<E extends Comparable<? super E>>
-            implements Comparable<ImageElement<E>>{
-        private URI uri;
-        private String callingAET;
+    final class ImageElement implements Comparable<ImageElement> {
+        private final URI uri;
+        private final String callingAET;
+        private final long seqNumber;
+
+        ImageElement(URI uri, String callingAET, long seqNumber) {
+            Objects.requireNonNull(uri);
+            Objects.requireNonNull(callingAET);
+            this.uri = uri;
+            this.callingAET = callingAET;
+            this.seqNumber = seqNumber;
+        }
 
         public URI getUri() {
             return uri;
-        }
-
-        public void setUri(URI uri) {
-            this.uri = uri;
         }
 
         public String getCallingAET() {
             return callingAET;
         }
 
-        public void setCallingAET(String callingAET) {
-            this.callingAET = callingAET;
+        public long getSequenceNumber() {
+            return seqNumber;
         }
 
         @Override
-        public int compareTo(ImageElement<E> o1) {
-            if (o1.getCallingAET().equals(this.getCallingAET()))
-                return 0 ;
-            else if (settings.getPriorityAETitles().contains(this.getCallingAET()))
-                return -1;
-            else return 1;
+        public int compareTo(ImageElement other) {
+            boolean thisPriority = priorityAETs.contains(this.getCallingAET());
+            boolean thatPriority = priorityAETs.contains(other.getCallingAET());
+
+            int priorityOrder = Boolean.compare(thisPriority, thatPriority);
+
+            if (priorityOrder != 0) {
+                return priorityOrder;
+            }
+
+            return Long.compare(this.seqNumber, other.seqNumber);
         }
     }
 
@@ -365,12 +376,9 @@ public class RSIStorage extends StorageService
                     // Fetch an element by the queue taking into account the priorities.
                     ImageElement element = queue.take();
                     URI exam = element.getUri();
-                    if(exam != null)
-                    {
-                        List <Report> reports = PluginController.getInstance().indexBlocking(exam);
-                    }
+                    List <Report> reports = PluginController.getInstance().indexBlocking(exam);
                 } catch (InterruptedException ex) {
-                    LoggerFactory.getLogger(RSIStorage.class).error(ex.getMessage(), ex);
+                    LoggerFactory.getLogger(DicomStorage.class).error("Could not take instance to index", ex);
                 }
                  
             }


### PR DESCRIPTION
This is a rebased version of #468 for Dicoogle 2. 

> The problem with the old algorithm is that it was not anti-symmetrical (a < b did not necessarily mean that !(b < a)), which could bring odd outcomes and starve other entries. Instead, the comparison function was rewritten to have two criteria, in this order:
> 
> - whether the calling AE title is listed as a priority AE title;
> - the earliest sequence number, counted by the DicomStorage instance.
> 
> Also other changes:
> 
> - remove unused things, such as old methods and variable declarations
> - While there may be interest in bringing back the thread pool eventually, we should not allocate resources which are never used, much less threads.
> - refactor log lines
