### PR TITLE
Remove duplicate SOP classes in transfer options

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/SOPList.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/SOPList.java
@@ -44,8 +44,6 @@ public class SOPList {
     private Hashtable<String, TransfersStorage> table;
 
     private String[] SOP = {
-        UID.BasicStudyContentNotificationSOPClassRetired, 
-        UID.StoredPrintStorageSOPClassRetired,
         UID.BasicStudyContentNotificationSOPClassRetired,
         UID.StoredPrintStorageSOPClassRetired,
         UID.HardcopyGrayscaleImageStorageSOPClassRetired,

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/SOPList.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/SOPList.java
@@ -91,7 +91,7 @@ public class SOPList {
         UID.SpatialFiducialsStorage,
         UID.RealWorldValueMappingStorage,
         UID.SecondaryCaptureImageStorage,
-        UID.MultiFrameSingleBitSecondaryCaptureImageStorage,        
+        UID.MultiFrameSingleBitSecondaryCaptureImageStorage,
         UID.MultiFrameGrayscaleByteSecondaryCaptureImageStorage,
         UID.MultiFrameGrayscaleWordSecondaryCaptureImageStorage,
         UID.MultiFrameTrueColorSecondaryCaptureImageStorage,


### PR DESCRIPTION
These two SOP classes were appearing twice in the global transfer options list. Likely a mistake from #474.

There could probably be some more cleaning up in this class, but I kept the PR simple to avoid having too many collisions with #516.