### PR TITLE
Remove dependency on commons-codec

### DIFF
--- a/dicoogle/pom.xml
+++ b/dicoogle/pom.xml
@@ -420,12 +420,6 @@
         </dependency>
 
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>1.8</version>
-        </dependency>
-
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.4</version>

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/DicoogleWeb.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/DicoogleWeb.java
@@ -18,7 +18,6 @@
  */
 package pt.ua.dicoogle.server.web;
 
-import org.apache.commons.codec.digest.Md5Crypt;
 import pt.ua.dicoogle.core.settings.ServerSettingsManager;
 import pt.ua.dicoogle.plugins.PluginController;
 import pt.ua.dicoogle.plugins.webui.WebUIPlugin;
@@ -56,6 +55,7 @@ import pt.ua.dicoogle.server.web.servlets.management.TransferOptionsServlet;
 
 import java.io.File;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.EnumSet;
 
@@ -78,6 +78,8 @@ import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlets.GzipFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.hash.Hashing;
 
 import pt.ua.dicoogle.server.LegacyRestletApplication;
 import pt.ua.dicoogle.server.web.servlets.accounts.LogoutServlet;
@@ -254,7 +256,7 @@ public class DicoogleWeb {
                 if (WebUIModuleServlet.isPrerelease(plugin.getVersion())) {
                     // pre-release, use hash (to facilitate development)
                     String fingerprint = PluginController.getInstance().getWebUIModuleJS(name);
-                    return '"' + Md5Crypt.md5Crypt(fingerprint.getBytes()) + '"';
+                    return '"' + Hashing.murmur3_32().hashString(fingerprint, StandardCharsets.UTF_8).toString() + '"';
                 } else {
                     // normal release, use weak ETag
                     String pProcess = req.getParameter("process");

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/utils/LocalImageCache.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/utils/LocalImageCache.java
@@ -26,11 +26,13 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 
-import org.apache.commons.codec.digest.DigestUtils;
+import com.google.common.hash.Hashing;
+
 import pt.ua.dicoogle.server.web.dicom.Convert2PNG;
 
 /**
@@ -227,7 +229,7 @@ public class LocalImageCache extends Thread implements ImageRetriever {
 
     protected static String toFileName(String imageUri, int frameNumber, boolean thumbnail) {
         String filecode = imageUri + ':' + frameNumber + ':' + (thumbnail ? '1' : '0');
-        return DigestUtils.sha256Hex(filecode) + ".png";
+        return Hashing.sha256().hashString(filecode, StandardCharsets.UTF_8).toString() + ".png";
     }
 
     @Override


### PR DESCRIPTION
This removes `commons-codec` for hashing, replacing it with Guava's hashing capabilities. These changes are safe because we do not need to ensure forward compatibility with the hash output in either case.

The `commons-codec` was outdated and often resulted in conflicts at plugins depending on a more recent version.
