### PR TITLE
Make the DICOM Storage SCP indexing queue to be asynchronous and independent task manager for queries (v3)

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
@@ -82,8 +82,13 @@ public class PluginController {
     private PluginSet remoteQueryPlugins = null;
     private final WebUIPluginManager webUI;
     private final DicooglePlatformProxy proxy;
+    // Task manager for index processes
     private TaskManager taskManager =
             new TaskManager(Integer.parseInt(System.getProperty("dicoogle.taskManager.nThreads", "4")));
+    // Task Managers for Queries
+    private TaskManager taskManagerQueries =
+            new TaskManager(Integer.parseInt(System.getProperty("dicoogle.taskManager.nQueryThreads", "4")));
+
 
     public PluginController(File pathToPluginDirectory) {
         logger.info("Creating PluginController Instance");
@@ -522,7 +527,7 @@ public class PluginController {
 
     public Task<Iterable<SearchResult>> query(String querySource, final String query, final Object... parameters) {
         Task<Iterable<SearchResult>> t = getTaskForQuery(querySource, query, parameters);
-        taskManager.dispatch(t);
+        taskManagerQueries.dispatch(t);
         return t;
 
     }
@@ -531,7 +536,7 @@ public class PluginController {
     public Task<Iterable<SearchResult>> query(String querySource, final String query, final DimLevel level,
             final Object... parameters) {
         Task<Iterable<SearchResult>> t = getTaskForQueryDim(querySource, query, level, parameters);
-        taskManager.dispatch(t);
+        taskManagerQueries.dispatch(t);
         // logger.info("Fired Query Task: "+querySource +" QueryString:"+query);
 
         return t;// returns the handler to obtain the computation results
@@ -551,7 +556,7 @@ public class PluginController {
 
         // and executes said task asynchronously
         for (Task<?> t : tasks)
-            taskManager.dispatch(t);
+            taskManagerQueries.dispatch(t);
 
         // logger.info("Fired Query Tasks: "+Arrays.toString(querySources.toArray()) +" QueryString:"+query);
         return holder;// returns the handler to obtain the computation results
@@ -571,7 +576,7 @@ public class PluginController {
 
         // and executes said task asynchronously
         for (Task<?> t : tasks)
-            taskManager.dispatch(t);
+            taskManagerQueries.dispatch(t);
 
         // logger.info("Fired Query Tasks: "+Arrays.toString(querySources.toArray()) +" QueryString:"+query);
         return holder;// returns the handler to obtain the computation results

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/DicomStorage.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/DicomStorage.java
@@ -78,6 +78,7 @@ public class DicomStorage extends StorageService {
     private BlockingQueue<ImageElement> queue = new PriorityBlockingQueue<>();
     private NetworkApplicationEntity[] naeArr = null;
     private AtomicLong seqNum = new AtomicLong(0L);
+    private static boolean ASYNC_INDEX = Boolean.valueOf(System.getProperty("dicoogle.index.async", "true"));
 
     /**
      *
@@ -371,7 +372,10 @@ public class DicomStorage extends StorageService {
                     // Fetch an element by the queue taking into account the priorities.
                     ImageElement element = queue.take();
                     URI exam = element.getUri();
-                    PluginController.getInstance().indexBlocking(exam);
+                    if (ASYNC_INDEX)
+                        PluginController.getInstance().index(exam);
+                    else
+                        PluginController.getInstance().indexBlocking(exam);
                 } catch (InterruptedException ex) {
                     LoggerFactory.getLogger(DicomStorage.class).error("Could not take instance to index", ex);
                 }


### PR DESCRIPTION
This PR introduces two changes:

- Make the DICOM Storage SCP indexing queue to be asynchronous 
- independent task manager for queries (v3)

