### PR TITLE
Switch to new maven repo dicoogle-public

### DIFF
--- a/dicoogle/pom.xml
+++ b/dicoogle/pom.xml
@@ -39,18 +39,10 @@
         </repository>
 
         <repository>
-            <id>mi</id>
-            <url>https://bioinformatics.ua.pt/maven/content/repositories/mi</url>
+            <id>dicoogle-public</id>
+            <url>https://dev.bmd-software.com/nexus/content/repositories/dicoogle-public</url>
             <snapshots>
                 <enabled>false</enabled>
-            </snapshots>
-        </repository>
-
-        <repository>
-            <id>mi-snapshots</id>
-            <url>https://bioinformatics.ua.pt/maven/content/repositories/mi-snapshots</url>
-            <snapshots>
-                <enabled>true</enabled>
             </snapshots>
         </repository>
 

--- a/pom.xml
+++ b/pom.xml
@@ -78,25 +78,13 @@
         <profile>
             <id>prod-repository</id>
             <activation>
-                <property>
-                    <name>!useBmdRepo</name>
-                </property>
+                <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-
-            </properties>
             <distributionManagement>
-                <!-- Versioned releases are published to the releases repository -->
                 <repository>
-                    <id>mi</id>
-                    <url>https://bioinformatics.ua.pt/maven/content/repositories/mi</url>
+                    <id>dicoogle-public</id>
+                    <url>https://dev.bmd-software.com/nexus/content/repositories/dicoogle-public</url>
                 </repository>
-
-                <!-- Snapshot releases are published to the snapshots repository -->
-                <snapshotRepository>
-                    <id>mi</id>
-                    <url>https://bioinformatics.ua.pt/maven/content/repositories/mi-snapshots</url>
-                </snapshotRepository>
             </distributionManagement>
         </profile>
 
@@ -104,7 +92,7 @@
             <id>bmd-repository</id>
             <activation>
                 <property>
-                    <name>useBmdRepo</name>
+                    <name>useBmdInternalRepo</name>
                     <value>true</value>
                 </property>
             </activation>
@@ -122,6 +110,30 @@
                     <id>bmdsoftware-snapshots</id>
                     <name>BMD Software Nexus (Internal Snapshots)</name>
                     <url>https://dev.bmd-software.com/nexus/content/repositories/snapshots</url>
+                </snapshotRepository>
+            </distributionManagement>
+        </profile>
+
+        <profile>
+            <id>bioinformatics-repository</id>
+            <activation>
+                <property>
+                    <name>useBioinformaticsPt</name>
+                    <value>true</value>
+                </property>
+            </activation>
+
+            <distributionManagement>
+                <!-- Versioned releases are published to the releases repository -->
+                <repository>
+                    <id>mi</id>
+                    <url>https://bioinformatics.ua.pt/maven/content/repositories/mi</url>
+                </repository>
+
+                <!-- Snapshot releases are published to the snapshots repository -->
+                <snapshotRepository>
+                    <id>mi</id>
+                    <url>https://bioinformatics.ua.pt/maven/content/repositories/mi-snapshots</url>
                 </snapshotRepository>
             </distributionManagement>
         </profile>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -28,8 +28,8 @@
         </repository>
 
         <repository>
-            <id>mi</id>
-            <url>https://bioinformatics.ua.pt/maven/content/repositories/mi</url>
+            <id>dicoogle-public</id>
+            <url>https://dev.bmd-software.com/nexus/content/repositories/dicoogle-public</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>


### PR DESCRIPTION
This replaces the main Maven repository for Dicoogle and key dependencies with a new repository hosted by BMD Software.

With the dependencies not found anywhere already uploaded here, this should help new developers build Dicoogle from a fresh development environment and bring CI back to a healthy state.

TODO: provide public read access to the repository (@bastiao)