### PR TITLE
Fix plugin categorization in management page

### DIFF
--- a/dicoogle/src/main/resources/webapp/js/components/management/pluginsView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/management/pluginsView.js
@@ -51,14 +51,23 @@ const PluginsView = createReactClass({
     }
 
     if (data.data.length !== 0) {
-      let type = data.data[0].type;
-      let plugins = this.state.plugins;
-
+      let plugins = {};
+      
       // apply this structure: plugins[query]: [...] ; plugins[storage]: [...] ; ...
-      plugins[type] = data.data;
+      for (const p of data.data) {
+        let type = p.type;
+        if (!plugins[type]) {
+          plugins[type] = [];
+        }
+        plugins[type].push(p);
+      }
 
+      // let new plugin lists override the old ones
       this.setState({
-        plugins: plugins
+        plugins: {
+          ...this.state.plugins,
+          ...plugins
+        }
       });
     }
 

--- a/dicoogle/src/main/resources/webapp/js/stores/pluginStore.js
+++ b/dicoogle/src/main/resources/webapp/js/stores/pluginStore.js
@@ -12,8 +12,8 @@ const PluginStore = Reflux.createStore({
   },
 
   onGet: function(type) {
-    Dicoogle.getPlugins().then((response) => {
-        this._contents[type] = response.plugins;
+    Dicoogle.request(['plugins', type]).then((response) => {
+        this._contents[type] = response.body.plugins;
         this.trigger({
           data: this._contents[type],
           success: true


### PR DESCRIPTION
Fixes a regression from #523, where plugins in the management page were not presented correctly in their respective categories.

![Capture-dicoogle-bug-before](https://user-images.githubusercontent.com/4738426/147589797-184b5d05-809a-4a56-9a66-e2b501a5bc04.PNG)

After the fix:

![Capture-dicoogle-bug-after](https://user-images.githubusercontent.com/4738426/147589792-25f9fec5-a1a8-495a-8c0b-b5681431f953.PNG)

- revert to filtering plugins by requested type
   - `getPlugins(type)` is planned but not yet available
- ensure that plugin categorization still works with mixed types of plugins anyway