### PR TITLE
Add opt-in `call-shutdown` setting to call plugin shutdown routines on Dicoogle shutdown

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/Main.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/Main.java
@@ -92,7 +92,7 @@ public class Main {
                 System.out.println("-w : Start the server and load web application in default browser (default)");
             }
         }
-        /** Register System Exceptions Hook */
+        // Register System Exceptions Hook
         ExceptionHandler.registerExceptionHandler();
     }
 
@@ -167,7 +167,7 @@ public class Main {
         Authentication.getInstance();
 
         // Initialize platform controller
-        PluginController.getInstance();
+        PluginController pluginController = PluginController.getInstance();
 
         // Start the initial Services of Dicoogle
         pt.ua.dicoogle.server.ControlServices.getInstance();
@@ -178,5 +178,17 @@ public class Main {
         if (settings.getArchiveSettings().isDirectoryWatcherEnabled()) {
             AsyncIndex asyncIndex = new AsyncIndex();
         }
+
+        // set up shutdown hook
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            boolean shutdownPlugins = true;
+
+            if (shutdownPlugins) {
+                logger.debug("Initiating plugin shutdown sequence...");
+                // call shutdown routines
+                pluginController.shutdown();
+                logger.debug("Plugins were shut down.");
+            }
+        }));
     }
 }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/Main.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/Main.java
@@ -181,7 +181,7 @@ public class Main {
 
         // set up shutdown hook
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            boolean shutdownPlugins = true;
+            boolean shutdownPlugins = settings.getArchiveSettings().isCallShutdown();
 
             if (shutdownPlugins) {
                 logger.debug("Initiating plugin shutdown sequence...");

--- a/dicoogle/src/main/java/pt/ua/dicoogle/core/settings/LegacyServerSettings.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/core/settings/LegacyServerSettings.java
@@ -1270,6 +1270,17 @@ public class LegacyServerSettings implements ServerSettings {
         public boolean isEncryptUsersFile() {
             return LegacyServerSettings.this.isEncryptUsersFile();
         }
+
+        @JsonGetter("call-shutdown")
+        @Override
+        public boolean isCallShutdown() {
+            return false;
+        }
+
+        @Override
+        public void setCallShutdown(boolean shutdown) {
+            // no-op, not supported
+        }
     }
 
     @JsonGetter("archive")

--- a/dicoogle/src/main/java/pt/ua/dicoogle/core/settings/part/ArchiveImpl.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/core/settings/part/ArchiveImpl.java
@@ -44,6 +44,9 @@ public class ArchiveImpl implements ServerSettings.Archive {
         a.dirWatcherEnabled = false;
         a.watchDirectory = "";
 
+        // Note: make it `true` in Dicoogle 4
+        a.callShutdown = false;
+
         a.dimProviders = Collections.EMPTY_LIST;
         a.defaultStorage = Collections.EMPTY_LIST;
 
@@ -91,6 +94,9 @@ public class ArchiveImpl implements ServerSettings.Archive {
 
     @JsonProperty("node-name")
     private String nodeName;
+
+    @JsonProperty("call-shutdown")
+    private boolean callShutdown;
 
     public boolean getSaveThumbnails() {
         return saveThumbnails;
@@ -159,11 +165,13 @@ public class ArchiveImpl implements ServerSettings.Archive {
     }
 
     @Override
-    public String toString() {
-        return "ArchiveImpl{" + "saveThumbnails=" + saveThumbnails + ", thumbnailSize=" + thumbnailSize
-                + ", indexerEffort=" + indexerEffort + ", dimProviders=" + dimProviders + ", defaultStorage="
-                + defaultStorage + ", dirWatcherEnabled=" + dirWatcherEnabled + ", watchDirectory='" + watchDirectory
-                + '\'' + ", mainDirectory='" + mainDirectory + '\'' + ", nodeName='" + nodeName + '\'' + '}';
+    public boolean isCallShutdown() {
+        return this.callShutdown;
+    }
+
+    @Override
+    public void setCallShutdown(boolean callShutdown) {
+        this.callShutdown = callShutdown;
     }
 
     @Override
@@ -174,5 +182,14 @@ public class ArchiveImpl implements ServerSettings.Archive {
     @Override
     public void setEncryptUsersFile(boolean encrypt) {
         this.encryptUsersFile = encrypt;
+    }
+
+    @Override
+    public String toString() {
+        return "ArchiveImpl{" + "saveThumbnails=" + saveThumbnails + ", thumbnailSize=" + thumbnailSize
+                + ", indexerEffort=" + indexerEffort + ", dimProviders=" + dimProviders + ", defaultStorage="
+                + defaultStorage + ", dirWatcherEnabled=" + dirWatcherEnabled + ", watchDirectory='" + watchDirectory
+                + '\'' + ", mainDirectory='" + mainDirectory + '\'' + ", nodeName='" + nodeName + '\''
+                + ", callShutdown=" + callShutdown + ", encryptUsersFile=" + encryptUsersFile + '}';
     }
 }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
@@ -278,7 +278,7 @@ public class PluginController {
                 logger.debug("Plugin set {} is shutting down", plugin.getName());
                 plugin.shutdown();
             } catch (Exception ex) {
-                logger.warn("Plugin set {} did not shutdown gracefully", plugin.getName(), ex);
+                logger.error("Plugin set {} did not shutdown gracefully", plugin.getName(), ex);
             }
         }
     }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
@@ -263,16 +263,23 @@ public class PluginController {
     /**
      * Stops the plugins and saves the settings
      */
-    public void shutdown() throws IOException {
+    public void shutdown() {
         for (PluginSet plugin : pluginSets) {
-            // TODO: I Think it is better to enable auto-save settings
-            /*Settings settings = plugin.getSettings();
+            // TODO(#605) Consider auto-saving settings on shutdown:
+            /*
+            Settings settings = plugin.getSettings();
             if (settings != null) {
                 settings.save();
             }
             */
-            // lets the plugin know we are shutting down
-            plugin.shutdown();
+
+            // let the plugin know we are shutting down
+            try {
+                logger.debug("Plugin set {} is shutting down", plugin.getName());
+                plugin.shutdown();
+            } catch (Exception ex) {
+                logger.warn("Plugin set {} did not shutdown gracefully", plugin.getName(), ex);
+            }
         }
     }
 

--- a/dicoogle/src/test/java/pt/ua/dicoogle/core/settings/ServerSettingsTest.java
+++ b/dicoogle/src/test/java/pt/ua/dicoogle/core/settings/ServerSettingsTest.java
@@ -73,6 +73,7 @@ public class ServerSettingsTest {
         assertEquals("/opt/my-data/watched", ar.getWatchDirectory());
         assertEquals("dicoogle01", ar.getNodeName());
         assertEquals(true, ar.isEncryptUsersFile());
+        assertEquals(true, ar.isCallShutdown());
 
         assertSameContent(Collections.singleton("lucene"), ar.getDIMProviders());
         assertSameContent(Collections.singleton("filestorage"), ar.getDefaultStorage());
@@ -143,6 +144,7 @@ public class ServerSettingsTest {
         assertEquals(100, ar.getIndexerEffort());
         assertEquals("", ar.getWatchDirectory());
         assertEquals(null, ar.getNodeName());
+        assertEquals(false, ar.isCallShutdown());
 
         assertEquals("DICOOGLE-STORAGE", dcm.getAETitle());
 

--- a/dicoogle/src/test/resources/pt/ua/dicoogle/core/settings/test-config-new.xml
+++ b/dicoogle/src/test/resources/pt/ua/dicoogle/core/settings/test-config-new.xml
@@ -18,6 +18,7 @@
         <enable-watch-directory>true</enable-watch-directory>
         <watch-directory>/opt/my-data/watched</watch-directory>
         <node-name>dicoogle01</node-name>
+        <call-shutdown>true</call-shutdown>
     </archive>
     <dicom-services>
         <aetitle>TEST-STORAGE</aetitle>

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/settings/server/ServerSettings.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/settings/server/ServerSettings.java
@@ -70,6 +70,8 @@ public interface ServerSettings extends ServerSettingsReader {
         void setDefaultStorage(List<String> storages);
 
         void setNodeName(String nodeName);
+
+        void setCallShutdown(boolean shutdown);
     }
 
     @JsonGetter("dicom-services")

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/settings/server/ServerSettingsReader.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/settings/server/ServerSettingsReader.java
@@ -87,6 +87,12 @@ public interface ServerSettingsReader {
 
         @JsonGetter("node-name")
         String getNodeName();
+
+        /**
+         * Whether to call the shutdown routine for installed plugin sets.
+         */
+        @JsonGetter("call-shutdown")
+        boolean isCallShutdown();
     }
 
     @JsonGetter("archive")


### PR DESCRIPTION
Although I was originally thinking about bringing the shutdown hook to call `shutdown()` on all plugin sets in Dicoogle 4, we felt that there was a need to have this earlier. This PR makes this capability _opt-in_, so that it does not require any breaking changes and does not lead to surprising behaviors.

Resolves #149.

- New server settings XML element `<call-shutdown>` in `<archive>`
   - if true, Dicoogle will call  `shutdown` on (not dead) plugin sets installed
   - this is false by default, but the plan is to make it true by default (opt-out) in Dicoogle 4, and maybe even deprecate it, so that in later versions the behavior becomes mandatory.
   - add test coverage for call-shutdown setting
- add shutdown hook to call  `PluginController.shutdown`
   - Although we've had issues with this when interoperating with Sentry, we currently believe that this functionality is more important than Sentry integration.
- improve `PluginController.shutdown()` by catching and reporting all exceptions individually