### PR TITLE
Fix cast in SeriesNumber mostly affecting C-FIND and C-MOVE services

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/SearchDicomResult.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/SearchDicomResult.java
@@ -279,7 +279,11 @@ public class SearchDicomResult implements Iterator<DicomObject> {
 
                 result.putString(Tag.Modality, VR.CS, (String) sR.get("Modality"));
 
-                result.putString(Tag.SeriesNumber, VR.IS, "" + sR.get("SeriesNumber"));
+                String seriesNumber = String.valueOf(sR.get("SeriesNumber"));
+                if (seriesNumber.endsWith(".0")) {
+                    seriesNumber = seriesNumber.substring(0, seriesNumber.length() - 2);
+                }
+                result.putString(Tag.SeriesNumber, VR.IS, seriesNumber);
 
 
                 return result;

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/SearchDicomResult.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/SearchDicomResult.java
@@ -279,7 +279,7 @@ public class SearchDicomResult implements Iterator<DicomObject> {
 
                 result.putString(Tag.Modality, VR.CS, (String) sR.get("Modality"));
 
-                result.putString(Tag.SeriesNumber, VR.IS, "" + (String) sR.get("SeriesNumber"));
+                result.putString(Tag.SeriesNumber, VR.IS, "" + sR.get("SeriesNumber"));
 
 
                 return result;


### PR DESCRIPTION
Just avoid cast issue if the result of SeriesNumber is an integer.