### PR TITLE
Save transfer options to server settings

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/ControlServices.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/ControlServices.java
@@ -117,9 +117,7 @@ public class ControlServices {
 
 
             SOPList list = SOPList.getInstance();
-            settings.getDicomServicesSettings().getSOPClasses().forEach(sopClass -> sopClass.getTransferSyntaxes()
-                    .forEach(ts -> list.updateTSFieldByTsUID(sopClass.getUID(), ts, true)));
-
+            list.readFromSettings(settings);
 
             int i;
 

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/SOPList.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/SOPList.java
@@ -44,7 +44,7 @@ import java.util.stream.Collectors;
 public class SOPList {
 
     private static SOPList instance = null;
-    private static Logger logger = LoggerFactory.getLogger(SOPList.class);
+    private static final Logger logger = LoggerFactory.getLogger(SOPList.class);
 
     private Hashtable<String, TransfersStorage> table;
 
@@ -260,8 +260,8 @@ public class SOPList {
      * Removes selected services that do not have accepted transfers syntaxes 
      */
     public synchronized void CleanList() {
-        List l = new ArrayList();
-        Enumeration e = table.keys();
+        List<String> l = new ArrayList<>();
+        Enumeration<?> e = table.keys();
         TransfersStorage TS;
         boolean[] p;
         boolean unused;
@@ -293,9 +293,9 @@ public class SOPList {
      * Get the name of all the SOP Classes used in list
      * @return List with all the identifiers of SOP Class currently in use
      */
-    public synchronized List getKeys() {
-        List l = new ArrayList();
-        Enumeration e = table.keys();
+    public synchronized List<String> getKeys() {
+        List<String> l = new ArrayList<>();
+        Enumeration<?> e = table.keys();
 
         while (e.hasMoreElements()) {
             l.add(e.nextElement().toString());
@@ -308,9 +308,9 @@ public class SOPList {
      * @return The number of SOP Classes that are actually marked as accepted
      */
     public synchronized int getAccepted() {
-        List l = new ArrayList();
+        List<String> l = new ArrayList<>();
         TransfersStorage local;
-        Enumeration e = table.keys();
+        Enumeration<?> e = table.keys();
 
         while (e.hasMoreElements()) {
             l.add(e.nextElement().toString());

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/SOPList.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/SOPList.java
@@ -145,11 +145,19 @@ public class SOPList {
      * Creates a new list 
      */
     private SOPList() {
-        table = new Hashtable<>();
+        this.reset();
+    }
+
+    /** Reset the SOP list to an empty slate.
+     *
+     * This is not recommended unless you know what you're doing.
+     */
+    public final void reset() {
+        this.table = new Hashtable<>();
 
         // Hardcoded (pre-#498) SOPs
         for (String sop : SOP) {
-            table.put(sop, new TransfersStorage());
+            this.table.put(sop, new TransfersStorage());
         }
     }
 

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/TransfersStorage.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/TransfersStorage.java
@@ -190,6 +190,7 @@ public class TransfersStorage {
         return Arrays.asList(this.getVerboseTS());
     }
 
+    /** Read the active server settings and record additional transfer syntaxes. */
     public static void completeList() {
 
         // Get additional transfer syntaxes (not present in the hardcoded list)

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/management/TransferOptionsServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/management/TransferOptionsServlet.java
@@ -73,7 +73,9 @@ public class TransferOptionsServlet extends HttpServlet {
 
         boolean value = Boolean.parseBoolean(valueS);
 
-        SOPList.getInstance().updateTSField(UID, option, value);
+        SOPList sopList = SOPList.getInstance();
+        sopList.updateTSField(UID, option, value);
+        sopList.writeToSettings();
         ServerSettingsManager.saveSettings();
         ResponseUtil.simpleResponse(resp, "success", true);
     }

--- a/dicoogle/src/test/java/pt/ua/dicoogle/core/settings/LegacyServerSettingsTest.java
+++ b/dicoogle/src/test/java/pt/ua/dicoogle/core/settings/LegacyServerSettingsTest.java
@@ -109,6 +109,9 @@ public class LegacyServerSettingsTest {
 
     @Test
     public void testMigrate() throws IOException {
+        // clean up SOP list from past tests
+        SOPList.getInstance().reset();
+
         Path newconf = Files.createTempFile("conf", ".xml");
 
         // load legacy server settings

--- a/dicoogle/src/test/java/pt/ua/dicoogle/core/settings/LegacyServerSettingsTest.java
+++ b/dicoogle/src/test/java/pt/ua/dicoogle/core/settings/LegacyServerSettingsTest.java
@@ -18,18 +18,22 @@
  */
 package pt.ua.dicoogle.core.settings;
 
-import org.junit.Before;
 import org.junit.ComparisonFailure;
 import org.junit.Test;
 import pt.ua.dicoogle.sdk.datastructs.MoveDestination;
+import pt.ua.dicoogle.sdk.datastructs.SOPClass;
 import pt.ua.dicoogle.sdk.settings.server.ServerSettings;
+import pt.ua.dicoogle.server.SOPList;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
 
@@ -38,17 +42,12 @@ import static org.junit.Assert.*;
  */
 public class LegacyServerSettingsTest {
 
-    private URL testConfig;
-
-    @Before
-    public void init() {
-        this.testConfig = this.getClass().getResource("test-config-legacy.xml");
-    }
+    private final URL legacyConfig = this.getClass().getResource("test-config-legacy.xml");
 
     @Test
     public void test() throws IOException {
         // read the settings from our test config file
-        ServerSettings settings = ServerSettingsManager.loadLegacySettingsAt(this.testConfig);
+        ServerSettings settings = ServerSettingsManager.loadLegacySettingsAt(this.legacyConfig);
 
         assertTrue(settings instanceof LegacyServerSettings);
 
@@ -93,7 +92,7 @@ public class LegacyServerSettingsTest {
         assertSameContent(destinations, settings.getDicomServicesSettings().getMoveDestinations());
     }
 
-    private static void assertSameContent(Collection o1, Collection o2) {
+    private static void assertSameContent(Collection<?> o1, Collection<?> o2) {
         for (Object o : o1) {
             if (!o2.contains(o)) {
                 throw new ComparisonFailure("Collections do not have the same content", String.valueOf(o1),
@@ -108,4 +107,74 @@ public class LegacyServerSettingsTest {
         }
     }
 
+    @Test
+    public void testMigrate() throws IOException {
+        Path newconf = Files.createTempFile("conf", ".xml");
+
+        // load legacy server settings
+        ServerSettings settings = ServerSettingsManager.loadLegacySettingsAt(this.legacyConfig);
+        assertTrue(settings instanceof LegacyServerSettings);
+
+        // save as new
+        ServerSettingsManager.saveSettingsTo(settings, newconf);
+
+        // check new file
+        settings = ServerSettingsManager.loadSettingsAt(newconf);
+        assertTrue(settings instanceof ServerSettingsImpl);
+        ServerSettings.Archive a = settings.getArchiveSettings();
+
+        // assertions follow
+        assertEquals("/opt/dicoogle/repository", a.getMainDirectory());
+        assertEquals("/tmp", a.getWatchDirectory());
+        assertEquals(97, a.getIndexerEffort());
+        assertEquals("dicoogle-old", a.getNodeName());
+
+        assertEquals("TEST-STORAGE", settings.getDicomServicesSettings().getAETitle());
+
+        // QR settings
+        assertEquals(106, settings.getDicomServicesSettings().getQueryRetrieveSettings().getPort());
+        assertSameContent(Collections.singleton("any"),
+                settings.getDicomServicesSettings().getAllowedLocalInterfaces());
+        assertSameContent(Collections.singleton("any"), settings.getDicomServicesSettings().getAllowedHostnames());
+        assertEquals(3, settings.getDicomServicesSettings().getQueryRetrieveSettings().getRspDelay());
+        assertEquals(50, settings.getDicomServicesSettings().getQueryRetrieveSettings().getDIMSERspTimeout());
+        assertEquals(50, settings.getDicomServicesSettings().getQueryRetrieveSettings().getIdleTimeout());
+        assertEquals(50, settings.getDicomServicesSettings().getQueryRetrieveSettings().getAcceptTimeout());
+        assertEquals(50, settings.getDicomServicesSettings().getQueryRetrieveSettings().getConnectionTimeout());
+        // assertEquals("1.2.840.10008.5.1.4.1.2.1.1", settings.getSOPClasses());
+        assertEquals(22, settings.getDicomServicesSettings().getQueryRetrieveSettings().getMaxClientAssoc());
+        assertEquals(16360, settings.getDicomServicesSettings().getQueryRetrieveSettings().getMaxPDULengthSend());
+        assertEquals(16360, settings.getDicomServicesSettings().getQueryRetrieveSettings().getMaxPDULengthReceive());
+
+        // DICOM Storage settings
+        assertFalse(settings.getDicomServicesSettings().getStorageSettings().isAutostart());
+        assertEquals(6666, settings.getDicomServicesSettings().getStorageSettings().getPort());
+
+        // Web server settings
+        ServerSettings.WebServer web = settings.getWebServerSettings();
+        assertTrue(web.isAutostart());
+        assertEquals(8484, web.getPort());
+        assertEquals("test.dicoogle.com", web.getAllowedOrigins());
+
+
+        // SOP Classes
+
+        Collection<SOPClass> sopClasses = Arrays.asList(
+                new SOPClass("1.2.840.10008.5.1.4.1.1.88.40",
+                        Arrays.asList("1.2.840.10008.1.2", "1.2.840.10008.1.2.1", "1.2.840.10008.1.2.4.80",
+                                "1.2.840.10008.1.2.4.50")),
+                new SOPClass("1.2.840.10008.5.1.4.1.1.77.1.1",
+                        Arrays.asList("1.2.840.10008.1.2", "1.2.840.10008.1.2.1", "1.2.840.10008.1.2.4.80",
+                                "1.2.840.10008.1.2.4.50")),
+                new SOPClass("1.2.840.10008.5.1.1.30", Arrays.asList("1.2.840.10008.1.2", "1.2.840.10008.1.2.1",
+                        "1.2.840.10008.1.2.4.80", "1.2.840.10008.1.2.4.50")));
+
+        Collection<SOPClass> sopClassesFromSettings = settings.getDicomServicesSettings().getSOPClasses().stream()
+                .filter(c -> !c.getTransferSyntaxes().isEmpty()).collect(Collectors.toList());
+
+        assertSameContent(sopClasses, sopClassesFromSettings);
+
+        // clean up
+        Files.delete(newconf);
+    }
 }

--- a/dicoogle/src/test/java/pt/ua/dicoogle/core/settings/ServerSettingsTest.java
+++ b/dicoogle/src/test/java/pt/ua/dicoogle/core/settings/ServerSettingsTest.java
@@ -53,7 +53,6 @@ public class ServerSettingsTest {
     private final URL testConfigTs = this.getClass().getResource("test-config-ts.xml");
     private final URL testConfigSopClasses = this.getClass().getResource("test-config-sopclasses.xml");
     private final URL testConfigAdditionals = this.getClass().getResource("test-config-additionals.xml");
-    private final URL legacyConfig = this.getClass().getResource("test-config-legacy.xml");
 
     @Test
     public void testLoadConfig1() throws IOException {
@@ -380,78 +379,6 @@ public class ServerSettingsTest {
                     break;
             }
         }
-    }
-
-    @Test
-    public void testMigrate() throws IOException {
-        Path newconf = Files.createTempFile("conf", ".xml");
-
-        // load legacy server settings
-        ServerSettings settings = ServerSettingsManager.loadLegacySettingsAt(this.legacyConfig);
-        assertTrue(settings instanceof LegacyServerSettings);
-
-        // save as new
-        ServerSettingsManager.saveSettingsTo(settings, newconf);
-
-        // check new file
-        settings = ServerSettingsManager.loadSettingsAt(newconf);
-        assertTrue(settings instanceof ServerSettingsImpl);
-        ServerSettings.Archive a = settings.getArchiveSettings();
-
-        // assertions follow
-        assertEquals("/opt/dicoogle/repository", a.getMainDirectory());
-        assertEquals("/tmp", a.getWatchDirectory());
-        assertEquals(97, a.getIndexerEffort());
-        assertEquals("dicoogle-old", a.getNodeName());
-
-        assertEquals("TEST-STORAGE", settings.getDicomServicesSettings().getAETitle());
-
-        // QR settings
-        assertEquals(106, settings.getDicomServicesSettings().getQueryRetrieveSettings().getPort());
-        assertSameContent(Collections.singleton("any"),
-                settings.getDicomServicesSettings().getAllowedLocalInterfaces());
-        assertSameContent(Collections.singleton("any"), settings.getDicomServicesSettings().getAllowedHostnames());
-        assertEquals(3, settings.getDicomServicesSettings().getQueryRetrieveSettings().getRspDelay());
-        assertEquals(50, settings.getDicomServicesSettings().getQueryRetrieveSettings().getDIMSERspTimeout());
-        assertEquals(50, settings.getDicomServicesSettings().getQueryRetrieveSettings().getIdleTimeout());
-        assertEquals(50, settings.getDicomServicesSettings().getQueryRetrieveSettings().getAcceptTimeout());
-        assertEquals(50, settings.getDicomServicesSettings().getQueryRetrieveSettings().getConnectionTimeout());
-        // assertEquals("1.2.840.10008.5.1.4.1.2.1.1", settings.getSOPClasses());
-        assertEquals(22, settings.getDicomServicesSettings().getQueryRetrieveSettings().getMaxClientAssoc());
-        assertEquals(16360, settings.getDicomServicesSettings().getQueryRetrieveSettings().getMaxPDULengthSend());
-        assertEquals(16360, settings.getDicomServicesSettings().getQueryRetrieveSettings().getMaxPDULengthReceive());
-
-        // DICOM Storage settings
-        assertFalse(settings.getDicomServicesSettings().getStorageSettings().isAutostart());
-        assertEquals(6666, settings.getDicomServicesSettings().getStorageSettings().getPort());
-
-        // Web server settings
-        ServerSettings.WebServer web = settings.getWebServerSettings();
-        assertTrue(web.isAutostart());
-        assertEquals(8484, web.getPort());
-        assertEquals("test.dicoogle.com", web.getAllowedOrigins());
-
-
-        // SOP Classes
-
-
-        Collection<SOPClass> sopClasses = Arrays.asList(
-                new SOPClass("1.2.840.10008.5.1.4.1.1.88.40",
-                        Arrays.asList("1.2.840.10008.1.2", "1.2.840.10008.1.2.1", "1.2.840.10008.1.2.4.80",
-                                "1.2.840.10008.1.2.4.50")),
-                new SOPClass("1.2.840.10008.5.1.4.1.1.77.1.1",
-                        Arrays.asList("1.2.840.10008.1.2", "1.2.840.10008.1.2.1", "1.2.840.10008.1.2.4.80",
-                                "1.2.840.10008.1.2.4.50")),
-                new SOPClass("1.2.840.10008.5.1.1.30", Arrays.asList("1.2.840.10008.1.2", "1.2.840.10008.1.2.1",
-                        "1.2.840.10008.1.2.4.80", "1.2.840.10008.1.2.4.50")));
-
-        Collection<SOPClass> sopClassesFromSettings = settings.getDicomServicesSettings().getSOPClasses().stream()
-                .filter(c -> !c.getTransferSyntaxes().isEmpty()).collect(Collectors.toList());
-
-        assertSameContent(sopClasses, sopClassesFromSettings);
-
-        // clean up
-        Files.delete(newconf);
     }
 
     @Test

--- a/dicoogle/src/test/resources/pt/ua/dicoogle/core/settings/test-config-ts.xml
+++ b/dicoogle/src/test/resources/pt/ua/dicoogle/core/settings/test-config-ts.xml
@@ -25,22 +25,28 @@
         <allowed-aetitles>any</allowed-aetitles>
         <allowed-local-interfaces>any</allowed-local-interfaces>
         <allowed-hostnames>any</allowed-hostnames>
-        <default-ts>
-            <ts>1.2.840.10008.1.2</ts>
-            <ts>1.2.840.10008.1.2.1</ts>
-            <ts>1.2.840.10008.1.2.4.80</ts>
-            <ts>1.2.840.10008.1.2.4.50</ts>
-        </default-ts>
+        <!-- No default transfer syntaxes,
+          so that some SOP classes can be fully rejected
+        -->
+        <default-ts/>
         <sop-classes>
             <!-- CT Image Storage -->
             <sop-class>
                 <uid>1.2.840.10008.5.1.4.1.1.2</uid>
-                <!-- should inherit default TSes -->
+                <transfer-syntaxes>
+                    <ts>1.2.840.10008.1.2</ts>
+                    <ts>1.2.840.10008.1.2.1</ts>
+                </transfer-syntaxes>
             </sop-class>
             <!-- Enhanced CT Image Storage -->
             <sop-class>
                 <uid>1.2.840.10008.5.1.4.1.1.2.1</uid>
-                <!-- should inherit default TSes -->
+                <transfer-syntaxes>
+                    <ts>1.2.840.10008.1.2</ts>
+                    <ts>1.2.840.10008.1.2.1</ts>
+                    <ts>1.2.840.10008.1.2.4.50</ts>
+                    <ts>1.2.840.10008.1.2.4.70</ts>
+                </transfer-syntaxes>
             </sop-class>
             <!-- Enhanced XA Image Storage -->
             <sop-class>
@@ -60,6 +66,10 @@
                     <ts>1.2.840.10008.1.2.4.50</ts>
                     <ts>1.2.840.10008.1.2.4.70</ts>
                 </transfer-syntaxes>
+            </sop-class>
+            <!-- Do not accept retired Ultrasound Multi-frame Image Storage-->
+            <sop-class>
+                <uid>1.2.840.10008.5.1.4.1.1.3</uid>
             </sop-class>
         </sop-classes>
         <move-destinations>


### PR DESCRIPTION

Resolves #632. It turns out that the various changes to the server settings made it so that transfer options were not written back to server.xml at all, so this PR mostly creates the necessary methods for this and adds tests.

---


While working on this, I realized that the mechanism to introduce default transfer syntaxes is in effect regardless of whether an empty transfer syntax list (`<transfer-syntaxes/>`) or no list is provided in an SOP class. This means that in order for Dicoogle to be able to reject SOP classes, we need to clear the list of default transfer syntaxes. Fixing this behavior would have required updating Jackson, so I left that alone.

---

### Test plan

Use the Dicoogle UI to change the accepted transfer syntaxes of one or more SOP classes (see also #649). After doing so, inspect `confs/server.xml` to see that the changes were applied there shortly after.

