### PR TITLE
[Dicoogle2] Fix config.xml not being saved properly

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/core/XMLSupport.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/core/XMLSupport.java
@@ -1069,12 +1069,10 @@ public class XMLSupport extends DefaultHandler
     
     public void printXML()
     {
-        FileOutputStream out = null;
         list.CleanList();
-        try {
-            out = new FileOutputStream(Platform.homePath() + "config.xml");
-            PrintWriter pw = new PrintWriter(out);
-            StreamResult streamResult = new StreamResult(pw);
+        
+        try (BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(Platform.homePath() + "config.xml"))) {
+            StreamResult streamResult = new StreamResult(out);
             SAXTransformerFactory tf = (SAXTransformerFactory) TransformerFactory.newInstance();
             //      SAX2.0 ContentHandler.
             TransformerHandler hd = tf.newTransformerHandler();
@@ -1655,18 +1653,8 @@ public class XMLSupport extends DefaultHandler
             
             hd.endDocument();
                         
-        } catch (TransformerConfigurationException ex) {
-            
-        } catch (SAXException ex) {
-            
-        } catch (FileNotFoundException ex) {
-            
-        } finally {
-            try {
-                out.close();
-            } catch (IOException ex) {
-                
-            }
+        } catch (TransformerConfigurationException|SAXException|IOException ex) {
+            logger.error("An error occurred while printing XML server settings", ex);  
         }
    }
 }


### PR DESCRIPTION
This resolves a long running bug which is no longer a problem in Dicoogle 3, but is annoying enough that it might merit this final patch. We'll see it if works OK like this, otherwise the plan is not to invest too much effort.

- replace `PrintWriter` with `BufferedOutputStream`
- use try-with to ensure the resources are closed at the right level
- log any errors that emerge