### PR TITLE
Removed not used distribution management endpoints

### DIFF
--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -230,17 +230,4 @@
         </dependency>
     </dependencies>
 
-    <distributionManagement>
-        <!-- Versioned releases are published to the releases repository -->
-        <repository>
-            <id>mi</id>
-            <url>https://bioinformatics.ua.pt/maven/content/repositories/mi</url>
-        </repository>
-
-        <!-- Snapshot releases are published to the snapshots repository -->
-        <snapshotRepository>
-            <id>mi</id>
-            <url>https://bioinformatics.ua.pt/maven/content/repositories/mi-snapshots</url>
-        </snapshotRepository>
-    </distributionManagement>
 </project>


### PR DESCRIPTION
Removed not used distribution management endpoints 
They were declared already in the parent `pom.xml` and create issues while deploying to remote maven repos.