### PR TITLE
Updated restlet url to https://maven.restlet.talend.com

### DIFF
--- a/dicoogle/pom.xml
+++ b/dicoogle/pom.xml
@@ -63,7 +63,7 @@
         <repository>
             <id>maven-restlet</id>
             <name>Public online Restlet repository</name>
-            <url>https://maven.restlet.com</url>
+            <url>https://maven.restlet.talend.com</url>
         </repository>
 
         <repository>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -38,7 +38,7 @@
         <repository>
             <id>maven-restlet</id>
             <name>Public online Restlet repository</name>
-            <url>https://maven.restlet.com</url>
+            <url>https://maven.restlet.talend.com</url>
         </repository>
 
         <repository>


### PR DESCRIPTION
The Maven Restlet dependency URLs have become deprecated, and the associated certificates have become invalid since December 11th, making it an insecure connection which fails Maven installations.

This PR replaces the Dicoogle and Dicoogle SDK Restlet dependency URLs to the current URL: `https://maven.restlet.talend.com`