### PR TITLE
Modified search result onChanged binds to be regular w/ event stop propagation.

### DIFF
--- a/dicoogle/src/main/resources/webapp/js/components/search/result/imageView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/imageView.js
@@ -112,7 +112,10 @@ const ImageView = React.createClass({
       return (<div></div>);
   },
 
-    handleSelect(item){
+    handleSelect(item, event){
+
+        event.stopPropagation();
+
         let {sopInstanceUID} = item;
         // ResultSelectActions.select(item);
         let value = this.refsClone[sopInstanceUID].getChecked();
@@ -131,7 +134,7 @@ const ImageView = React.createClass({
     let classNameForIt = "advancedOptions " + sopInstanceUID;
     return (<div className={classNameForIt}>
               <Input type="checkbox" label=""
-                    onChange={this.handleSelect.bind(this, item)}
+                     onChange={(e) => this.handleSelect(item, e)}
                     ref={this.handleRefs.bind(this, sopInstanceUID)}/>
             </div>
     );

--- a/dicoogle/src/main/resources/webapp/js/components/search/result/patientView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/patientView.js
@@ -95,8 +95,11 @@ const PatientView = React.createClass({
           return (<div></div>);
 
   },
-  handleSelect(item){
-      let {id} = item;
+      handleSelect(item, event){
+
+          event.stopPropagation();
+
+          let {id} = item;
      // ResultSelectActions.select(item);
       let value = this.refsClone[id].getChecked();
       if (value)
@@ -114,7 +117,7 @@ const PatientView = React.createClass({
     let classNameForIt = "advancedOptions " + id;
     return (<div className={classNameForIt}>
               <Input type="checkbox" label=""
-                    onChange={this.handleSelect.bind(this, item)}
+                     onChange={(e) => this.handleSelect(item, e)}
                     ref={this.handleRefs.bind(this, id)}/>
             </div>
     );

--- a/dicoogle/src/main/resources/webapp/js/components/search/result/serieView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/serieView.js
@@ -93,7 +93,9 @@ const SeriesView = React.createClass({
       return (<div></div>);
   },
 
-  handleSelect(item){
+  handleSelect(item, event){
+
+    event.stopPropagation();
 
     let {serieInstanceUID} = item;
     // ResultSelectActions.select(item);
@@ -112,7 +114,7 @@ const SeriesView = React.createClass({
     let classNameForIt = "advancedOptions " + serieInstanceUID;
     return (<div className={classNameForIt}>
               <Input type="checkbox" label=""
-                    onChange={this.handleSelect.bind(this, item)}
+                    onChange={(e) => this.handleSelect(item, e)}
                     ref={this.handleRefs.bind(this, serieInstanceUID)}/>
             </div>
     );

--- a/dicoogle/src/main/resources/webapp/js/components/search/result/studyView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/studyView.js
@@ -85,7 +85,10 @@ const StudyView = React.createClass({
       }
       return (<div></div>);
   },
-    handleSelect(item){
+    handleSelect(item, event){
+
+        event.stopPropagation();
+
         let {studyInstanceUID} = item;
         // ResultSelectActions.select(item);
         let value = this.refsClone[studyInstanceUID].getChecked();
@@ -104,7 +107,7 @@ const StudyView = React.createClass({
     let classNameForIt = "advancedOptions " + studyInstanceUID;
     return (<div className={classNameForIt}>
               <Input type="checkbox" label=""
-                    onChange={this.handleSelect.bind(this, item)}
+                     onChange={(e) => this.handleSelect(item, e)}
                     ref={this.handleRefs.bind(this, studyInstanceUID)}/>
             </div>
     );


### PR DESCRIPTION
Modifies `onChanged` behavior to resolve webmove plugin's current issue of receiving duplicate data.

## Description
Dicoogle has `handleSelect` methods for its search result views wherein these are bound to the `onChanged` event. What would happen is that these methods would be triggered when clicking the checkbox **and** immediately after in a rerendering of the page after the click, which would add duplicated entries in the data to be moved. 

This PR modifies the binds to be regular method usage, and includes the addition of a parameter for the event to run the `stopPropagation()` method, resolving the duplicated method call.