### PR TITLE
[webapp] Show URI on image meta-data dump 

### DIFF
--- a/dicoogle/src/main/resources/webapp/js/components/search/result/imageView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/imageView.js
@@ -451,6 +451,7 @@ var PopOverView = createReactClass({
               dataField="field"
               width="40%"
               isKey={false}
+              tdStyle={{ whiteSpace: 'normal', wordWrap: 'break-word' }} // To avoid shorten the field text 
               dataSort
             >
               Field

--- a/dicoogle/src/main/resources/webapp/js/components/search/result/imageView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/imageView.js
@@ -402,6 +402,9 @@ var PopOverView = createReactClass({
       fields.push({ att: key, field: obj[key] });
     });
 
+    // Add URI as location definition of the DICOM resource.
+    fields.push({ att: "URI", field:this.state.data.data.results.uri });
+
     var selectRowProp = {
       clickToSelect: true,
       mode: "none",


### PR DESCRIPTION
- Show URI on image meta-data dump. 
- Avoid the text to be cutted if the width of field text is not enough.

Resolves #423. 

