### PR TITLE
Fix requesting for web UI plugins by slot

### DIFF
--- a/webcore/src/dicoogle-webcore.js
+++ b/webcore/src/dicoogle-webcore.js
@@ -239,14 +239,11 @@ export const updateSlot = m.updateSlot;
   m.fetchPlugins = function (slotIds, callback) {
     if (process.env.NODE_ENV !== 'production' && !check_initialized()) return;
     console.log('Fetching Dicoogle web UI plugin descriptors ...');
-    slotIds = [].concat(slotIds);
-    let uri = 'webui';
-    service_get(uri, {'slot-id': slotIds}, function(error, data) {
+    Dicoogle.getWebUIPlugins(slotIds, function(error, packageArray) {
       if (error) {
         console.error('Failed to fetch plugin descriptors:' , error);
         return;
       }
-      var packageArray = data.plugins;
       for (let i = 0; i < packageArray.length; i++) {
         if (!packages[packageArray[i].name]) {
           packages[packageArray[i].name] = packageArray[i];
@@ -296,13 +293,12 @@ export const fetchModules = m.fetchModules;
     options.query = query;
     let requestTime = new Date();
     let queryService = options.overrideService || 'search';
-    service_get(queryService, options, function (error, data) {
-      if (error) {
-        if (callback) callback(error, null);
-        return;
-      }
+    
+    Dicoogle.request(queryService, options).then((data) => {
       dispatch_result(data, requestTime, options);
       if (callback) callback(null, data);
+    }, (error) => {
+      callback && callback(error);
     });
   }
   
@@ -473,20 +469,7 @@ export const webUISlot = m.webUISlot;
     }
     event_hub.emit('result', result, requestTime, options);
   }
-  
-  /**
-   * Send a GET request to a Dicoogle service.
-   *
-   * @param {string} uri the request URI in string or array form
-   * @param {string} qs an object containing query string parameters (or a QS without '?')
-   * @param {function(error, outcome)} callback a callback function
-   * @return {void}
-   */
-  function service_get(uri, qs, callback) {
-    // issue request
-    Dicoogle.request('GET', uri, qs).then((x) => callback(null, x.body), callback);
-  }
-  
+    
   function getScript(moduleName, callback) {
     let script = document.createElement('script');
     let prior = document.getElementsByTagName('script')[0];


### PR DESCRIPTION
In a permissive setting, webcore would fetch all plugins regardless of type, causing instability in the process.

For testing, consider enabling the `webui.permissive` JVM variable (`-Dwebui.permissive=1`), so that all web UI plugins appear regardless of RBAC policies.

- remove service_get, replace all uses
   - fetchPlugins can use getWebUIPlugins instead
   - use Dicoogle.request directly on issueSearch