### PR TITLE
Fix queries using the platform for query plugins that implements QueryInterface

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/DicooglePlatformProxy.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/DicooglePlatformProxy.java
@@ -133,7 +133,7 @@ public class DicooglePlatformProxy implements DicooglePlatformInterface {
 
     @Override
     public Task<Iterable<SearchResult>> query(String querySource, String query, Object... parameters) {
-        return pluginController.query(querySource, query, DimLevel.INSTANCE, parameters);
+        return pluginController.query(querySource, query, parameters);
     }
 
     @Override

--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
@@ -617,7 +617,7 @@ public class PluginController {
         Task<Iterable<SearchResult>> queryTask = new Task<>(uid, querySource, new Callable<Iterable<SearchResult>>() {
             @Override
             public Iterable<SearchResult> call() throws Exception {
-                if (queryEngine == null || !(queryEngine instanceof QueryInterface))
+                if (queryEngine == null || !(queryEngine instanceof QueryDimInterface))
                     return Collections.emptyList();
                 try {
                     return queryEngine.query(query, level, parameters);

--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
@@ -617,7 +617,7 @@ public class PluginController {
         Task<Iterable<SearchResult>> queryTask = new Task<>(uid, querySource, new Callable<Iterable<SearchResult>>() {
             @Override
             public Iterable<SearchResult> call() throws Exception {
-                if (queryEngine == null || !(queryEngine instanceof QueryDimInterface))
+                if (queryEngine == null || !(queryEngine instanceof QueryInterface))
                     return Collections.emptyList();
                 try {
                     return queryEngine.query(query, level, parameters);


### PR DESCRIPTION
Fix the problem of queries using the platform for query plugins that implements QueryInterface. This will avoid the plugin of query to implement QueryDimInterface, if it is not expected to. 

An example of the issue was: 

```
Task<Iterable<SearchResult>> result = this.platform.query("lucene", "*:*", extraFields);
result.get();
```

It was reported by @rlebre.
