### PR TITLE
Transfer Options - improve web service and UI

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/SOPList.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/SOPList.java
@@ -339,6 +339,7 @@ public class SOPList {
                 JSONObject tsobj = new JSONObject();
                 String name = TransfersStorage.getGlobalTransferMap().get(i);
                 boolean value = ts.getTS()[i];
+                tsobj.put("uid", TransfersStorage.convertTsNameToUID(name));
                 tsobj.put("name", name);
                 tsobj.put("value", value);
 

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/TransfersStorage.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/TransfersStorage.java
@@ -185,6 +185,10 @@ public class TransfersStorage {
         }
         return return_value;
     }
+    
+    public static String convertTsNameToUID(String name) {
+        return namesUidMapping.getKey(name).toString();
+    }
 
     public List<String> asList() {
         return Arrays.asList(this.getVerboseTS());

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/management/TransferOptionsServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/management/TransferOptionsServlet.java
@@ -50,7 +50,7 @@ public class TransferOptionsServlet extends HttpServlet {
     }
 
     @Override
-    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+    protected void doPut(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
 
         String UID = req.getParameter("uid");
         String option = req.getParameter("option");
@@ -76,6 +76,11 @@ public class TransferOptionsServlet extends HttpServlet {
         SOPList.getInstance().updateTSField(UID, option, value);
         ServerSettingsManager.saveSettings();
         ResponseUtil.simpleResponse(resp, "success", true);
+    }
+    
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        this.doPut(req, resp);
     }
 
     public static class TransferenceOptionsResponse {

--- a/dicoogle/src/main/resources/webapp/js/actions/transferActions.js
+++ b/dicoogle/src/main/resources/webapp/js/actions/transferActions.js
@@ -1,7 +1,17 @@
 import Reflux from "reflux";
+
+export const get = Reflux.createAction();
+export const set = Reflux.createAction();
+export const selectAll = Reflux.createAction();
+export const unSelectAll = Reflux.createAction();
+export const selectAllSOP = Reflux.createAction();
+export const unSelectAllSOP = Reflux.createAction();
+
 export const TransferActions = {
-  get: Reflux.createAction(),
-  set: Reflux.createAction(),
-  selectAll: Reflux.createAction(),
-  unSelectAll: Reflux.createAction()
+  get,
+  set,
+  selectAll,
+  unSelectAll,
+  selectAllSOP,
+  unSelectAllSOP,
 };

--- a/dicoogle/src/main/resources/webapp/js/stores/transferStore.js
+++ b/dicoogle/src/main/resources/webapp/js/stores/transferStore.js
@@ -53,6 +53,28 @@ const TransferStore = Reflux.createStore({
     this.select(false);
   },
 
+  onSelectAllSOP(sopClassOption) {
+    this.selectSOP(sopClassOption, true);
+  },
+
+  onUnSelectAllSOP(sopClassOption) {
+    this.selectSOP(sopClassOption, false);
+  },
+
+  selectSOP(sopClassUid, value) {
+    let sop = this._contents.find((sop) => sop.uid === sopClassUid);
+    
+    Promise.all(sop.options.map((tsOptions) => {
+      tsOptions.value = value;
+      return this.request(sop.uid, tsOptions.name, tsOptions.value);
+    })).then(() => {
+      this.trigger({
+        data: this._contents,
+        success: true
+      });
+    });
+  },
+
   select(value) {
     for (let index of this._contents) {
       for (let indexOptions of index.options) {
@@ -66,12 +88,8 @@ const TransferStore = Reflux.createStore({
     });
   },
 
-  request(uid, id, value) {
-    this.dicoogle.setTransferSyntaxOption(uid, id, value, error => {
-      if (error) {
-        console.error("Dicoogle service error", error);
-      }
-    });
+  async request(uid, id, value) {
+    await this.dicoogle.setTransferSyntaxOption(uid, id, value);
   },
 
   onSet(index, indexOption, uid, id, value) {

--- a/dicoogle/src/main/resources/webapp/sass/modules/_management.scss
+++ b/dicoogle/src/main/resources/webapp/sass/modules/_management.scss
@@ -81,3 +81,7 @@
 .panel-heading-toggle {
   padding-right: 40px;
 }
+
+.manage-ts-options {
+  padding-left: 20px;
+}


### PR DESCRIPTION
### Summary

- Include transfer syntax UID in transfer options response
   - `uid` field is added for each transfer syntax in each SOP class, so that it can be presented in the UI
- Tweak transfer option update endpoint to also accept HTTP methods PUT (as well as POST)
- [webapp] Improve Transfer Options submenu
   - show Transfer Syntax UID in each option
   - simplify and restyle form, reduce text
   - have two "Select all" buttons instead of one
      - One of them changes TSes for the selected SOP class, the other one changes all transfer syntaxes. (resolves #428)

![Screenshot 2023-06-07 164939](https://github.com/bioinformatics-ua/dicoogle/assets/4738426/b25d3469-400f-48cb-bcae-eb1680267cee)

