### PR TITLE
Improve StorageInterface, add method `get` 

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/dicom/Information.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/dicom/Information.java
@@ -113,20 +113,17 @@ public class Information {
                 for (SearchResult r : itResults) {
                     if (uri == null)
                         uri = r.getURI();
-                    System.out.println("URI: " + uri.toString());
                 }
 
                 if (uri != null) {
                     StorageInterface str = PluginController.getInstance().getStorageForSchema(uri);
                     if (str != null) {
-                        Iterable<StorageInputStream> stream = str.at(uri);
-                        for (StorageInputStream r : stream) {
+                        StorageInputStream r = str.get(uri);
+                        if (r != null) {
                             ret = r;
 
                             stopAllTaks();
-
                             latch.countDown();
-
                             return;
                         }
                     }

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/StorageInterface.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/StorageInterface.java
@@ -61,7 +61,7 @@ public interface StorageInterface extends DicooglePlugin {
      * This method is particularly nice for use in for-each loops.
      * 
      * The provided scheme is not relevant at this point, but the developer must avoid calling this method
-     * with a path of a different schema.
+     * with a path of a different scheme.
      *
      * <pre>
      * URI uri = URI.create("file://dataset/");
@@ -82,7 +82,7 @@ public interface StorageInterface extends DicooglePlugin {
      *
      * The provided scheme is not relevant at this point,
      * but the developer must avoid calling this method
-     * with a path of a different schema.
+     * with a path of a different scheme.
      *
      * <pre>
      * URI uri = URI.create("file://dataset/CT/001.dcm");

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/StorageInterface.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/StorageInterface.java
@@ -62,13 +62,16 @@ public interface StorageInterface extends DicooglePlugin {
      * 
      * The provided scheme is not relevant at this point, but the developer must avoid calling this method
      * with a path of a different schema.
-     * 
-     * <pre>for(StorageInputStream dicomObj : storagePlugin.at("file://dataset/")){
-     *      System.err.println(dicomObj.getURI());
-     * }</pre>
+     *
+     * <pre>
+     * URI uri = URI.create("file://dataset/");
+     * for (StorageInputStream dicomObj: storagePlugin.at(uri)) {
+     *     System.err.println(dicomObj.getURI());
+     * }
+     * </pre>
      * 
      * @param location the location to read
-     * @param parameters a variable list of extra parameters for the retrieve
+     * @param parameters a variable list of extra retrieval parameters
      * @return an iterable of storage input streams
      * @see StorageInputStream
      */
@@ -138,6 +141,9 @@ public interface StorageInterface extends DicooglePlugin {
      * Unlike {@link StorageInterface#at}, this method is not recursive and
      * can yield intermediate URIs representing other directories rather than
      * objects.
+     * 
+     * Directories can be distinguished from regular files
+     * by the presence of a trailing forward slash in the URI.
      * 
      * The provided scheme is not relevant at this point, but the developer
      * must avoid calling this method with a path of a different scheme.

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/StorageInterface.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/StorageInterface.java
@@ -75,6 +75,41 @@ public interface StorageInterface extends DicooglePlugin {
     public Iterable<StorageInputStream> at(URI location, Object... parameters);
 
     /**
+     * Obtains an item stored at the exact location specified.
+     *
+     * The provided scheme is not relevant at this point,
+     * but the developer must avoid calling this method
+     * with a path of a different schema.
+     *
+     * <pre>
+     * URI uri = URI.create("file://dataset/CT/001.dcm");
+     * StorageInputStream item = storagePlugin.get(uri);
+     * if (item != null) {
+     *      System.err.println("Item at " + dicomObj.getURI() + " is available");
+     * }
+     * </pre>
+     *
+     * The default implementation calls {@linkplain #at}
+     * and returns the first item if its URI matches the location requested.
+     * Implementations may wish to override this method for performance reasons.
+     *
+     * @param location the URI of the item to retrieve
+     * @param parameters a variable list of extra retrieval parameters
+     * @return a storage item if it was found, <code>null</code> otherwise
+     * @see StorageInputStream
+     */
+    default public StorageInputStream get(URI location, Object... parameters) {
+        for (StorageInputStream sis : this.at(location, parameters)) {
+            if (Objects.equals(sis.getURI(), location)) {
+                return sis;
+            }
+            // don't try any further
+            break;
+        }
+        return null;
+    }
+
+    /**
      * Stores a DICOM object into the storage.
      *
      * @param dicomObject Object to be Stored


### PR DESCRIPTION
This PR proposes a backwards-compatible extension to `StorageInterface` with default method `get`. Unlike `at`, `get` is designed to retrieve up to a single item in storage, so it does not need file system tree traversal or building up iterables and iterators.

A default implementation is provided that uses `at` underneath, but implementors may wish to override it for more efficiency.

This PR also includes a few quality-of-life improvements, including some clarifications to other methods in the plugin interface.

### Summary

- Add default method `StorageInterface#get`, to retrieve a single item from storage
   - update code in core to use it where suitable
   - also correct image servlet to only query for instances to DIM providers if specified
- Fix example code in `at`
- Clarify in `list` that a trailing forward slash means that it's a directory
