### PR TITLE
Provide search results on search-result plugin mount event

### DIFF
--- a/dicoogle/src/main/resources/webapp/js/components/plugin/pluginForm.jsx
+++ b/dicoogle/src/main/resources/webapp/js/components/plugin/pluginForm.jsx
@@ -42,12 +42,10 @@ export default class PluginForm extends React.Component {
       Webcore.emitSlotSignal(
           node,
           "result-selection-ready",
-          ResultsSelected.get()
-      );
-      Webcore.emitSlotSignal(
-          node,
-          "result",
-          SearchStore.get()
+          {
+            "selected": ResultsSelected.get(),
+            "search": SearchStore.get()
+          }
       );
     }
   }

--- a/dicoogle/src/main/resources/webapp/js/components/plugin/pluginForm.jsx
+++ b/dicoogle/src/main/resources/webapp/js/components/plugin/pluginForm.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import * as PropTypes from "prop-types";
 import { ResultsSelected } from "../../stores/resultSelected";
+import { SearchStore } from "../../stores/searchStore";
 import Webcore from "dicoogle-webcore";
 
 export default class PluginForm extends React.Component {
@@ -39,9 +40,14 @@ export default class PluginForm extends React.Component {
       node.addEventListener("hide", this.handleHideSignal);
 
       Webcore.emitSlotSignal(
-        node,
-        "result-selection-ready",
-        ResultsSelected.get()
+          node,
+          "result-selection-ready",
+          ResultsSelected.get()
+      );
+      Webcore.emitSlotSignal(
+          node,
+          "result",
+          SearchStore.get()
       );
     }
   }

--- a/dicoogle/src/main/resources/webapp/js/stores/searchStore.js
+++ b/dicoogle/src/main/resources/webapp/js/stores/searchStore.js
@@ -92,6 +92,12 @@ const SearchStore = Reflux.createStore({
       data: this._contents,
       success: true
     });
+  },
+
+  get: function() {
+    return {
+      data: this._contents
+    };
   }
 });
 

--- a/webcore/README.md
+++ b/webcore/README.md
@@ -181,7 +181,7 @@ This section documents each possible type of web UI plugin. Note that not all of
 - **result-option**: Result option plugins are used to provide advanced operations to a result entry. If the user activates
   _"Advanced Options"_ in the search results view, these plugins will be attached into a new column, one for each visible result entry.
 - **result-batch**: Result batch plugins are used to provide advanced operations over an existing list of results. These plugins will
-  attach a button (named with the plugin's caption property), which will pop-up a division below the search result view.
+  attach a button (named with the plugin's caption property), which appear in a division below the search result view.
 - **settings**: Settings plugins can be used to provide addition management information and control. These plugins will be attached to
   the _"Plugins & Services"_ tab in the _Management_ menu.
 - **query**: _(currently unsupported)_ Create different query user interfaces. Once supported, they will be
@@ -257,6 +257,7 @@ Full list of events that can be used by plugins and the webapp. _(Work in Progre
 
  - "load" : Emitted when a plugin package is retrieved.
  - "result" : Emitted when a list of search results is obtained from the search interface.
+ - "result-selection-ready" : Emitted on plugin mount for "result-batch" plugins. Provides current list of search results and selected entries.
 
 ## Installing Plugins
 


### PR DESCRIPTION
The webapp does not provide the full search results on the `result-selection-ready` event.

This PR fixes this issue by providing both the search results and the search results that were selected via the UI, instead of only providing the selected entries.
