### PR TITLE
Remove RuntimeException stack trace from query warning log

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
@@ -604,7 +604,7 @@ public class PluginController {
                 try {
                     return queryEngine.query(query, parameters);
                 } catch (RuntimeException ex) {
-                    logger.warn("Query plugin {} unable to query at {} level", querySource, level);
+                    logger.warn("Query plugin {} failed unexpectedly", querySource, ex);
                     return Collections.EMPTY_LIST;
                 }
 

--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
@@ -604,7 +604,7 @@ public class PluginController {
                 try {
                     return queryEngine.query(query, parameters);
                 } catch (RuntimeException ex) {
-                    logger.warn("Query plugin {} failed unexpectedly", querySource, ex);
+                    logger.warn("Query plugin {} unable to query at {} level", querySource, level);
                     return Collections.EMPTY_LIST;
                 }
 
@@ -629,7 +629,7 @@ public class PluginController {
                 try {
                     return queryEngine.query(query, level, parameters);
                 } catch (RuntimeException ex) {
-                    logger.warn("Query plugin {} failed unexpectedly", querySource, ex);
+                    logger.warn("Query plugin {} unable to query at {} level", querySource, level);
                     return Collections.EMPTY_LIST;
                 }
 


### PR DESCRIPTION
This PR adjusts the PluginController to change the warning log when getting a `RuntimeException` from a query plugin (both regular queries or DIM queries).

Instead of writing that the query plugin “failed unexpectedly” and printing the stack trace, the warning now removes the stack trace in favor of indicating the level of the attempted query. 

It can be possible that a query plugin can only handle queries of one or few levels. The plugin controller already deals with this situation by returning an empty list instead of propagating the error, and this empty list can be handled by whatever had requested the query task. Because of these facts, printing the stack trace is a bit overkill, and can flood the Dicoogle logs. 