### PR TITLE
Improve indexer queue worker thread handling

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/DicomStorage.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/DicomStorage.java
@@ -401,6 +401,12 @@ public class DicomStorage extends StorageService {
     public void start() throws IOException {
         device.startListening(executor);
         indexer.start();
+
+        indexer.setUncaughtExceptionHandler((Thread t, Throwable e) -> {
+            LOG.error("Fatal error in indexer queue worker", e);
+            ControlServices.getInstance().stopStorage();
+            LOG.warn("DICOM storage service was taken down to prevent further errors");
+        });
     }
 
     /**

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/DicomStorage.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/DicomStorage.java
@@ -383,9 +383,9 @@ public class DicomStorage extends StorageService {
                     else
                         PluginController.getInstance().indexBlocking(exam);
                 } catch (InterruptedException ex) {
-                    LOG.error("Could not take instance to index", ex);
+                    LOG.warn("Indexer queue worker thread interrupted", ex);
                 } catch (Exception ex) {
-                    LOG.error("Unexpected error in storage index actor", ex);
+                    LOG.error("Unexpected error in indexer queue worker", ex);
                 }
             }
             LOG.debug("Indexer queue worker exiting by request");


### PR DESCRIPTION
This PR resolves some known issues with the DICOM storage indexer worker thread, most importantly:

- The indexer thread is taken down when DICOM storage is stopped (resolves #663).
- If the indexer thread dies, the incident is logged and the DICOM storage service is stopped to prevent further damage. We do expect IT to intervene at this stage. An alternative would be terminating the whole archive.

### Summary

- The indexer thread was given the name `indexer-queue-worker`
- Define indexer thread with a `Runnable` instead of a `Thread` subclass
- Add logic to take down the old indexer worker thread when DICOM storage is stopped.
   - if DICOM storage service is stopped, flip `workerShouldExit` flag and interrupt thread
- Add exception handler to indexer queue worker for damage control. DICOM storage service is disabled automatically, which prevents the archive from accepting files that will never be indexed.
