### PR TITLE
Bulk unindexing for IndexerInterface

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
@@ -28,6 +28,7 @@ import pt.ua.dicoogle.plugins.webui.WebUIPlugin;
 import pt.ua.dicoogle.plugins.webui.WebUIPluginManager;
 import pt.ua.dicoogle.sdk.*;
 import pt.ua.dicoogle.sdk.datastructs.Report;
+import pt.ua.dicoogle.sdk.datastructs.UnindexReport;
 import pt.ua.dicoogle.sdk.datastructs.SearchResult;
 import pt.ua.dicoogle.sdk.datastructs.dim.DimLevel;
 import pt.ua.dicoogle.sdk.settings.ConfigurationHolder;
@@ -45,6 +46,7 @@ import java.net.URI;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.zip.ZipFile;
 
@@ -761,7 +763,34 @@ public class PluginController {
         }
     }
 
-    /** Issue an unindexation procedure to the given indexers.
+    /** Issue the removal of indexed entries in bulk.
+     * 
+     * @param indexProvider the name of the indexer
+     * @param items a collections of item identifiers to unindex
+     * @param progressCallback an optional function (can be `null`),
+     *        called for every batch of items successfully unindexed
+     *        to indicate early progress
+     *        and inform consumers that
+     *        it is safe to remove or exclude the unindexed item
+     * @return an asynchronous task object returning
+     *         a report containing which files were not unindexed,
+     *         and whether some of them were not found in the database
+     * @throws IOException
+     */
+    public Task<UnindexReport> unindex(String indexProvider, Collection<URI> items, Consumer<Collection<URI>> progressCallback) throws IOException {
+        logger.info("Starting unindexing procedure for {} items", items.size());
+
+        IndexerInterface indexer = null;
+        if (indexProvider != null) {
+            indexer = this.getIndexerByName(indexProvider, true);
+        }
+        if (indexer == null) {
+            indexer = this.getIndexingPlugins(true).iterator().next();
+        }
+        return indexer.unindex(items, progressCallback);
+    }
+
+    /** Issue an unindexing procedure to the given indexers.
      * 
      * @param path the URI of the directory or file to unindex
      * @param indexers a collection of providers

--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
@@ -811,7 +811,7 @@ public class PluginController {
     }
 
     public void doRemove(URI uri, StorageInterface si) {
-        if (si.handles(uri)) {
+        if (Objects.equals(uri.getScheme(), si.getScheme())) {
             si.remove(uri);
         } else {
             logger.warn("Storage Plugin does not handle URI: {},{}", uri, si);

--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
@@ -787,7 +787,16 @@ public class PluginController {
         if (indexer == null) {
             indexer = this.getIndexingPlugins(true).iterator().next();
         }
-        return indexer.unindex(items, progressCallback);
+        Task<UnindexReport> task = indexer.unindex(items, progressCallback);
+        if (task != null) {
+            final String taskUniqueID = UUID.randomUUID().toString();
+            task.setName(String.format("[%s]unindex", indexer.getName()));
+            task.onCompletion(() -> {
+                logger.info("Unindexing task [{}] complete", taskUniqueID);
+            });
+            taskManager.dispatch(task);
+        }
+        return task;
     }
 
     /** Issue an unindexing procedure to the given indexers.

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/management/UnindexServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/management/UnindexServlet.java
@@ -121,8 +121,8 @@ public class UnindexServlet extends HttpServlet {
             for (Task<UnindexReport> task: tasks) {
                 try {
                     UnindexReport report = task.get();
-                    indexed = uris.size() - report.errorCount();
-                    failed = report.getUnindexFailures().size();
+                    indexed = uris.size() - report.notUnindexedFileCount();
+                    failed = report.failedFileCount();
                     notfound = report.getNotFound().size();
                 } catch (Exception ex) {
                     logger.error("Task to unindex items in {} failed", providers.get(i), ex);

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/IndexerInterface.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/IndexerInterface.java
@@ -25,41 +25,58 @@ import pt.ua.dicoogle.sdk.datastructs.Report;
 import pt.ua.dicoogle.sdk.task.Task;
 
 /**
- * Index Interface Plugin. Indexers analyze documents for performing queries. They may index
- * documents by DICOM metadata for instance, but other document processing procedures may be involved.
+ * Indexing plugin interface.
+ * 
+ * Indexers analyze and record documents for future retrieval.
+ * They are primarily designed to index DICOM meta-data,
+ * which in that case they are accompanied by a query plugin,
+ * and both plugins are called <em>DIM providers</em>.
+ * However, indexers are not restricted to processing DICOM files,
+ * or to retrieving and indexing meta-data.
  *
- * @author Luís A. Bastião Silva <bastiao@ua.pt>
+ * @author Luís A. Bastião Silva <bastiao@bmd-software.com>
  * @author Frederico Valente <fmvalente@ua.pt>
  */
 public interface IndexerInterface extends DicooglePlugin {
 
     /**
-     * Indexes the file path to the database. Indexation procedures are asynchronous, and will return
+     * Indexes the file path to the database. Indexing procedures are asynchronous, and will return
      * immediately after the call. The outcome is a report that can be retrieved from the given task
      * as a future.
      *
      * @param file directory or file to index
-     * @return a representation of the asynchronous indexation task
+     * @return a representation of the asynchronous indexing task
      */
     public Task<Report> index(StorageInputStream file, Object... parameters);
 
     /**
-     * Indexes multiple file paths to the database. Indexation procedures are asynchronous, and will return
+     * Indexes multiple file paths to the database. Indexing procedures are asynchronous, and will return
      * immediately after the call. The outcomes are aggregated into a single report and can be retrieved from
      * the given task as a future.
      *
      * @param files a collection of directories and/or files to index
-     * @return a representation of the asynchronous indexation task
+     * @return a representation of the asynchronous indexing task
      */
     public Task<Report> index(Iterable<StorageInputStream> files, Object... parameters);
 
     /**
-     * Checks whether the file in the given path can be indexed by this indexer. The indexer should verify if
-     * the file holds compatible content (e.g. a DICOM file). If this method returns false, the file will not
-     * be indexed.
-     *
+     * Checks whether the file in the given path can be indexed by this indexer.
+     * 
+     * The method should return <code>false</code> <em>if and only if</em>
+     * it is sure that the file cannot be indexed,
+     * by observation of its URI.
+     * This method exists in order to filter out files
+     * that are obviously incompatible for the indexer.
+     * However, there are situations where this is not reliable,
+     * since the storage is free to establish its own file naming rules,
+     * and that can affect the file extension.
+     * In case of doubt, it is recommended to leave the default implementation,
+     * which returns true unconditionally.
+     * Attempts to read invalid files can instead
+     * be handled gracefully by the indexer by capturing exceptions.
+     * 
      * @param path a URI to the file to check
-     * @return whether the indexer can handle the file at the given path
+     * @return whether the item at the given URI path can be fed to this indexer
      */
     public default boolean handles(URI path) {
         return true;

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/IndexerInterface.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/IndexerInterface.java
@@ -143,10 +143,10 @@ public interface IndexerInterface extends DicooglePlugin {
                         }
                     } else {
                         // failed to unindex, reason unknown
-                        failures.add(new FailedUnindex(uri, null));
+                        failures.add(new FailedUnindex(Collections.singleton(uri), null));
                     }
                 } catch (Exception ex) {
-                    failures.add(new FailedUnindex(uri, ex));
+                    failures.add(new FailedUnindex(Collections.singleton(uri), ex));
                 }
             }
             return UnindexReport.withFailures(failures);

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/IndexerInterface.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/IndexerInterface.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 
 import pt.ua.dicoogle.sdk.datastructs.Report;
@@ -123,7 +122,8 @@ public interface IndexerInterface extends DicooglePlugin {
      *        to indicate early progress
      *        and inform consumers that
      *        it is safe to remove or exclude the unindexed item
-     * @return a report containing which files were not unindexed,
+     * @return an asynchronous task object returning
+     *         a report containing which files were not unindexed,
      *         and whether some of them were not found in the database
      * @throws IOException if an error occurred
      *         before the unindexing operation could start,

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/UnindexReport.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/UnindexReport.java
@@ -43,7 +43,7 @@ public final class UnindexReport implements Serializable {
          * when no cause is specified.
          */
         public final Exception cause;
-        
+
         /** Creates a failed unindex description
          * due to the file not being found in the database.
          * 
@@ -54,9 +54,9 @@ public final class UnindexReport implements Serializable {
             Objects.requireNonNull(uri);
             this.uri = uri;
             this.cause = cause;
-        }   
+        }
     }
-    
+
     /** URIs of files which were not found. */
     private final Collection<URI> notFound;
     private final Collection<FailedUnindex> failures;
@@ -66,7 +66,7 @@ public final class UnindexReport implements Serializable {
      * in which case is equivalent to passing an empty collection.
      * @param notFound the URIs of files which were not found
      * @param failures the error reports of files which could not be unindexed
-     */    
+     */
     public UnindexReport(Collection<URI> notFound, Collection<FailedUnindex> failures) {
         if (notFound == null) {
             notFound = Collections.emptyList();

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/UnindexReport.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/UnindexReport.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (C) 2014  Universidade de Aveiro, DETI/IEETA, Bioinformatics Group - http://bioinformatics.ua.pt/
+ *
+ * This file is part of Dicoogle/dicoogle-sdk.
+ *
+ * Dicoogle/dicoogle-sdk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Dicoogle/dicoogle-sdk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Dicoogle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package pt.ua.dicoogle.sdk.datastructs;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Objects;
+
+/** Describes a report for a bulk unindexing operation.
+ */
+public final class UnindexReport implements Serializable {
+
+    /** The description of a file which
+     * could not be unindexed due to an error.
+     * 
+     * When an error of this kind occurs,
+     * it is not specified whether the file remains indexed or not.
+     */
+    public static final class FailedUnindex implements Serializable {
+        /** The URI to the item which failed to unindex. */
+        public final URI uri;
+
+        /** The exception describing the error which led to the failure.
+         * This field can be <code>null</code>
+         * when no cause is specified.
+         */
+        public final Exception cause;
+        
+        /** Creates a failed unindex description
+         * due to the file not being found in the database.
+         * 
+         * @param uri the URI of the file which could not be unindexed
+         * @param cause the underlying exception, if any
+         */
+        public FailedUnindex(URI uri, Exception cause) {
+            Objects.requireNonNull(uri);
+            this.uri = uri;
+            this.cause = cause;
+        }   
+    }
+    
+    /** URIs of files which were not found. */
+    private final Collection<URI> notFound;
+    private final Collection<FailedUnindex> failures;
+
+    /** Creates a full report for a bulk unindexing operation.
+     * All parameters are nullable,
+     * in which case is equivalent to passing an empty collection.
+     * @param notFound the URIs of files which were not found
+     * @param failures the error reports of files which could not be unindexed
+     */    
+    public UnindexReport(Collection<URI> notFound, Collection<FailedUnindex> failures) {
+        if (notFound == null) {
+            notFound = Collections.emptyList();
+        }
+        if (failures == null) {
+            failures = Collections.emptyList();
+        }
+        this.notFound = notFound;
+        this.failures = failures;
+    }
+
+    /** Creates a report that all files were successfully unindexed. */
+    public static UnindexReport ok() {
+        return new UnindexReport(null, null);
+    }
+
+    /** Creates a report with the files which failed to unindex
+     * due to some error.
+     */
+    public static UnindexReport withFailures(Collection<FailedUnindex> failures) {
+        return new UnindexReport(null, failures);
+    }
+
+    /** Returns whether all files were successfully unindexed from the database
+     * as requested.
+     */
+    public boolean isOk() {
+        return notFound.isEmpty() && failures.isEmpty();
+    }
+
+    /** Returns whether all files are no longer unindexed,
+     * meaning that no errors occurred when trying to unindex an indexed file.
+     * 
+     * This is different from {@link #isOk()} in that
+     * it does not imply that all files to unindex were found in the database.
+     * 
+     * @return true if no unindex failures are reported other than files not found
+     */
+    public boolean allUnindexed() {
+        return failures.isEmpty();
+    }
+
+    /** Obtains an immutable collection to
+     * the files which failed to unindex due to an error.
+     */
+    public Collection<FailedUnindex> getUnindexFailures() {
+        return Collections.unmodifiableCollection(this.failures);
+    }
+
+    /** Obtains an immutable collection to the files
+     *  which were not found in the index.
+     */
+    public Collection<URI> getNotFound() {
+        return Collections.unmodifiableCollection(this.notFound);
+    }
+}

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/UnindexReport.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/UnindexReport.java
@@ -122,4 +122,11 @@ public final class UnindexReport implements Serializable {
     public Collection<URI> getNotFound() {
         return Collections.unmodifiableCollection(this.notFound);
     }
+
+    /** Return the total count of files which were requested to be unindexed,
+     * but were either not found or failed to unindex.
+     */
+    public long errorCount() {
+        return this.failures.size() + this.notFound.size();
+    }
 }

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/UnindexReport.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/UnindexReport.java
@@ -130,10 +130,30 @@ public final class UnindexReport implements Serializable {
         return Collections.unmodifiableCollection(this.notFound);
     }
 
-    /** Returns the total count of errors reported during unindexing
-     * due to either not having been found or other failures.
+    /** Returns the total count of failures reported during unindexing.
+     *
+     * Note that this does not necessarily correspond to
+     * the number of files affected,
+     * and does not include files which were not found.
      */
-    public long errorCount() {
-        return this.failures.size() + this.notFound.size();
+    public long failureCount() {
+        return this.failures.size();
+    }
+
+    /** Returns the total count of files which were not unindexed,
+     * whether because they were not found
+     * or could not be unindexed for other reasons.
+     */
+    public long notUnindexedFileCount() {
+        return this.notFound.size() + failedFileCount();
+    }
+
+    /** Returns the total count of files which failed to unindexed
+     * for reasons other than the files not being found.
+     */
+    public long failedFileCount() {
+        return this.failures.stream()
+                .mapToLong(f -> f.urisAffected.size())
+                .sum();
     }
 }


### PR DESCRIPTION
This proposes an extension to the `IndexerInterface` so that API consumers can request multiple items to be unindexed at once. Resolves #594.

This extension to the API should be carefully reviewed and evaluated to ensure that implementers can use it properly and that it can be well integrated into existing workflows.

Breaking changes are minimal. It is only a problem if an existing plugin already has a method with the exact same signature, which is unlikely. Hence, we are in position to deliver this in 3.4.0, or postpone to version 4 anyway.

---

To ensure some level of quality in this suggestion, we should have:

- [x] at least one proof of concept plugin implementation
   - We could take this as an opportunity to move forward with hosting the open plugins on GitHub. 
- [x] at least one example that the Dicoogle core can consume this method in a usable way without downsides
   - I suggest an extension to the unindexing service so that it accepts multiple URIs

---

Problems resolved in the latest version:

- [x] No way to retrieve the task's unindexing progress from another thread. **Now has a second parameter as a progress callback.**
- [x] Even if the indexer periodically flushes some unindexing operations during the task, other routines cannot work with URIs which have already been unindexed before the task ends completely. This could pose an issue in file removal tasks, because it requires `unindex` to finish before we start cleaning up the files. **The operation is now asynchronous.**

---

Known caveats:
- ~~It is not clear whether we can properly constrain the number of parallel unindexing tasks by pushing this to our indexing task pool. The current indexing task manager depends on task objects returning a different kind of report, which `UnindexReport` does not implement. Maybe it should be subclassed from `Report`?~~ As of the latest version, unindexing tasks can be dispatched by the indexer thread pool.
- Having a second parameter to keep track of progress is quirky. One would naturally expect an `UnindexTask<T>` to extend `Task<T>`, but it is very different from indexing tasks and would make it even harder to attach to the task pool.
- The resulting object is too complex and granular. While there is a lot of power in being able to specify an error for each URI, it is not always the case that files will be unindexed independently, so it may be hard to build such results in batched unindexing.
