### PR TITLE
Add encrypt-users-file to server settings

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/core/settings/LegacyServerSettings.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/core/settings/LegacyServerSettings.java
@@ -1206,6 +1206,11 @@ public class LegacyServerSettings implements ServerSettings {
             LegacyServerSettings.this.setNodeName(nodeName);
         }
 
+        @Override
+        public void setEncryptUsersFile(boolean encrypt) {
+            LegacyServerSettings.this.setEncryptUsersFile(encrypt);
+        }
+
         @JsonGetter("save-thumbnails")
         @Override
         public boolean getSaveThumbnails() {
@@ -1258,6 +1263,12 @@ public class LegacyServerSettings implements ServerSettings {
         @Override
         public String getNodeName() {
             return LegacyServerSettings.this.getNodeName();
+        }
+
+        @JsonGetter("encrypt-users-file")
+        @Override
+        public boolean isEncryptUsersFile() {
+            return LegacyServerSettings.this.isEncryptUsersFile();
         }
     }
 

--- a/dicoogle/src/main/java/pt/ua/dicoogle/core/settings/part/ArchiveImpl.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/core/settings/part/ArchiveImpl.java
@@ -73,6 +73,9 @@ public class ArchiveImpl implements ServerSettings.Archive {
     @JsonProperty("watch-directory")
     private String watchDirectory;
 
+    @JsonProperty(value = "encrypt-users-file", defaultValue = "false")
+    private boolean encryptUsersFile;
+
     @Override
     public String getMainDirectory() {
         return mainDirectory;
@@ -161,5 +164,15 @@ public class ArchiveImpl implements ServerSettings.Archive {
                 + ", indexerEffort=" + indexerEffort + ", dimProviders=" + dimProviders + ", defaultStorage="
                 + defaultStorage + ", dirWatcherEnabled=" + dirWatcherEnabled + ", watchDirectory='" + watchDirectory
                 + '\'' + ", mainDirectory='" + mainDirectory + '\'' + ", nodeName='" + nodeName + '\'' + '}';
+    }
+
+    @Override
+    public boolean isEncryptUsersFile() {
+        return this.encryptUsersFile;
+    }
+
+    @Override
+    public void setEncryptUsersFile(boolean encrypt) {
+        this.encryptUsersFile = encrypt;
     }
 }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/users/UserFileHandle.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/users/UserFileHandle.java
@@ -56,15 +56,86 @@ public class UserFileHandle {
     private final boolean encrypt;
 
     public UserFileHandle() throws IOException {
-        filename = Paths.get("users");
-        keyFile = Paths.get("users.key");
-        boolean doEncrypt = ServerSettingsManager.getSettings().getArchiveSettings().isEncryptUsersFile();
+        this(Paths.get("."));
+    }
 
-        if (!doEncrypt) {
+    public UserFileHandle(Path baseConfDir) throws IOException {
+        // The following cases will be tested, in this order:
+        // 1. Users file `users.xml.enc` and key file users.key (encrypted)
+        // 2. Users file `users` and key file users.key (encrypted)
+        // 3. Users file `users.xml` (not encrypted)
+        // 4. Users file `users` (not encrypted)
+        // 5. No users files, encrypt-users-file enabled (generate new key and users.xml.enc)
+        // 6. No files, encrypt-users-file disabled (generate plain new users.xml, ignore eventual users.key)
+
+        Path usersXmlEnc = baseConfDir.resolve("users.xml.enc");
+        Path usersXml = baseConfDir.resolve("users.xml");
+        Path users = baseConfDir.resolve("users");
+
+        keyFile = baseConfDir.resolve("users.key");
+
+        boolean encryptUsersFile = ServerSettingsManager.getSettings().getArchiveSettings().isEncryptUsersFile();
+
+        // check whether we have a key file
+        final boolean keyExists = Files.exists(keyFile);
+
+        final boolean shouldEncrypt;
+
+        if (keyExists) {
+            if (Files.exists(usersXmlEnc)) {
+                // (1) users.xml.enc, encrypted
+                filename = usersXmlEnc;
+                shouldEncrypt = true;
+            } else if (Files.exists(users)) {
+                // (2) users, encrypted
+                logger.warn("File `users` will be interpreted as an encrypted users file. "
+                    + "If this is correct, please rename to `users.xml.enc`");
+                filename = users;
+                shouldEncrypt = true;
+            } else if (Files.exists(usersXml)) {
+                // (3) users.xml
+                logger.warn("Users file `users.xml` is not encrypted, encryption key will be ignored");
+                filename = usersXml;
+                shouldEncrypt = false;
+            } else if (encryptUsersFile) {
+                // (5) users.xml.enc, use existing key
+                logger.debug("Using existing key to create a new encrypted users file");
+                filename = usersXmlEnc;
+                shouldEncrypt = true;
+            } else {
+                logger.warn("Users file encryption is disabled, existing key will be ignored");
+                // (6) users.xml
+                filename = usersXml;
+                shouldEncrypt = false;
+            }
+        } else {
+            if (Files.exists(usersXmlEnc)) {
+                logger.warn("No user encryption key, the file `users.xml.enc` will be ignored");
+            }
+            if (Files.exists(users)) {
+                // (4) users, no encryption
+                logger.warn("File `users` will be interpreted as an plain XML users file. "
+                    + "If this is correct, please rename to `users.xml`");
+                filename = users;
+                shouldEncrypt = false;
+            } else if (encryptUsersFile) {
+                // (5) users.xml.enc, new key
+                filename = usersXmlEnc;
+                shouldEncrypt = true;
+            } else {
+                // (6) users.xml, no encryption
+                filename = usersXml;
+                shouldEncrypt = false;
+            }
+        }
+
+        if (!shouldEncrypt) {
             // stop here
             this.encrypt = false;
             return;
         }
+
+        boolean doEncrypt = true;
 
         // If there is neither a key file nor users file,
         // the program will generate a new key.
@@ -100,6 +171,7 @@ public class UserFileHandle {
                     // a new key was successfully created
                 } else {
                     logger.error("No key to decrypt users file, encryption disabled");
+                    key = null;
                     doEncrypt = false;
                 }
             }
@@ -160,7 +232,7 @@ public class UserFileHandle {
             return data;
 
         } catch (NoSuchFileException ex) {
-            logger.info("No such users file \"{}\", will create one with default settings.", filename);
+            logger.info("No users file \"{}\", will create one with default settings.", filename);
         } catch (IllegalBlockSizeException ex) {
             logger.error("Users file \"{}\" is corrupted, will override it with default settings.", filename, ex);
         } catch (InvalidKeyException ex) {

--- a/dicoogle/src/test/java/pt/ua/dicoogle/core/settings/LegacyServerSettingsTest.java
+++ b/dicoogle/src/test/java/pt/ua/dicoogle/core/settings/LegacyServerSettingsTest.java
@@ -59,6 +59,7 @@ public class LegacyServerSettingsTest {
         assertEquals("/tmp", a.getWatchDirectory());
         assertEquals(97, a.getIndexerEffort());
         assertEquals("dicoogle-old", a.getNodeName());
+        assertEquals(true, a.isEncryptUsersFile());
 
         assertEquals("TEST-STORAGE", settings.getDicomServicesSettings().getAETitle());
 

--- a/dicoogle/src/test/java/pt/ua/dicoogle/core/settings/ServerSettingsTest.java
+++ b/dicoogle/src/test/java/pt/ua/dicoogle/core/settings/ServerSettingsTest.java
@@ -72,6 +72,7 @@ public class ServerSettingsTest {
         assertEquals(98, ar.getIndexerEffort());
         assertEquals("/opt/my-data/watched", ar.getWatchDirectory());
         assertEquals("dicoogle01", ar.getNodeName());
+        assertEquals(true, ar.isEncryptUsersFile());
 
         assertSameContent(Collections.singleton("lucene"), ar.getDIMProviders());
         assertSameContent(Collections.singleton("filestorage"), ar.getDefaultStorage());

--- a/dicoogle/src/test/resources/pt/ua/dicoogle/core/settings/test-config-new.xml
+++ b/dicoogle/src/test/resources/pt/ua/dicoogle/core/settings/test-config-new.xml
@@ -14,6 +14,7 @@
         <default-storages>
             <default-storage>filestorage</default-storage>
         </default-storages>
+        <encrypt-users-file>true</encrypt-users-file>
         <enable-watch-directory>true</enable-watch-directory>
         <watch-directory>/opt/my-data/watched</watch-directory>
         <node-name>dicoogle01</node-name>

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/settings/server/ServerSettings.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/settings/server/ServerSettings.java
@@ -63,6 +63,8 @@ public interface ServerSettings extends ServerSettingsReader {
 
         void setDirectoryWatcherEnabled(boolean watch);
 
+        void setEncryptUsersFile(boolean encrypt);
+
         void setDIMProviders(List<String> providers);
 
         void setDefaultStorage(List<String> storages);

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/settings/server/ServerSettingsReader.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/settings/server/ServerSettingsReader.java
@@ -68,6 +68,9 @@ public interface ServerSettingsReader {
         @JsonGetter("main-directory")
         String getMainDirectory();
 
+        @JsonGetter("encrypt-users-file")
+        boolean isEncryptUsersFile();
+
         @JsonGetter("enable-watch-directory")
         boolean isDirectoryWatcherEnabled();
 


### PR DESCRIPTION
This was overlooked when creating the new server settings format, but with the recommendation to not implement server settings readers, we can safely add new properties without calling it a breaking change.

- [sdk] add getter and setter for property to encrypt the users file (`EncryptUsersFile` in legacy)
- [core] implement new methods in server settings impl
- update tests to ensure it is loaded and migrated from legacy
- Use `encrypt-users-file` setting in UserFileHandle
   - do not try to encrypt anything if false
   - update comments to reflect the current behavior