### PR TITLE
Fix #653 - URI can be dumped in meta table

### DIFF
--- a/dicoogle/src/main/resources/webapp/js/components/search/result/imageView.js
+++ b/dicoogle/src/main/resources/webapp/js/components/search/result/imageView.js
@@ -409,7 +409,7 @@ var PopOverView = createReactClass({
     });
 
     // Add URI as location definition of the DICOM resource.
-    fields.push({ att: "URI", field:this.state.data.data.results.uri });
+    fields.push({ Attribute: "URI", Value:this.state.data.data.results.uri });
 
     var selectRowProp = {
       clickToSelect: true,


### PR DESCRIPTION
Fix #653 - URI can be dumped again in meta table