### PR TITLE
Update logging dependencies and add jul-to-slf4j

### DIFF
--- a/dicoogle/pom.xml
+++ b/dicoogle/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <log4j.version>2.17.1</log4j.version>
+        <log4j.version>2.17.2</log4j.version>
         <maven.build.timestamp.format>yyyyMMdd_HHmm</maven.build.timestamp.format>
         <buildNumber>${maven.build.timestamp}</buildNumber>
     </properties>

--- a/dicoogle/pom.xml
+++ b/dicoogle/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <log4j.version>2.17.2</log4j.version>
+        <log4j.version>2.20.0</log4j.version>
         <maven.build.timestamp.format>yyyyMMdd_HHmm</maven.build.timestamp.format>
         <buildNumber>${maven.build.timestamp}</buildNumber>
     </properties>

--- a/dicoogle/pom.xml
+++ b/dicoogle/pom.xml
@@ -436,6 +436,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
             <version>${log4j.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <jetty.version>9.0.3.v20130506</jetty.version>
         <restlet.version>2.1.2</restlet.version>
         <dcm4che.version>2.0.29</dcm4che.version>
-        <slf4j.version>1.7.12</slf4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
     </properties>
     <build>
         <plugins>


### PR DESCRIPTION
### Summary

- Update logging dependencies:
   - slf4j to 1.7.36
   - log4j to 2.20.0
- Add `jul-to-slf4j` so that it is possible to collect logs from libraries using java util logging