### PR TITLE
Build webapp on Maven execution

### DIFF
--- a/dicoogle/pom.xml
+++ b/dicoogle/pom.xml
@@ -244,7 +244,7 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.7.5</version>
+                <version>1.12.0</version>
                 <executions>
                     <!-- Install Node and NPM -->
                     <execution>
@@ -254,7 +254,7 @@
                         </goals>
                         <phase>generate-resources</phase>
                     </execution>
-                    <!-- install dependencies and build for webapp for production-->
+                    <!-- install dependencies -->
                     <execution>
                         <id>npm install</id>
                         <goals>
@@ -264,14 +264,27 @@
                         <phase>generate-resources</phase>
 
                         <configuration>
-                            <arguments>install</arguments>
+                            <arguments>install --no-audit</arguments>
+                        </configuration>
+                    </execution>
+                    <!-- build webapp for production-->
+                    <execution>
+                        <id>npm run build</id>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+
+                        <phase>generate-resources</phase>
+
+                        <configuration>
+                            <arguments>run build</arguments>
                         </configuration>
                     </execution>
 
                 </executions>
                 <configuration>
-                    <nodeVersion>v12.16.1</nodeVersion>
-                    <npmVersion>6.11.3</npmVersion>
+                    <nodeVersion>v14.17.3</nodeVersion>
+                    <npmVersion>6.14.13</npmVersion>
                     <installDirectory>target</installDirectory>
                     <!-- Defining webapp directory -->
                     <workingDirectory>src/main/resources/webapp</workingDirectory>


### PR DESCRIPTION
With the current setup, `npm install` does not build the webapp automatically.

- Add npm run build execution step to frontend-maven-plugin
- Update frontend-maven-plugin to latest version
- Update Node.js and npm to latest LTS

Should hopefully resolve some of the recent issues encountered while building Dicoogle 3.