### PR TITLE
Remove aclmanager

### DIFF
--- a/dicoogle/pom.xml
+++ b/dicoogle/pom.xml
@@ -382,13 +382,6 @@
             <artifactId>dcm4che-imageio</artifactId>
             <version>${dcm4che.version}</version>
         </dependency>
-
-        <dependency>
-            <groupId>com.bmd.archive</groupId>
-            <artifactId>aclmanager</artifactId>
-            <version>1.2.0</version>
-        </dependency>
-
         <dependency>
             <groupId>pt.ua.ieeta</groupId>
             <artifactId>dicoogle-sdk</artifactId>

--- a/dicoogle/pom.xml
+++ b/dicoogle/pom.xml
@@ -382,6 +382,13 @@
             <artifactId>dcm4che-imageio</artifactId>
             <version>${dcm4che.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.jdom</groupId>
+            <artifactId>jdom2</artifactId>
+            <version>2.0.6.1</version>
+        </dependency>
+
         <dependency>
             <groupId>pt.ua.ieeta</groupId>
             <artifactId>dicoogle-sdk</artifactId>

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/queryretrieve/CFindServiceSCP.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/queryretrieve/CFindServiceSCP.java
@@ -33,7 +33,6 @@ import org.dcm4che2.net.DicomServiceException;
 import org.dcm4che2.net.DimseRSP;
 import org.dcm4che2.net.service.CFindService;
 
-import aclmanager.core.LuceneQueryACLManager;
 import pt.ua.dicoogle.DicomLog.LogDICOM;
 import pt.ua.dicoogle.DicomLog.LogLine;
 import pt.ua.dicoogle.DicomLog.LogXML;
@@ -52,19 +51,12 @@ public class CFindServiceSCP extends CFindService {
             ServerSettingsManager.getSettings().getDicomServicesSettings().getQueryRetrieveSettings().getRspDelay();
 
     private DicomNetwork service = null;
-    private LuceneQueryACLManager luke = null;
 
     private boolean superSpeed = false;
 
 
     public CFindServiceSCP(String[] multiSop, Executor e) {
         super(multiSop, e);
-        this.luke = null;
-    }
-
-    public CFindServiceSCP(String[] multiSop, Executor e, LuceneQueryACLManager luke) {
-        super(multiSop, e);
-        this.luke = luke;
     }
 
     /*** CFIND */
@@ -113,7 +105,7 @@ public class CFindServiceSCP extends CFindService {
          * Search information at Lucene Indexer
          * So the FindRSP will fill the DimRSP
          */
-        replay = new FindRSP(keys, rsp, as.getCallingAET(), luke);
+        replay = new FindRSP(keys, rsp, as.getCallingAET());
 
 
         if (!superSpeed) {

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/queryretrieve/CMoveServiceSCP.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/queryretrieve/CMoveServiceSCP.java
@@ -18,8 +18,6 @@
  */
 package pt.ua.dicoogle.server.queryretrieve;
 
-import aclmanager.core.LuceneQueryACLManager;
-import aclmanager.models.Principal;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -57,18 +55,14 @@ public class CMoveServiceSCP extends CMoveService {
 
 
     private DicomNetwork service = null;
-    private LuceneQueryACLManager luke;
 
-    public CMoveServiceSCP(String[] sopClasses, Executor executor, LuceneQueryACLManager luke) {
+    public CMoveServiceSCP(String[] sopClasses, Executor executor) {
         super(sopClasses, executor);
-        this.luke = luke;
     }
 
     public CMoveServiceSCP(String sopClass, Executor executor) {
         super(sopClass, executor);
-        this.luke = null;
     }
-
 
     @Override
 
@@ -152,12 +146,6 @@ public class CMoveServiceSCP extends CMoveService {
         }
         String query = cfind.getQueryString();
 
-        if (luke != null) {
-            String filterQuery = luke.produceQueryFilter(new Principal("AETitle", as.getCallingAET()));
-            if (query.length() > 0)
-                query += filterQuery;
-        }
-        // TODO: FIlter Query;
         SearchDicomResult search = new SearchDicomResult(query, true, extrafields, SearchDicomResult.QUERYLEVEL.IMAGE);
         ArrayList<URI> files = new ArrayList<URI>();
 

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/queryretrieve/FindRSP.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/queryretrieve/FindRSP.java
@@ -26,9 +26,6 @@
  */
 package pt.ua.dicoogle.server.queryretrieve;
 
-import aclmanager.core.LuceneQueryACLManager;
-import aclmanager.models.Principal;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import org.slf4j.LoggerFactory;
@@ -64,14 +61,12 @@ public class FindRSP implements DimseRSP {
     SearchDicomResult search = null;
 
     private String callingAET;
-    private LuceneQueryACLManager luke;
 
-    public FindRSP(DicomObject keys, DicomObject rsp, String callingAET, LuceneQueryACLManager luke) {
+    public FindRSP(DicomObject keys, DicomObject rsp, String callingAET) {
         this.rsp = rsp;
         this.keys = keys;
 
         this.callingAET = callingAET;
-        this.luke = luke;
 
 
         /** Debug - show keys, rsp, index */
@@ -201,14 +196,6 @@ public class FindRSP implements DimseRSP {
     }
 
     private String applyQueryFilter(String normalQuery) {
-        if (luke == null)
-            return normalQuery;
-        // LuceneQueryACLManager luke = new LuceneQueryACLManager(manager);
-
-        String query = luke.produceQueryFilter(new Principal("AETitle", callingAET));
-        if (query.length() > 0)
-            return normalQuery + query;
-
         return normalQuery;
     }
 

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/queryretrieve/QueryRetrieve.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/queryretrieve/QueryRetrieve.java
@@ -19,11 +19,6 @@
 package pt.ua.dicoogle.server.queryretrieve;
 
 
-import aclmanager.core.ACLManagerInterface;
-import aclmanager.core.ACLXMLParser;
-import aclmanager.core.LuceneQueryACLManager;
-import aclmanager.exceptions.CannotParseFileException;
-
 import java.io.File;
 import java.util.Collection;
 import java.util.concurrent.Executor;
@@ -94,8 +89,6 @@ public class QueryRetrieve extends DicomNetwork {
     private static String[] moveSop =
             {UID.StudyRootQueryRetrieveInformationModelMOVE, UID.PatientRootQueryRetrieveInformationModelMOVE};
 
-    private LuceneQueryACLManager luke;
-
     public QueryRetrieve() {
 
         super("DICOOGLE-QUERYRETRIEVE");
@@ -138,19 +131,8 @@ public class QueryRetrieve extends DicomNetwork {
         this.localAE.setMaxPDULengthReceive(s.getMaxPDULengthReceive() + 1000);
         this.localAE.setMaxPDULengthSend(s.getMaxPDULengthSend() + 1000);
 
-        try {// TODO: HERE IIII XD
-            File xmlFile = new File(Platform.homePath() + "aetitleFilter.xml");
-
-            if (xmlFile.exists()) {
-                ACLManagerInterface manager = ACLXMLParser.parseFromFile(xmlFile);
-                this.luke = new LuceneQueryACLManager(manager);
-            }
-        } catch (CannotParseFileException ex) {
-            LoggerFactory.getLogger(CFindServiceSCP.class).error(ex.getMessage(), ex);
-        }
-
-        this.localAE.register(new CMoveServiceSCP(moveSop, executor, luke));
-        this.localAE.register(new CFindServiceSCP(multiSop, executor, luke));
+        this.localAE.register(new CMoveServiceSCP(moveSop, executor));
+        this.localAE.register(new CFindServiceSCP(multiSop, executor));
         this.localAE.register(new VerificationService());
 
         this.localConn.setPort(s.getPort());


### PR DESCRIPTION
Dicoogle was holding remnants of a DICOM ACL mechanism which filtered C-Find requests by the title of the AE which provided the DICOM objects. At this time, support for this filter would require a very custom indexer plugin and it is very unlikely that anyone is still depending on it (still I would appreciate a confirmation from @bastiao).

Closes #636

### Summary

- Remove uses of ACL manager
- Remove dependency aclmanager from core
- Add dependency jdom2 to core, in its latest version 2.0.6.1
   - It was a transitive dependency that we were still depending on.