### PR TITLE
[webapp] Added capability to export dump of metadata to CSV 

### DIFF
--- a/dicoogle/src/main/resources/webapp/js/components/search/result/imageView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/imageView.js
@@ -404,7 +404,8 @@ var PopOverView = createReactClass({
           <b>{key}:</b> {obj[key]}
         </p>
       );
-      fields.push({ att: key, field: obj[key] });
+      // Using capital letter in _A_ttribute and _V_alue to keep consistency in CSV Header Export.
+      fields.push({ Attribute: key, Value: obj[key] });
     });
 
     var selectRowProp = {
@@ -447,7 +448,7 @@ var PopOverView = createReactClass({
           >
             <TableHeaderColumn
               dataAlign="right"
-              dataField="att"
+              dataField="Attribute"
               width="20%"
               isKey
               dataSort
@@ -456,12 +457,12 @@ var PopOverView = createReactClass({
             </TableHeaderColumn>
             <TableHeaderColumn
               dataAlign="left"
-              dataField="field"
+              dataField="Value"
               width="40%"
               isKey={false}
               dataSort
             >
-              Field
+              Value
             </TableHeaderColumn>
           </BootstrapTable>
         </div>

--- a/dicoogle/src/main/resources/webapp/js/components/search/result/imageView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/imageView.js
@@ -371,7 +371,7 @@ var PopOverView = createReactClass({
   },
   createCustomExportCSVButton : function(onClick) {
     return (
-      <button className="btn btn_dicoogle" onClick={ onClick }><i className="fa fa-download"></i>Export CSV</button>
+      <button className="btn btn_dicoogle" onClick={ onClick }><i className="fa fa-download"></i> Export CSV</button>
     );
   },
   render: function() {

--- a/dicoogle/src/main/resources/webapp/js/components/search/result/imageView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/imageView.js
@@ -369,7 +369,11 @@ var PopOverView = createReactClass({
     this.setState({ data: null });
     this.props.onHide();
   },
-
+  createCustomExportCSVButton : function(onClick) {
+    return (
+      <button className="btn btn_dicoogle" onClick={ onClick }><i className="fa fa-download"></i>Export CSV</button>
+    );
+  },
   render: function() {
     if (this.state.data === null) {
       return (
@@ -393,6 +397,7 @@ var PopOverView = createReactClass({
     var rows = [];
 
     var fields = [];
+    
     Object.keys(obj).forEach(function(key, i) {
       rows.push(
         <p key={i}>
@@ -407,6 +412,9 @@ var PopOverView = createReactClass({
       mode: "none",
       bgColor: "rgb(163, 210, 216)",
       onSelect: this.onRowSelect
+    };
+    const options = {
+      exportCSVBtn: this.createCustomExportCSVButton
     };
     return (
       <Modal
@@ -427,6 +435,9 @@ var PopOverView = createReactClass({
             data={fields}
             selectRow={selectRowProp}
             condensed
+            options={options}
+            exportCSV
+            csvFileName={`${this.props.uid}.csv`}
             pagination
             striped
             hover


### PR DESCRIPTION
Added capability to export dump of metadata to CSV.

This can be useful to re-use the tags for instance in the Export or to easily record/compare metadata from different series/images. 

![image](https://user-images.githubusercontent.com/110873/178105480-ee98fbf0-28cb-410c-8028-b58b60398126.png)
