### PR TITLE
Fix index settings `zip` property and remove it from UI

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/management/IndexerSettingsServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/management/IndexerSettingsServlet.java
@@ -123,7 +123,7 @@ public class IndexerSettingsServlet extends HttpServlet {
                 result = ServerSettingsManager.getSettings().getArchiveSettings().getMainDirectory();
                 break;
             case zip:
-                result = "false"; // String.valueOf(ServerSettingsManager.getSettings().isGzipStorage());
+                result = "false";
                 break;
             case effort:
                 result = String.valueOf(ServerSettingsManager.getSettings().getArchiveSettings().getIndexerEffort());
@@ -141,7 +141,7 @@ public class IndexerSettingsServlet extends HttpServlet {
             case all:
                 JSONObject allresponse = new JSONObject();
                 allresponse.put("path", ServerSettingsManager.getSettings().getArchiveSettings().getMainDirectory());
-                allresponse.put("zip", "false"); // ServerSettingsManager.getSettings().isGzipStorage());
+                allresponse.put("zip", false);
                 allresponse.put("effort",
                         String.valueOf(ServerSettingsManager.getSettings().getArchiveSettings().getIndexerEffort()));
                 allresponse.put("thumbnail",

--- a/dicoogle/src/main/resources/webapp/js/components/management/indexerView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/management/indexerView.js
@@ -147,7 +147,6 @@ const IndexerView = createReactClass({
     saveIndexOptions(
       document.getElementById("mon_path").value,
       document.getElementById("watcher").checked,
-      document.getElementById("zip").checked,
       document.getElementById("save").checked,
       document.getElementById("effort_range").value,
       document.getElementById("tsize").value

--- a/dicoogle/src/main/resources/webapp/js/components/management/indexerView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/management/indexerView.js
@@ -94,16 +94,7 @@ const IndexerView = createReactClass({
                   placeholder="/path/to/directory"
                 />
               </ConfigurationEntry>
-              <ConfigurationEntry description="Index Zip Files">
-                <input
-                  id="zip"
-                  type="checkbox"
-                  aria-label="..."
-                  defaultChecked={this.state.data.zip}
-                  onChange={this.onZipClicked}
-                />
-              </ConfigurationEntry>
-              <ConfigurationEntry description="Indexation Effort">
+              <ConfigurationEntry description="Indexing Effort">
                 <input
                   className="bar"
                   type="range"

--- a/dicoogle/src/main/resources/webapp/js/handlers/requestHandler.js
+++ b/dicoogle/src/main/resources/webapp/js/handlers/requestHandler.js
@@ -129,7 +129,6 @@ export function setSaveT(state, callback) {
 export function saveIndexOptions(
   path,
   watcher,
-  zip,
   thumbnail,
   effort,
   thumbnailSize
@@ -138,7 +137,6 @@ export function saveIndexOptions(
     {
       path,
       watcher,
-      zip,
       thumbnail,
       effort,
       thumbnailSize


### PR DESCRIPTION
The "Index Zip Files" archive setting was not used anywhere in Dicoogle since version 2, which is why it was removed from the server settings in Dicoogle 3. However, it stayed as a visible property in the index settings service and in the user interface, which was misleadingly presented as enabled and could not even be changed in practice.

- Change index settings JSON output so that zip is `false` instead of the string `"false"`
   - We will treat this as a small regression of the Web API
- Remove the Index Zip Files row from the web UI
- Tweak "Indexation effort" to "Indexing effort", which is more accurate

The result:

![dicoogle-remove-zip-from-webapp](https://user-images.githubusercontent.com/4738426/135606671-5cdb7e69-33da-41e1-b793-c477c15dc681.PNG)

