### PR TITLE
Set key to dicoogle-slot in PluginView

### DIFF
--- a/dicoogle/src/main/resources/webapp/js/components/plugin/pluginView.jsx
+++ b/dicoogle/src/main/resources/webapp/js/components/plugin/pluginView.jsx
@@ -67,6 +67,7 @@ export default class PluginView extends React.Component {
           <div>{this.state.elements[plugin]}</div>
         ) : (
           <dicoogle-slot
+            key={`${this.props.slotId}.${plugin}`}
             {...this.props.data}
             ref={this.handleMounted}
             data-slot-id={this.props.slotId}


### PR DESCRIPTION
This forces React to rebuild the slot in the event that the plugin within changes, as is the case in menu plugins.

Resolves #586.