### PR TITLE
Update commons-collections4 to 4.4

### DIFF
--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -213,7 +213,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
-            <version>4.0</version>
+            <version>4.4</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
While bumping SDK dependencies could be risky, the documentation claims that it is source and binary compatible with version 4, save for some implementations of `Serializable` removed for a few types.

Test plan:

- Run Dicoogle with the patched SDK, but without patched plugins
- Run an unpatched version of Dicoogle with the patched plugins
- Run both Dicoogle and plugins patched
