### PR TITLE
bug/Cast QueryInterface to QueryDimInterface

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
@@ -619,14 +619,13 @@ public class PluginController {
             final DimLevel level, final Object... parameters) {
 
         final QueryDimInterface queryEngine;
-        QueryDimInterface tmpQueryDimInterface;
-        try {
-            tmpQueryDimInterface = (QueryDimInterface) getQueryProviderByName(querySource, true);
-        } catch (NullPointerException ignored) {
-            tmpQueryDimInterface = null;
+        QueryInterface tmpQueryDimInterface = getQueryProviderByName(querySource, true);
+        if (tmpQueryDimInterface instanceof QueryDimInterface) {
+            queryEngine = (QueryDimInterface) tmpQueryDimInterface;
+        } else {
+            logger.warn("Query plugin {} is not a DIM query provider", querySource);
+            queryEngine = null;
         }
-
-        queryEngine = tmpQueryDimInterface;
 
         // returns a tasks that runs the query from the selected query engine
         String uid = UUID.randomUUID().toString();
@@ -634,7 +633,8 @@ public class PluginController {
             @Override
             public Iterable<SearchResult> call() {
                 if (queryEngine == null) {
-                    logger.warn("Query plugin {} did not produce valid DIM query provider", querySource);
+                    logger.warn("Could not query provider {} as a DIM source", querySource);
+
                     return Collections.emptyList();
                 }
                 try {


### PR DESCRIPTION
This PR ensures that the `getTaskForQueryDim` method explicitly casts its `queryEngine` var into a `QueryDimInterface` instance, instead of `QueryInterface`. The lack of casting to `QueryDimInterface` was causing issues with query providers, namely when trying to use DIM query methods.