### PR TITLE
Update minimum supported Node.js in CI workflow

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         # Recommended versions to include:
         # - minimum supported version


### PR DESCRIPTION
Although #569 now requires Node.js >=12.22, I forgot to update CI.