### PR TITLE
Make the DICOM Storage SCP indexing queue to be asynchronous 

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
@@ -83,7 +83,7 @@ public class PluginController{
     private final WebUIPluginManager webUI;
     private final DicooglePlatformProxy proxy;
     private TaskManager taskManager = new TaskManager(Integer.parseInt(System.getProperty("dicoogle.taskManager.nThreads", "4")));
-    private TaskManager taskManagerQueries = new TaskManager(Integer.parseInt(System.getProperty("dicoogle.taskManager.nThreads", "4")));
+    private TaskManager taskManagerQueries = new TaskManager(Integer.parseInt(System.getProperty("dicoogle.taskManager.nQueryThreads", "4")));
 
     public PluginController(File pathToPluginDirectory) {
     	logger.info("Creating PluginController Instance");

--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
@@ -83,7 +83,8 @@ public class PluginController{
     private final WebUIPluginManager webUI;
     private final DicooglePlatformProxy proxy;
     private TaskManager taskManager = new TaskManager(Integer.parseInt(System.getProperty("dicoogle.taskManager.nThreads", "4")));
-    
+    private TaskManager taskManagerQueries = new TaskManager(Integer.parseInt(System.getProperty("dicoogle.taskManager.nThreads", "4")));
+
     public PluginController(File pathToPluginDirectory) {
     	logger.info("Creating PluginController Instance");
         pluginFolder = pathToPluginDirectory;
@@ -450,7 +451,7 @@ public class PluginController{
     
     public Task<Iterable<SearchResult>> query(String querySource, final String query, final Object ... parameters){
         Task<Iterable<SearchResult>> t = getTaskForQuery(querySource, query, parameters);       
-        taskManager.dispatch(t);
+        taskManagerQueries.dispatch(t);
         //logger.info("Fired Query Task: "+querySource +" QueryString:"+query);
         
         return t;//returns the handler to obtain the computation results
@@ -469,7 +470,7 @@ public class PluginController{
 
         //and executes said task asynchronously
         for(Task<?> t : tasks)
-        	taskManager.dispatch(t);
+            taskManagerQueries.dispatch(t);
 
         //logger.info("Fired Query Tasks: "+Arrays.toString(querySources.toArray()) +" QueryString:"+query);
         return holder;//returns the handler to obtain the computation results

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/RSIStorage.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/RSIStorage.java
@@ -377,7 +377,7 @@ public class RSIStorage extends StorageService
                     // Fetch an element by the queue taking into account the priorities.
                     ImageElement element = queue.take();
                     URI exam = element.getUri();
-                    PluginController.getInstance().indexBlocking(exam);
+                    PluginController.getInstance().index(exam);
                 } catch (InterruptedException ex) {
                     LoggerFactory.getLogger(RSIStorage.class).error("Could not take instance to index", ex);
                 }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/RSIStorage.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/RSIStorage.java
@@ -76,8 +76,8 @@ public class RSIStorage extends StorageService
     private BlockingQueue<ImageElement> queue = new PriorityBlockingQueue<>();
     private NetworkApplicationEntity[] naeArr = null;
     private AtomicLong seqNum = new AtomicLong(0L);
+    private static boolean ENABLED_ASYNC_INDEX = Boolean.valueOf(System.getProperty("dicoogle.index.async", "true"));
 
-    
     /**
      * 
      * @param Services List of supported SOP Classes
@@ -377,7 +377,10 @@ public class RSIStorage extends StorageService
                     // Fetch an element by the queue taking into account the priorities.
                     ImageElement element = queue.take();
                     URI exam = element.getUri();
-                    PluginController.getInstance().index(exam);
+                    if (ENABLED_ASYNC_INDEX)
+                        PluginController.getInstance().index(exam);
+                    else
+                        PluginController.getInstance().indexBlocking(exam);
                 } catch (InterruptedException ex) {
                     LoggerFactory.getLogger(RSIStorage.class).error("Could not take instance to index", ex);
                 }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/RSIStorage.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/RSIStorage.java
@@ -76,7 +76,7 @@ public class RSIStorage extends StorageService
     private BlockingQueue<ImageElement> queue = new PriorityBlockingQueue<>();
     private NetworkApplicationEntity[] naeArr = null;
     private AtomicLong seqNum = new AtomicLong(0L);
-    private static boolean ENABLED_ASYNC_INDEX = Boolean.valueOf(System.getProperty("dicoogle.index.async", "true"));
+    private static boolean ASYNC_INDEX = Boolean.valueOf(System.getProperty("dicoogle.index.async", "true"));
 
     /**
      * 
@@ -377,7 +377,7 @@ public class RSIStorage extends StorageService
                     // Fetch an element by the queue taking into account the priorities.
                     ImageElement element = queue.take();
                     URI exam = element.getUri();
-                    if (ENABLED_ASYNC_INDEX)
+                    if (ASYNC_INDEX)
                         PluginController.getInstance().index(exam);
                     else
                         PluginController.getInstance().indexBlocking(exam);


### PR DESCRIPTION
Make the DICOM Storage SCP indexing queue to be asynchronous.
As a consequence, a new task manager instance was created for query to avoid overload of index tasks, and avoid starvation of query tasks.