### PR TITLE
Change DICOM logging and deprecate XML log

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/DicomLog/LogLine.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/DicomLog/LogLine.java
@@ -29,18 +29,22 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 /**
- *
- * @author Luís A. Bastião Silva <bastiao@ua.pt>
+ * A log line representing a DICOM event.
  */
 public class LogLine implements Serializable {
     static final long serialVersionUID = 1L;
 
-    private String type;
-    private String date;
-    private String ae;
-    private String add;
-    private String params;
+    private final String type;
+    @Deprecated
+    private final String date;
+    private final String ae;
+    private final String add;
+    private final String params;
 
+    /**
+     * @deprecated Discard the `date` parameter.
+     */
+    @Deprecated
     public LogLine(String type, String date, String ae, String add, String params) {
         this.type = type;
         this.date = date;
@@ -49,13 +53,25 @@ public class LogLine implements Serializable {
         this.params = params;
     }
 
-    public static String getDateTime() {
+    /**
+     * @param type the type of event
+     * @param ae the peer AE title
+     * @param add the additional information about the operation
+     * @param params the parameters of the operation
+     */
+    public LogLine(String type, String ae, String add, String params) {
+        this.type = type;
+        this.date = getDateTime();
+        this.ae = ae;
+        this.add = add;
+        this.params = params;
+    }
+
+    private static String getDateTime() {
         DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
         Date date = new Date();
         return dateFormat.format(date);
     }
-
-
 
     /**
      * @return the type
@@ -65,60 +81,34 @@ public class LogLine implements Serializable {
     }
 
     /**
-     * @param type the type to set
+     * @return the date and time of the event
+     * 
+     * @deprecated Will be removed in Dicoogle 4 in favor of
+     * letting the logger record the date and time of the event.
      */
-    public void setType(String type) {
-        this.type = type;
-    }
-
-    /**
-     * @return the date
-     */
+    @Deprecated
     public String getDate() {
         return date;
     }
 
     /**
-     * @param date the date to set
-     */
-    public void setDate(String date) {
-        this.date = date;
-    }
-
-    /**
-     * @return the ae
+     * @return the AE title
      */
     public String getAe() {
         return ae;
     }
 
     /**
-     * @param ae the ae to set
-     */
-    public void setAe(String ae) {
-        this.ae = ae;
-    }
-
-    /**
-     * @return the add
+     * @return the additional information
      */
     public String getAdd() {
         return add;
     }
 
     /**
-     * @param add the add to set
+     * @return the additional parameters
      */
-    public void setAdd(String add) {
-        this.add = add;
-    }
-
-
     public String getParams() {
         return params;
-    }
-
-    public void setParams(String params) {
-        this.params = params;
     }
 }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/DicomLog/LogXML.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/DicomLog/LogXML.java
@@ -43,7 +43,10 @@ import org.xml.sax.XMLReader;
 /**
  *
  * @author Luís A. Bastião Silva <bastiao@ua.pt>
+ * @see LogDICOM
+ * @deprecated Legacy functionality, use only `LogDICOM` to log DICOM events.
  */
+@Deprecated
 public class LogXML extends DefaultHandler {
 
     // private final String filename = Platform.homePath() + "DICOM_Services_Log.xml";
@@ -91,6 +94,11 @@ public class LogXML extends DefaultHandler {
     }
 
     public LogDICOM getXML() {
+        if (!logs.isPersistent()) {
+            // Disable XML logs
+            return logs;
+        }
+
         try {
             File file = new File(filename);
             if (!file.exists()) {
@@ -111,7 +119,10 @@ public class LogXML extends DefaultHandler {
     }
 
     public void printXML() throws TransformerConfigurationException {
-
+        if (!logs.isPersistent()) {
+            // Disable XML logs
+            return;
+        }
 
         FileOutputStream out = null;
 

--- a/dicoogle/src/main/java/pt/ua/dicoogle/Main.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/Main.java
@@ -22,7 +22,6 @@ import org.dcm4che2.data.TransferSyntax;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
-import pt.ua.dicoogle.DicomLog.LogDICOM;
 import pt.ua.dicoogle.DicomLog.LogXML;
 import pt.ua.dicoogle.core.AsyncIndex;
 import pt.ua.dicoogle.core.TagsXML;
@@ -30,7 +29,6 @@ import pt.ua.dicoogle.core.settings.ServerSettingsManager;
 import pt.ua.dicoogle.plugins.PluginController;
 import pt.ua.dicoogle.utils.Platform;
 import pt.ua.dicoogle.sdk.settings.server.ServerSettings;
-import pt.ua.dicoogle.sdk.utils.TagsStruct;
 import pt.ua.dicoogle.server.web.auth.Authentication;
 
 import javax.swing.*;
@@ -129,15 +127,15 @@ public class Main {
         }
         ServerSettings settings = ServerSettingsManager.getSettings();
 
+        // load tags listings
         try {
-            TagsStruct _tags = new TagsXML().getXML();
-
-            // load DICOM Services Log
-            LogDICOM ll = new LogXML().getXML();
-
+            new TagsXML().getXML();
         } catch (SAXException | IOException ex) {
             logger.error(ex.getMessage(), ex);
         }
+
+        // FIXME remove in Dicoogle 4, this loads legacy DICOM Services Log
+        new LogXML().getXML();
 
         /** Verify if it have a defined node */
         if (settings.getArchiveSettings().getNodeName() == null) {

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/queryretrieve/CFindServiceSCP.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/queryretrieve/CFindServiceSCP.java
@@ -18,9 +18,6 @@
  */
 package pt.ua.dicoogle.server.queryretrieve;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.concurrent.Executor;
 
@@ -138,27 +135,22 @@ public class CFindServiceSCP extends CFindService {
                 }
             }
 
-            LogLine ll =
-                    new LogLine("cfind", getDateTime(), as.getCallingAET(), as.toString() + " -- " + add, queryParams);
+            LogLine ll = new LogLine("cfind", as.getCallingAET(), as.toString() + " -- " + add, queryParams);
             LogDICOM.getInstance().addLine(ll);
 
-            synchronized (LogDICOM.getInstance()) {
-                LogXML l = new LogXML();
-                try {
-                    l.printXML();
-                } catch (TransformerConfigurationException ex) {
-                    ex.printStackTrace();
+            if (LogDICOM.getInstance().isPersistent()) {
+                synchronized (LogDICOM.getInstance()) {
+                    LogXML l = new LogXML();
+                    try {
+                        l.printXML();
+                    } catch (TransformerConfigurationException ex) {
+                        ex.printStackTrace();
+                    }
                 }
             }
 
         }
         return replay;
-    }
-
-    private String getDateTime() {
-        DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
-        Date date = new Date();
-        return dateFormat.format(date);
     }
 
     /**

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/queryretrieve/CMoveServiceSCP.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/queryretrieve/CMoveServiceSCP.java
@@ -201,17 +201,19 @@ public class CMoveServiceSCP extends CMoveService {
             }
 
 
-            LogLine ll = new LogLine("cmove", LogLine.getDateTime(), destination,
+            LogLine ll = new LogLine("cmove", destination,
                     "Files: " + files.size() + " -- (" + hostDest + ":" + portAddr + ")",
                     "studyUID=" + data.getString(Tag.StudyInstanceUID));
             LogDICOM.getInstance().addLine(ll);
 
-            synchronized (LogDICOM.getInstance()) {
-                try {
-                    LogXML l = new LogXML();
-                    l.printXML();
-                } catch (TransformerConfigurationException ex) {
-                    LoggerFactory.getLogger(CMoveServiceSCP.class).error(ex.getMessage(), ex);
+            if (LogDICOM.getInstance().isPersistent()) {
+                synchronized (LogDICOM.getInstance()) {
+                    try {
+                        LogXML l = new LogXML();
+                        l.printXML();
+                    } catch (TransformerConfigurationException ex) {
+                        LoggerFactory.getLogger(CMoveServiceSCP.class).error(ex.getMessage(), ex);
+                    }
                 }
             }
 


### PR DESCRIPTION
Resolves #528.

- Change implementation to send log line to slf4j logger
   - format is `"[{peer-aetitle}] {type} {additional-info} {params}"`, suggestions on a different structure are welcome
- Disable XML logging by default ("DICOM_Services_Log.xml")
   - can be enabled again with `-Ddicoogle.dicom.xmlLog=true`
- mark related constructs as deprecated, so we can remove them in Dicoogle 4
- tweak `LogLine` class
   - deprecate current constructor, advise users to discard `date`
   - currently still stores `date`, but will be gone in the future