### PR TITLE
Add Instance Number to DIM search output and webapp image results

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/search/SearchServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/search/SearchServlet.java
@@ -60,7 +60,7 @@ public class SearchServlet extends HttpServlet {
 
     private final Collection<String> DEFAULT_FIELDS = Arrays.asList("SOPInstanceUID", "StudyInstanceUID",
             "SeriesInstanceUID", "PatientID", "PatientName", "PatientSex", "Modality", "StudyDate", "StudyID",
-            "StudyDescription", "SeriesNumber", "SeriesDescription", "InstitutionName", "uri");
+            "StudyDescription", "SeriesNumber", "SeriesDescription", "InstitutionName", "InstanceNumber", "uri");
 
     public enum SearchType {
         ALL, PATIENT;

--- a/dicoogle/src/main/resources/webapp/js/components/search/result/imageView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/imageView.js
@@ -71,7 +71,6 @@ const ImageView = createReactClass({
           src={thumbUrl}
           style={{ width: "64px", cursor: "pointer" }}
         >
-          <img />
           <img src="assets/image-not-found.png" width="64px" />
           {this._preloader()}
         </ImageLoader>

--- a/dicoogle/src/main/resources/webapp/js/components/search/result/imageView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/imageView.js
@@ -206,11 +206,19 @@ const ImageView = createReactClass({
         >
           <TableHeaderColumn
             dataAlign="left"
+            dataField="number"
+            dataSort
+            width="100"
+          >
+            Instance #
+          </TableHeaderColumn>
+          <TableHeaderColumn
+            dataAlign="left"
             dataField="fileName"
             isKey
             dataFormat={this.formatFileName}
             dataSort
-            width="20%"
+            width="25%"
           >
             File Name
           </TableHeaderColumn>

--- a/dicoogle/src/main/resources/webapp/js/components/search/result/imageView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/imageView.js
@@ -139,6 +139,7 @@ const ImageView = createReactClass({
               type: "image",
               uri: item.uri,
               uid: item.sopInstanceUID,
+              instanceNumber: item.number,
               // deprecated data properties
               "data-result-type": "image",
               "data-result-uri": item.uri,

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/dim/DIMGeneric.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/dim/DIMGeneric.java
@@ -187,6 +187,8 @@ public class DIMGeneric {
         String SeriesDate = toTrimmedString(extra.get("SeriesDate"), false);
         String ProtocolName = toTrimmedString(extra.get("ProtocolName"), false);
 
+        String instanceNumber = toTrimmedString(extra.get("InstanceNumber"), true);
+
         /**
          * Get data to Image
          */
@@ -336,7 +338,7 @@ public class DIMGeneric {
             series.setViewCodeSequence_CodingSchemeDesignator(ViewCodeSequence_CodingSchemeDesignator);
             series.setViewCodeSequence_CodingSchemeVersion(ViewCodeSequence_CodingSchemeVersion);
 
-            series.addImage(uri, sopInstUID);
+            series.addImage(uri, sopInstUID, instanceNumber);
             s.addSerie(series);
             this.patients.add(p);
             this.patientsHash.put(patientIdentifier, p);
@@ -443,7 +445,11 @@ public class DIMGeneric {
                             image.put("rawPath", rawPath);
                             image.put("uri", serie.getImageList().get(i).toString());
                             image.put("filename", rawPath.substring(rawPath.lastIndexOf("/") + 1, rawPath.length()));
-
+                            String instanceNum = serie.getInstanceNumberList().get(i);
+                            if (instanceNum != null) {
+                                image.put("number", instanceNum);
+                            }
+    
                             instances.add(image);
                         }
                         seriesObj.put("images", instances);

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/dim/DIMGeneric.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/dim/DIMGeneric.java
@@ -291,7 +291,7 @@ public class DIMGeneric {
             series.setViewCodeSequence_CodingSchemeDesignator(ViewCodeSequence_CodingSchemeDesignator);
             series.setViewCodeSequence_CodingSchemeVersion(ViewCodeSequence_CodingSchemeVersion);
 
-            series.addImage(uri, sopInstUID);
+            series.addImage(uri, sopInstUID, instanceNumber);
             s.addSerie(series);
             p.addStudy(s);
 

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/dim/DIMGeneric.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/dim/DIMGeneric.java
@@ -447,7 +447,15 @@ public class DIMGeneric {
                             image.put("filename", rawPath.substring(rawPath.lastIndexOf("/") + 1, rawPath.length()));
                             String instanceNum = serie.getInstanceNumberList().get(i);
                             if (instanceNum != null) {
-                                image.put("number", instanceNum);
+                                if (instanceNum.endsWith(".0")) {
+                                    instanceNum = instanceNum.substring(0, instanceNum.length() - 2);
+                                }
+                                try {
+                                    long instanceNumLong = Long.parseLong(instanceNum);
+                                    image.put("number", instanceNumLong);
+                                } catch (NumberFormatException e) {
+                                    // not a number, do not include
+                                }
                             }
     
                             instances.add(image);

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/dim/Series.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/dim/Series.java
@@ -94,6 +94,10 @@ public class Series implements SeriesInterface {
         this.instanceNumbers.add(instanceNumber);
     }
 
+    /**
+     * @deprecated Dangerous method, do not use.
+     */
+    @Deprecated
     public void removeImage(URI imagePath) {
         this.imageList.remove(imagePath);
     }

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/dim/Series.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/dim/Series.java
@@ -54,6 +54,7 @@ public class Series implements SeriesInterface {
 
     private ArrayList<URI> imageList = new ArrayList<>();
     private ArrayList<String> UIDList = new ArrayList<>();
+    private ArrayList<String> instanceNumbers = new ArrayList<>();
 
     public Series(Study study, String SeriesInstanceUID, String modality) {
         this.parent = study;
@@ -71,8 +72,13 @@ public class Series implements SeriesInterface {
 
 
     public void addImage(URI ImagePath, String sopUid) {
+        this.addImage(ImagePath, sopUid, null);
+    }
+
+    public void addImage(URI ImagePath, String sopUid, String instanceNumber) {
         this.imageList.add(ImagePath);
         this.UIDList.add(sopUid);
+        this.instanceNumbers.add(instanceNumber);
     }
 
     public void removeImage(URI imagePath) {
@@ -119,12 +125,20 @@ public class Series implements SeriesInterface {
         return UIDList;
     }
 
+    public ArrayList<String> getInstanceNumberList() {
+        return instanceNumbers;
+    }
+
     /**
      * @param imageList the imageList to set
      */
     public void setImageList(ArrayList<URI> imageList, ArrayList<String> sops) {
         this.imageList = imageList;
         this.UIDList = sops;
+    }
+
+    public void setInstanceNumberList(ArrayList<String> list) {
+        this.instanceNumbers = list;
     }
 
     /**

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/dim/Series.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/dim/Series.java
@@ -71,12 +71,25 @@ public class Series implements SeriesInterface {
     }
 
 
-    public void addImage(URI ImagePath, String sopUid) {
-        this.addImage(ImagePath, sopUid, null);
+    /** Add an instance to the end of the series' instance lists.
+     * Instance Number is left empty.
+     * 
+     * @param imageURI the URI of the instance
+     * @param sopUid the SOP Instance UID
+     * @see #addInstance(String, String, String)
+     */
+    public void addImage(URI imageURI, String sopUid) {
+        this.addImage(imageURI, sopUid, null);
     }
 
-    public void addImage(URI ImagePath, String sopUid, String instanceNumber) {
-        this.imageList.add(ImagePath);
+    /** Add an instance to the end of the series' instance lists.
+     * 
+     * @param imageURI the URI of the instance
+     * @param sopUid the SOP Instance UID
+     * @param instanceNumber the instance number
+     */
+    public void addImage(URI imageURI, String sopUid, String instanceNumber) {
+        this.imageList.add(imageURI);
         this.UIDList.add(sopUid);
         this.instanceNumbers.add(instanceNumber);
     }
@@ -115,16 +128,38 @@ public class Series implements SeriesInterface {
     }
 
     /**
-     * @return the imageList
+     * Gets the underlying URI list of the images in the series.
+     * It is recommended that the list is not modified from the outside.
+     *
+     * @return the underlying list of image URIs,
+     * in order of appearance
      */
     public ArrayList<URI> getImageList() {
         return imageList;
     }
 
+    /**
+     * Gets the underlying list of SOP instance UIDs
+     * of the images in the series.
+     * It is recommended that the list is not modified from the outside.
+     *
+     * @return the underlying list of SOP Instance UIDs,
+     * in order of appearance.
+     */
     public ArrayList<String> getSOPInstanceUIDList() {
         return UIDList;
     }
 
+    /**
+     * Gets the underlying list of instance number values
+     * of the images in the series.
+     * Note that the list may contain null values.
+     * 
+     * It is recommended that the list is not modified from the outside.
+     * 
+     * @return the underlying list of Instance Numbers,
+     * in order of appearance.
+     */
     public ArrayList<String> getInstanceNumberList() {
         return instanceNumbers;
     }

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/dim/Study.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/dim/Study.java
@@ -95,17 +95,21 @@ public class Study implements StudyInterface {
     }
 
 
-
+    /** Add or extend a DICOM series into this study.
+     * 
+     * @param s a series object
+     */
     public void addSerie(Series s) {
         if (this.seriesHash.containsKey(s.getSeriesInstanceUID())) {
 
             Series existSeries = this.seriesHash.get(s.getSeriesInstanceUID());
             ArrayList<URI> img = s.getImageList();
             ArrayList<String> uid = s.getSOPInstanceUIDList();
+            ArrayList<String> instanceNum = s.getInstanceNumberList();
 
             int size = img.size();
             for (int i = 0; i < size; i++) {
-                existSeries.addImage(img.get(i), uid.get(i));
+                existSeries.addImage(img.get(i), uid.get(i), instanceNum.get(i));
             }
         } else {
             this.series.add(s);


### PR DESCRIPTION
Resolves #477.

- In `images`, objects may also have a `number` field, which is present if the field is an integer.
- On the web app, a new column was added to the beginning of the search results table, on Image level.

![Screenshot from Dicoogle depicting part of the search results table, with column Instance # first](https://user-images.githubusercontent.com/4738426/174630163-8179eb79-db2c-4a06-a429-592b52d5888f.png)

This includes the necessary changes in GenericDIM plus extensions to documentation and a deprecation of an unused method which I believe is best removed in future versions.