### PR TITLE
Check roles before loading plugins and warn about missing roles

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/Main.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/Main.java
@@ -31,6 +31,7 @@ import pt.ua.dicoogle.plugins.PluginController;
 import pt.ua.dicoogle.utils.Platform;
 import pt.ua.dicoogle.sdk.settings.server.ServerSettings;
 import pt.ua.dicoogle.sdk.utils.TagsStruct;
+import pt.ua.dicoogle.server.web.auth.Authentication;
 
 import javax.swing.*;
 import java.awt.*;
@@ -164,6 +165,10 @@ public class Main {
         TransferSyntax.add(new TransferSyntax("1.2.840.10008.1.2.4.70", true, false, false, true));
         TransferSyntax.add(new TransferSyntax("1.2.840.10008.1.2.5.50", false, false, false, true));
 
+        // Initialize authentication and authorization system
+        Authentication.getInstance();
+
+        // Initialize platform controller
         PluginController.getInstance();
 
         // Start the initial Services of Dicoogle

--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/webui/WebUIPluginManager.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/webui/WebUIPluginManager.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -38,6 +39,8 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import net.sf.json.JSONObject;
 import net.sf.json.JSONSerializer;
+import pt.ua.dicoogle.server.users.RolesStruct;
+
 import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
 
@@ -107,6 +110,16 @@ public class WebUIPluginManager {
             try {
                 WebUIPlugin plugin = this.load(f);
                 logger.info("Loaded web plugin: {}", plugin.getName());
+
+                for (Iterator<String> it = plugin.getRoles().iterator(); it.hasNext();) {
+                    String pluginRole = it.next();
+                    if (RolesStruct.getInstance().getRole(pluginRole) == null) {
+                        logger.warn("Web UI plugin {} mentions unregistered role {}; Please update roles.xml",
+                                plugin.getName(), pluginRole);
+                        it.remove();
+                    }
+                }
+
             } catch (IOException ex) {
                 logger.error("Attempt to load plugin at {} failed", f.getName(), ex);
             } catch (PluginFormatException ex) {


### PR DESCRIPTION
Summary:

- Add user role loading to the beginning of the program, so that plugins are aware of the roles which are effectively registered.
- When loading web UI plugins, send a warning if the given role does not exist and ignore it from the plugin descriptor during that run.