### PR TITLE
Bump Dicoogle to 2.5.7

### DIFF
--- a/dicoogle/pom.xml
+++ b/dicoogle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>pt.ua.ieeta</groupId>
         <artifactId>dicoogle-all</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>pt.ua.ieeta</groupId>
   <artifactId>dicoogle-all</artifactId>
-    <version>2.5.6</version>
+    <version>2.5.7</version>
   <packaging>pom</packaging>
   <name>dicoogle-all</name>
   

--- a/sdk-ext/pom.xml
+++ b/sdk-ext/pom.xml
@@ -10,7 +10,7 @@
         <parent>
             <groupId>pt.ua.ieeta</groupId>
             <artifactId>dicoogle-all</artifactId>
-			<version>2.5.6</version>
+			<version>2.5.7</version>
             <relativePath>../pom.xml</relativePath>
         </parent>
 

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>pt.ua.ieeta</groupId>
         <artifactId>dicoogle-all</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
The repository was tagged with this version before the actual versions were bumped.