### PR TITLE
[Dicoogle3] Fix DICOM storage priority by AE title

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/DicomStorage.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/DicomStorage.java
@@ -330,19 +330,37 @@ public class DicomStorage extends StorageService {
 
         @Override
         public int compareTo(ImageElement other) {
-            boolean thisPriority = priorityAETs.contains(this.getCallingAET());
-            boolean thatPriority = priorityAETs.contains(other.getCallingAET());
-
-            int priorityOrder = Boolean.compare(thisPriority, thatPriority);
-
-            if (priorityOrder != 0) {
-                return priorityOrder;
-            }
-
-            return Long.compare(this.seqNumber, other.seqNumber);
+            return compareElementsImpl(DicomStorage.this.priorityAETs, this.callingAET, this.seqNumber,
+                    other.callingAET, other.seqNumber);
         }
     }
 
+    /** Standalone implementation of image element sorting criteria.
+     * 
+     * @param priorityAETs the set of calling AE titles
+     * from which incoming images have a HIGHER priority
+     * @param thisAETitle this image's AE title
+     * @param thisSeqNumber this image's sequence number
+     * @param otherAETitle the other image's AE title
+     * @param otherSeqNumber the other image's sequence number
+     * @return a number < 0 if this image has a higher priority than the other,
+     * > 0 if the other image has a higher priority
+     * (=0 should not happen because sequence numbers are unique)
+     * @see {@link ImageElement#compareTo(ImageElement)}
+     */
+    static int compareElementsImpl(Set<String> priorityAETs, String thisAETitle, long thisSeqNumber,
+            String otherAETitle, long otherSeqNumber) {
+        boolean thisPriority = priorityAETs.contains(thisAETitle);
+        boolean thatPriority = priorityAETs.contains(otherAETitle);
+
+        int priorityOrder = Boolean.compare(thisPriority, thatPriority);
+
+        if (priorityOrder != 0) {
+            return -priorityOrder;
+        }
+
+        return Long.compare(thisSeqNumber, otherSeqNumber);
+    }
 
     class Indexer extends Thread {
         public Collection<IndexerInterface> plugins;

--- a/dicoogle/src/test/java/pt/ua/dicoogle/server/DicomStorageTest.java
+++ b/dicoogle/src/test/java/pt/ua/dicoogle/server/DicomStorageTest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2014  Universidade de Aveiro, DETI/IEETA, Bioinformatics Group - http://bioinformatics.ua.pt/
+ *
+ * This file is part of Dicoogle/dicoogle.
+ *
+ * Dicoogle/dicoogle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Dicoogle/dicoogle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Dicoogle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pt.ua.dicoogle.server;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+public class DicomStorageTest {
+    final Set<String> priorityAETs = new HashSet<>(Arrays.asList("IMPORTANT AE 1", "IMPORTANT AE 2"));
+
+    private void assertPriorityOrderAsc(String aet1, long seq1, String aet2, long seq2) {
+        int order = DicomStorage.compareElementsImpl(priorityAETs, aet1, seq1, aet2, seq2);
+
+        assertTrue(String.format("Expected comparison (%s, %d)-(%s, %d) to be <0, but got %d", aet1, seq1, aet2, seq2,
+                order), order < 0);
+    }
+
+    @Test
+    public void testImageElementPriority() {
+
+        assertPriorityOrderAsc("AE01", 3, "AE02", 4);
+
+        assertPriorityOrderAsc("IMPORTANT AE 1", 0, "AE01", 200);
+
+        assertPriorityOrderAsc("IMPORTANT AE 1", 5000, "AE01", 2);
+
+        assertPriorityOrderAsc("IMPORTANT AE 1", 4, "IMPORTANT AE 2", 40);
+
+    }
+}


### PR DESCRIPTION
- invert order for priority AE title
   - its presence should represent a HIGHER priority rather than a lower one
- move priority implementation to static method so it does not depend on a storage service instance
- add test to prove that this bug was fixed