### PR TITLE
Fix server error on /webui without user session

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/webui/WebUIServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/webui/WebUIServlet.java
@@ -96,8 +96,8 @@ public class WebUIServlet extends HttpServlet {
             }
 
             final RolesStruct roles = RolesStruct.getInstance();
-            boolean pluginOk = PERMISSIVE_WEBUI || user.isAdmin() || plugin.getRoles().isEmpty();
-            if (!pluginOk) {
+            boolean pluginOk = PERMISSIVE_WEBUI || plugin.getRoles().isEmpty() || (user != null && user.isAdmin());
+            if (!pluginOk && user != null) {
                 for (String r : plugin.getRoles()) {
                     Role rr = roles.getRole(r);
 


### PR DESCRIPTION
500 would emerge if a webplugin is installed and a /webui request without an authenticated user would fetch it

This is a regression from #497, emerged once the PR was tweaked to let administrators see all web UI plugins. If the token does not refer to a valid session, `user` is null.
