### PR TITLE
Update CI workflows

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,6 +7,12 @@ on:
     branches: [ dev ]
   pull_request:
     branches: [ dev ]
+    paths:
+     - 'pom.xml'
+     - 'short-license.txt'
+     - 'dicoogle/**'
+     - 'sdk/**'
+     - '!dicoogle/src/main/resources/webapp/**'
 
 jobs:
   build:
@@ -18,18 +24,12 @@ jobs:
         java-version: ['8', '11']
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - uses: actions/checkout@v3
+    - name: Set up Java (JDK ${{ matrix.java-version }})
       uses: actions/setup-java@v2
       with:
         distribution: 'zulu'
         java-version: ${{ matrix.java-version }}
-    - name: Cache local Maven repo
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-java${{ matrix.java-version }}-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-java${{ matrix.java-version }}-
+        cache: 'maven'
     - name: Build with Maven
       run: mvn -B package license:check -Dskip.installnodenpm -Dskip.npm -Dskip.format --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,6 +12,7 @@ on:
      - 'short-license.txt'
      - 'dicoogle/**'
      - 'sdk/**'
+     - '.github/workflows/maven.yml'
      - '!dicoogle/src/main/resources/webapp/**'
 
 jobs:

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -6,6 +6,9 @@ on:
     branches: [ dev ]
   pull_request:
     branches: [ dev ]
+    paths:
+     - 'dicoogle/src/main/resources/webapp/**'
+     - 'webcore/**'
 
 jobs:
   build:
@@ -14,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [16.x, lts/*, latest]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         # Recommended versions to include:
         # - minimum supported version
@@ -22,12 +25,14 @@ jobs:
         # - latest stable
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
+        cache: 'npm'
     - working-directory: ./dicoogle/src/main/resources/webapp
       run: npm ci
-    - working-directory: ./dicoogle/src/main/resources/webapp
+    - name: Build webapp
+      working-directory: ./dicoogle/src/main/resources/webapp
       run: npm run build

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -32,7 +32,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-        cache-dependency-path: 'dicoogle/src/main/resources/webapp,webcore'
+        cache-dependency-path: '**/package-lock.json'
     - working-directory: ./dicoogle/src/main/resources/webapp
       run: npm ci
     - name: Check & build webapp

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -33,6 +33,6 @@ jobs:
         cache: 'npm'
     - working-directory: ./dicoogle/src/main/resources/webapp
       run: npm ci
-    - name: Build webapp
+    - name: Check & build webapp
       working-directory: ./dicoogle/src/main/resources/webapp
-      run: npm run build
+      run: npm run check && npm run build

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -32,9 +32,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-        cache-dependency-path:
-         - 'dicoogle/src/main/resources/webapp'
-         - 'webcore'
+        cache-dependency-path: 'dicoogle/src/main/resources/webapp,webcore'
     - working-directory: ./dicoogle/src/main/resources/webapp
       run: npm ci
     - name: Check & build webapp

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -31,6 +31,9 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
+        cache-dependency-path:
+         - 'dicoogle/src/main/resources/webapp'
+         - 'webcore'
     - working-directory: ./dicoogle/src/main/resources/webapp
       run: npm ci
     - name: Check & build webapp

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -9,6 +9,7 @@ on:
     paths:
      - 'dicoogle/src/main/resources/webapp/**'
      - 'webcore/**'
+     - '.github/workflows/node.yml'
 
 jobs:
   build:

--- a/dicoogle/src/main/resources/webapp/package.json
+++ b/dicoogle/src/main/resources/webapp/package.json
@@ -91,6 +91,7 @@
     "webpack-merge": "^5.8.0"
   },
   "scripts": {
+    "check": "eslint js/**",
     "build": "webpack --config webpack.prod.js",
     "start": "webpack-dev-server --open --config webpack.dev.js",
     "precommit": "lint-staged",


### PR DESCRIPTION
### Summary

- update actions to latest versions
   - removes use of Node.js 12 in workflows, which is deprecated and will stop working soon
- fix step descriptions
- change trigger conditions based on paths of files changed
- [maven.yml] configure maven caching via setup-java, thus simplifying workflow specification
- [node.js] update node-versions to stay up to date over time
- [node.js] bump minimum node version to 16
- [node.js] add npm caching
- Add npm check script
- [CI] Run check script in node workflow

