### PR TITLE
imp/Remove uri from default search servlet fields

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/search/SearchServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/search/SearchServlet.java
@@ -60,7 +60,7 @@ public class SearchServlet extends HttpServlet {
 
     private final Collection<String> DEFAULT_FIELDS = Arrays.asList("SOPInstanceUID", "StudyInstanceUID",
             "SeriesInstanceUID", "PatientID", "PatientName", "PatientSex", "Modality", "StudyDate", "StudyID",
-            "StudyDescription", "SeriesNumber", "SeriesDescription", "InstitutionName", "InstanceNumber", "uri");
+            "StudyDescription", "SeriesNumber", "SeriesDescription", "InstitutionName", "InstanceNumber");
 
     public enum SearchType {
         ALL, PATIENT;


### PR DESCRIPTION
This PR removes `uri` from the default search result fields, in order to prevent replicating this information inadvertently.