### PR TITLE
Update Maven plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,22 +1,26 @@
+/target
+/dicoogle/.classpath
+/dicoogle/.settings/*
+/sdk-ext/.classpath
+/sdk-ext/.settings/*
+/sdk/.classpath
+/sdk/.project
+/sdk/.settings/*
+/webcore/lib/
 node_modules/
-dist
+**/webapp/dist
 .tmp
 .sass-cache/
-app/bower_components
 
 #eclipse
 .project
 .settings/*
-dicoogle/.classpath
-dicoogle/.settings/*
-sdk-ext/.classpath
-sdk-ext/.settings/*
-sdk/.classpath
-sdk/.project
-sdk/.settings/*
-webcore/lib/
+# IDEA
 .idea
+
+# Visual Studio Code
 .vscode/
+
 *.iml
 
 

--- a/dicoogle/pom.xml
+++ b/dicoogle/pom.xml
@@ -105,7 +105,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.5.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -146,7 +146,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.11.0</version>
                 <configuration>
                     <encoding>${project.build.sourceEncoding}</encoding>
                     <source>1.8</source>
@@ -158,7 +158,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.3.1</version>
                 <configuration>
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
@@ -209,16 +209,22 @@
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <version>2.4</version>
+                <version>4.3</version>
                 <configuration>
-                    <header>../short-license.txt</header>
-                    <includes>
-                        <include>**/*.java</include>
-                    </includes>
-                    <excludes>
-                        <exclude>**/package-info.java</exclude>
-                    </excludes>
-
+                    <mapping>
+                        <java>JAVADOC_STYLE</java>
+                    </mapping>
+                    <licenseSets>
+                        <licenseSet>
+                            <header>../short-license.txt</header>
+                            <includes>
+                                <include>**/*.java</include>
+                            </includes>
+                            <excludes>
+                                <exclude>**/package-info.java</exclude>
+                            </excludes>
+                        </licenseSet>
+                    </licenseSets>
                 </configuration>
                 <executions>
                     <execution>
@@ -232,7 +238,7 @@
             <plugin>
                 <groupId>net.revelc.code.formatter</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>
-                <version>2.11.0</version>
+                <version>2.12.2</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
                     <includes>
@@ -257,7 +263,7 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.12.0</version>
+                <version>1.14.0</version>
                 <executions>
                     <!-- Install Node and NPM -->
                     <execution>
@@ -296,8 +302,8 @@
 
                 </executions>
                 <configuration>
-                    <nodeVersion>v14.17.3</nodeVersion>
-                    <npmVersion>6.14.13</npmVersion>
+                    <nodeVersion>v18.17.1</nodeVersion>
+                    <npmVersion>9.6.7</npmVersion>
                     <installDirectory>target</installDirectory>
                     <!-- Defining webapp directory -->
                     <workingDirectory>src/main/resources/webapp</workingDirectory>

--- a/dicoogle/pom.xml
+++ b/dicoogle/pom.xml
@@ -238,9 +238,10 @@
             <plugin>
                 <groupId>net.revelc.code.formatter</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>
-                <version>2.12.2</version>
+                <version>2.16.0</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
+                    <lineEnding>KEEP</lineEnding>
                     <includes>
                         <include>**/*.java</include>
                     </includes>

--- a/dicoogle/src/main/java/pt/ua/dicoogle/core/settings/LegacyServerSettings.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/core/settings/LegacyServerSettings.java
@@ -1284,7 +1284,7 @@ public class LegacyServerSettings implements ServerSettings {
         public String getNodeName() {
             return LegacyServerSettings.this.getNodeName();
         }
-        
+
         @JsonGetter("encrypt-users-file")
         @Override
         public boolean isEncryptUsersFile() {

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/SOPList.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/SOPList.java
@@ -48,91 +48,42 @@ public class SOPList {
 
     private Hashtable<String, TransfersStorage> table;
 
-    private String[] SOP = {
-        UID.BasicStudyContentNotificationSOPClassRetired,
-        UID.StoredPrintStorageSOPClassRetired,
-        UID.HardcopyGrayscaleImageStorageSOPClassRetired,
-        UID.HardcopyColorImageStorageSOPClassRetired,
-        UID.ComputedRadiographyImageStorage,
-        UID.DigitalXRayImageStorageForPresentation,
-        UID.DigitalXRayImageStorageForProcessing,
-        UID.DigitalMammographyXRayImageStorageForPresentation,
-        UID.DigitalIntraOralXRayImageStorageForPresentation,
-        UID.DigitalIntraOralXRayImageStorageForProcessing,
-        UID.StandaloneModalityLUTStorageRetired,
-        UID.EncapsulatedPDFStorage,
-        UID.StandaloneVOILUTStorageRetired,
-        UID.GrayscaleSoftcopyPresentationStateStorageSOPClass,
-        UID.ColorSoftcopyPresentationStateStorageSOPClass,
-        UID.PseudoColorSoftcopyPresentationStateStorageSOPClass,
-        UID.BlendingSoftcopyPresentationStateStorageSOPClass,
-        UID.XRayAngiographicImageStorage,
-        UID.EnhancedXAImageStorage,
-        UID.XRayRadiofluoroscopicImageStorage,
-        UID.EnhancedXRFImageStorage,
-        UID.XRayAngiographicBiPlaneImageStorageRetired,
-        UID.PositronEmissionTomographyImageStorage,
-        UID.StandalonePETCurveStorageRetired,
-        UID.CTImageStorage,
-        UID.EnhancedCTImageStorage,
-        UID.NuclearMedicineImageStorage,
-        UID.UltrasoundMultiFrameImageStorageRetired,
-        UID.UltrasoundMultiFrameImageStorage,
-        UID.MRImageStorage,
-        UID.EnhancedMRImageStorage,
-        UID.MRSpectroscopyStorage,
-        UID.RTImageStorage,
-        UID.RTDoseStorage,
-        UID.RTStructureSetStorage,
-        UID.RTBeamsTreatmentRecordStorage,
-        UID.RTPlanStorage,
-        UID.RTBrachyTreatmentRecordStorage,
-        UID.RTTreatmentSummaryRecordStorage,
-        UID.NuclearMedicineImageStorageRetired,
-        UID.UltrasoundImageStorageRetired,
-        UID.UltrasoundImageStorage,
-        UID.RawDataStorage,
-        UID.SpatialRegistrationStorage,
-        UID.SpatialFiducialsStorage,
-        UID.RealWorldValueMappingStorage,
-        UID.SecondaryCaptureImageStorage,
-        UID.MultiFrameSingleBitSecondaryCaptureImageStorage,
-        UID.MultiFrameGrayscaleByteSecondaryCaptureImageStorage,
-        UID.MultiFrameGrayscaleWordSecondaryCaptureImageStorage,
-        UID.MultiFrameTrueColorSecondaryCaptureImageStorage,
-        UID.VLImageStorageTrialRetired,
-        UID.VLEndoscopicImageStorage,
-        UID.VideoEndoscopicImageStorage,
-        UID.VLMicroscopicImageStorage,
-        UID.VideoMicroscopicImageStorage,
-        UID.VLSlideCoordinatesMicroscopicImageStorage,
-        UID.VLPhotographicImageStorage,
-        UID.VideoPhotographicImageStorage,
-        UID.OphthalmicPhotography8BitImageStorage,
-        UID.OphthalmicPhotography16BitImageStorage,
-        UID.StereometricRelationshipStorage,
-        UID.VLMultiFrameImageStorageTrialRetired,
-        UID.StandaloneOverlayStorageRetired,
-        UID.BasicTextSRStorage,
-        UID.EnhancedSRStorage,
-        UID.ComprehensiveSRStorage,
-        UID.ProcedureLogStorage,
-        UID.MammographyCADSRStorage,
-        UID.KeyObjectSelectionDocumentStorage,
-        UID.ChestCADSRStorage,
-        UID.StandaloneCurveStorageRetired,
-        //UID._12leadECGWaveformStorage,
-        UID.GeneralECGWaveformStorage,
-        UID.AmbulatoryECGWaveformStorage,
-        UID.HemodynamicWaveformStorage,
-        UID.CardiacElectrophysiologyWaveformStorage,
-        UID.BasicVoiceAudioWaveformStorage,
-        UID.HangingProtocolStorage,
-        UID.SiemensCSANonImageStorage,
-        UID.VLWholeSlideMicroscopyImageStorage,
-        UID.BreastTomosynthesisImageStorage,
-        UID.XRayRadiationDoseSRStorage
-    };
+    private String[] SOP = {UID.BasicStudyContentNotificationSOPClassRetired, UID.StoredPrintStorageSOPClassRetired,
+            UID.HardcopyGrayscaleImageStorageSOPClassRetired, UID.HardcopyColorImageStorageSOPClassRetired,
+            UID.ComputedRadiographyImageStorage, UID.DigitalXRayImageStorageForPresentation,
+            UID.DigitalXRayImageStorageForProcessing, UID.DigitalMammographyXRayImageStorageForPresentation,
+            UID.DigitalIntraOralXRayImageStorageForPresentation, UID.DigitalIntraOralXRayImageStorageForProcessing,
+            UID.StandaloneModalityLUTStorageRetired, UID.EncapsulatedPDFStorage, UID.StandaloneVOILUTStorageRetired,
+            UID.GrayscaleSoftcopyPresentationStateStorageSOPClass, UID.ColorSoftcopyPresentationStateStorageSOPClass,
+            UID.PseudoColorSoftcopyPresentationStateStorageSOPClass,
+            UID.BlendingSoftcopyPresentationStateStorageSOPClass, UID.XRayAngiographicImageStorage,
+            UID.EnhancedXAImageStorage, UID.XRayRadiofluoroscopicImageStorage, UID.EnhancedXRFImageStorage,
+            UID.XRayAngiographicBiPlaneImageStorageRetired, UID.PositronEmissionTomographyImageStorage,
+            UID.StandalonePETCurveStorageRetired, UID.CTImageStorage, UID.EnhancedCTImageStorage,
+            UID.NuclearMedicineImageStorage, UID.UltrasoundMultiFrameImageStorageRetired,
+            UID.UltrasoundMultiFrameImageStorage, UID.MRImageStorage, UID.EnhancedMRImageStorage,
+            UID.MRSpectroscopyStorage, UID.RTImageStorage, UID.RTDoseStorage, UID.RTStructureSetStorage,
+            UID.RTBeamsTreatmentRecordStorage, UID.RTPlanStorage, UID.RTBrachyTreatmentRecordStorage,
+            UID.RTTreatmentSummaryRecordStorage, UID.NuclearMedicineImageStorageRetired,
+            UID.UltrasoundImageStorageRetired, UID.UltrasoundImageStorage, UID.RawDataStorage,
+            UID.SpatialRegistrationStorage, UID.SpatialFiducialsStorage, UID.RealWorldValueMappingStorage,
+            UID.SecondaryCaptureImageStorage, UID.MultiFrameSingleBitSecondaryCaptureImageStorage,
+            UID.MultiFrameGrayscaleByteSecondaryCaptureImageStorage,
+            UID.MultiFrameGrayscaleWordSecondaryCaptureImageStorage,
+            UID.MultiFrameTrueColorSecondaryCaptureImageStorage, UID.VLImageStorageTrialRetired,
+            UID.VLEndoscopicImageStorage, UID.VideoEndoscopicImageStorage, UID.VLMicroscopicImageStorage,
+            UID.VideoMicroscopicImageStorage, UID.VLSlideCoordinatesMicroscopicImageStorage,
+            UID.VLPhotographicImageStorage, UID.VideoPhotographicImageStorage,
+            UID.OphthalmicPhotography8BitImageStorage, UID.OphthalmicPhotography16BitImageStorage,
+            UID.StereometricRelationshipStorage, UID.VLMultiFrameImageStorageTrialRetired,
+            UID.StandaloneOverlayStorageRetired, UID.BasicTextSRStorage, UID.EnhancedSRStorage,
+            UID.ComprehensiveSRStorage, UID.ProcedureLogStorage, UID.MammographyCADSRStorage,
+            UID.KeyObjectSelectionDocumentStorage, UID.ChestCADSRStorage, UID.StandaloneCurveStorageRetired,
+            // UID._12leadECGWaveformStorage,
+            UID.GeneralECGWaveformStorage, UID.AmbulatoryECGWaveformStorage, UID.HemodynamicWaveformStorage,
+            UID.CardiacElectrophysiologyWaveformStorage, UID.BasicVoiceAudioWaveformStorage, UID.HangingProtocolStorage,
+            UID.SiemensCSANonImageStorage, UID.VLWholeSlideMicroscopyImageStorage, UID.BreastTomosynthesisImageStorage,
+            UID.XRayRadiationDoseSRStorage};
 
     public static synchronized SOPList getInstance() {
         if (instance == null) {
@@ -383,10 +334,9 @@ public class SOPList {
      */
     public synchronized void updateList(ServerSettings settings) {
         // Get all new SOP classes' UID (not existing in String[] SOP)
-        Collection<String> newSOPs = settings.getDicomServicesSettings().getAdditionalSOPClasses().stream()
-                .map(AdditionalSOPClass::getUid)
-                .filter(newSOPUID -> !Arrays.asList(SOP).contains(newSOPUID))
-                .collect(Collectors.toList());
+        Collection<String> newSOPs =
+                settings.getDicomServicesSettings().getAdditionalSOPClasses().stream().map(AdditionalSOPClass::getUid)
+                        .filter(newSOPUID -> !Arrays.asList(SOP).contains(newSOPUID)).collect(Collectors.toList());
         // Refresh hardcoded SOPs (outdated TransfersStorage)
         Arrays.asList(SOP).forEach(sop -> table.put(sop, new TransfersStorage()));
         // Add "Additional" SOPs to table w/ default transfer syntaxes
@@ -417,11 +367,8 @@ public class SOPList {
      * and update the archive's SOP list and storage transfer options accordingly.
      */
     public synchronized void readFromSettings(ServerSettings settings) {
-        settings.getDicomServicesSettings()
-            .getSOPClasses()
-            .forEach(sopClass -> sopClass.getTransferSyntaxes()
-                .forEach(ts -> this.updateTSFieldByTsUID(sopClass.getUID(), ts, true))
-            );
+        settings.getDicomServicesSettings().getSOPClasses().forEach(sopClass -> sopClass.getTransferSyntaxes()
+                .forEach(ts -> this.updateTSFieldByTsUID(sopClass.getUID(), ts, true)));
     }
 
     /** Save any changes made to the SOP transfer options listings

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/TransfersStorage.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/TransfersStorage.java
@@ -185,7 +185,7 @@ public class TransfersStorage {
         }
         return return_value;
     }
-    
+
     public static String convertTsNameToUID(String name) {
         return namesUidMapping.getKey(name).toString();
     }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/queryretrieve/DicoogleDcmSend.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/queryretrieve/DicoogleDcmSend.java
@@ -100,7 +100,8 @@ public class DicoogleDcmSend extends StorageCommitmentService {
     /** TransferSyntax: DCM4CHE URI Referenced */
     private static final String DCM4CHEE_URI_REFERENCED_TS_UID = "1.2.40.0.13.1.1.2.4.94";
 
-    private static final boolean FILE_READ_GUARD = System.getProperty("dicoogle.store.fileReadGuard", "").equalsIgnoreCase("true");
+    private static final boolean FILE_READ_GUARD =
+            System.getProperty("dicoogle.store.fileReadGuard", "").equalsIgnoreCase("true");
 
     private Executor executor = new NewThreadExecutor("DCMSND");
 
@@ -458,10 +459,8 @@ public class DicoogleDcmSend extends StorageCommitmentService {
             FileInfo info = files.get(i);
             TransferCapability tc = assoc.getTransferCapabilityAsSCU(info.cuid);
             if (tc == null) {
-                LOGGER.warn("{} not supported by {}, skip file {}",
-                        UIDDictionary.getDictionary().prompt(info.cuid),
-                        remoteAE.getAETitle(),
-                        info.item.getURI());
+                LOGGER.warn("{} not supported by {}, skip file {}", UIDDictionary.getDictionary().prompt(info.cuid),
+                        remoteAE.getAETitle(), info.item.getURI());
                 continue;
             }
 
@@ -472,8 +471,7 @@ public class DicoogleDcmSend extends StorageCommitmentService {
                 LOGGER.warn("{} with {} not supported by {}, skip file {}",
                         UIDDictionary.getDictionary().prompt(info.cuid),
                         UIDDictionary.getDictionary().prompt(fileref ? DCM4CHEE_URI_REFERENCED_TS_UID : info.tsuid),
-                        remoteAE.getAETitle(),
-                        info.item.getURI());
+                        remoteAE.getAETitle(), info.item.getURI());
                 continue;
             }
 
@@ -690,14 +688,12 @@ public class DicoogleDcmSend extends StorageCommitmentService {
     }
 
     private void promptWarnRSP(String prefix, int status, FileInfo info, DicomObject cmd) {
-        LOGGER.warn("{} {}H for {}, cuid={}, tsuid={} (Command: {})",
-                prefix, StringUtils.shortToHex(status),
+        LOGGER.warn("{} {}H for {}, cuid={}, tsuid={} (Command: {})", prefix, StringUtils.shortToHex(status),
                 info.item.getURI(), info.cuid, info.tsuid, cmd);
     }
 
     private void promptErrRSP(String prefix, int status, FileInfo info, DicomObject cmd) {
-        LOGGER.error("{} {}H for {}, cuid={}, tsuid={} (Command: {})",
-                prefix, StringUtils.shortToHex(status),
+        LOGGER.error("{} {}H for {}, cuid={}, tsuid={} (Command: {})", prefix, StringUtils.shortToHex(status),
                 info.item.getURI(), info.cuid, info.tsuid, cmd);
     }
 

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/users/UserFileHandle.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/users/UserFileHandle.java
@@ -89,7 +89,7 @@ public class UserFileHandle {
             } else if (Files.exists(users)) {
                 // (2) users, encrypted
                 logger.warn("File `users` will be interpreted as an encrypted users file. "
-                    + "If this is correct, please rename to `users.xml.enc`");
+                        + "If this is correct, please rename to `users.xml.enc`");
                 filename = users;
                 shouldEncrypt = true;
             } else if (Files.exists(usersXml)) {
@@ -115,7 +115,7 @@ public class UserFileHandle {
             if (Files.exists(users)) {
                 // (4) users, no encryption
                 logger.warn("File `users` will be interpreted as an plain XML users file. "
-                    + "If this is correct, please rename to `users.xml`");
+                        + "If this is correct, please rename to `users.xml`");
                 filename = users;
                 shouldEncrypt = false;
             } else if (encryptUsersFile) {

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/management/TransferOptionsServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/management/TransferOptionsServlet.java
@@ -79,7 +79,7 @@ public class TransferOptionsServlet extends HttpServlet {
         ServerSettingsManager.saveSettings();
         ResponseUtil.simpleResponse(resp, "success", true);
     }
-    
+
     @Override
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         this.doPut(req, resp);

--- a/dicoogle/src/test/java/pt/ua/dicoogle/core/settings/ServerSettingsTest.java
+++ b/dicoogle/src/test/java/pt/ua/dicoogle/core/settings/ServerSettingsTest.java
@@ -85,19 +85,17 @@ public class ServerSettingsTest {
                 "1.2.840.10008.1.2.4.80", "1.2.840.10008.1.2.4.50");
         assertSameContent(defaultTS, ((DicomServicesImpl) dcm).getDefaultTransferSyntaxes());
 
-        Collection<SOPClass> sopClasses =
-                Arrays.asList(
-                        // CT Image Storage
-                        new SOPClass("1.2.840.10008.5.1.4.1.1.2", Collections.emptyList()),
-                        // Enhanced CT Image Storage
-                        new SOPClass("1.2.840.10008.5.1.4.1.1.2.1", Collections.emptyList()),
-                        // Enhanced CT Image Storage
-                        new SOPClass("1.2.840.10008.5.1.4.1.1.12.1.1",
-                                Arrays.asList("1.2.840.10008.1.2", "1.2.840.10008.1.2.1", "1.2.840.10008.1.2.5")),
-                        // Ultrasound Multi-frame Image Storage
-                        new SOPClass("1.2.840.10008.5.1.4.1.1.3.1",
-                                Arrays.asList("1.2.840.10008.1.2", "1.2.840.10008.1.2.1", "1.2.840.10008.1.2.4.50", "1.2.840.10008.1.2.4.70"))
-                        );
+        Collection<SOPClass> sopClasses = Arrays.asList(
+                // CT Image Storage
+                new SOPClass("1.2.840.10008.5.1.4.1.1.2", Collections.emptyList()),
+                // Enhanced CT Image Storage
+                new SOPClass("1.2.840.10008.5.1.4.1.1.2.1", Collections.emptyList()),
+                // Enhanced CT Image Storage
+                new SOPClass("1.2.840.10008.5.1.4.1.1.12.1.1",
+                        Arrays.asList("1.2.840.10008.1.2", "1.2.840.10008.1.2.1", "1.2.840.10008.1.2.5")),
+                // Ultrasound Multi-frame Image Storage
+                new SOPClass("1.2.840.10008.5.1.4.1.1.3.1", Arrays.asList("1.2.840.10008.1.2", "1.2.840.10008.1.2.1",
+                        "1.2.840.10008.1.2.4.50", "1.2.840.10008.1.2.4.70")));
         Collection<SOPClass> sopClassesFromSettings = ((DicomServicesImpl) dcm).getRawSOPClasses();
         assertSameContent(sopClasses, sopClassesFromSettings);
 
@@ -256,33 +254,21 @@ public class ServerSettingsTest {
         ServerSettings.DicomServices dcm = settings.getDicomServicesSettings();
 
         // should distinguish between an empty list and missing list
-        for (SOPClass sopClass: dcm.getSOPClasses()) {
+        for (SOPClass sopClass : dcm.getSOPClasses()) {
             switch (sopClass.getUID()) {
                 case UID.CTImageStorage:
-                    assertEquals(
-                        Arrays.asList(
-                            "1.2.840.10008.1.2",
-                            "1.2.840.10008.1.2.1"
-                        ),
-                        sopClass.getTransferSyntaxes());
+                    assertEquals(Arrays.asList("1.2.840.10008.1.2", "1.2.840.10008.1.2.1"),
+                            sopClass.getTransferSyntaxes());
                     break;
                 case UID.UltrasoundMultiFrameImageStorage:
-                    assertEquals(
-                        Arrays.asList(
-                            "1.2.840.10008.1.2",
-                            "1.2.840.10008.1.2.1",
-                            "1.2.840.10008.1.2.4.50",
-                            "1.2.840.10008.1.2.4.70"
-                        ),
-                        sopClass.getTransferSyntaxes());
+                    assertEquals(Arrays.asList("1.2.840.10008.1.2", "1.2.840.10008.1.2.1", "1.2.840.10008.1.2.4.50",
+                            "1.2.840.10008.1.2.4.70"), sopClass.getTransferSyntaxes());
                     break;
                 case UID.UltrasoundMultiFrameImageStorageRetired:
                     // no transfer syntaxes here,
                     // and no default transfer syntaxes,
                     // means no acceptable transfer syntax
-                    assertEquals(
-                        Collections.emptyList(),
-                        sopClass.getTransferSyntaxes());
+                    assertEquals(Collections.emptyList(), sopClass.getTransferSyntaxes());
                     break;
                 default:
             }
@@ -294,31 +280,16 @@ public class ServerSettingsTest {
 
         // see that the SOP list has been updated accordingly
 
-        assertEquals(
-            Arrays.asList("1.2.840.10008.1.2", "1.2.840.10008.1.2.1"),
-            list.getTS(UID.CTImageStorage).asList()
-        );
-        assertEquals(
-            Arrays.asList(
-                "1.2.840.10008.1.2",
-                "1.2.840.10008.1.2.1",
-                "1.2.840.10008.1.2.4.70",
-                "1.2.840.10008.1.2.4.50"
-            ),
-            list.getTS(UID.UltrasoundMultiFrameImageStorage).asList()
-        );
-        assertEquals(
-            Collections.emptyList(),
-            list.getTS(UID.UltrasoundMultiFrameImageStorageRetired).asList()
-        );
+        assertEquals(Arrays.asList("1.2.840.10008.1.2", "1.2.840.10008.1.2.1"),
+                list.getTS(UID.CTImageStorage).asList());
+        assertEquals(Arrays.asList("1.2.840.10008.1.2", "1.2.840.10008.1.2.1", "1.2.840.10008.1.2.4.70",
+                "1.2.840.10008.1.2.4.50"), list.getTS(UID.UltrasoundMultiFrameImageStorage).asList());
+        assertEquals(Collections.emptyList(), list.getTS(UID.UltrasoundMultiFrameImageStorageRetired).asList());
 
         // unmentioned SOP classes default to
         // accepting the default transfer syntaxes
         // (in this case, empty)
-        assertEquals(
-            Collections.emptyList(),
-            list.getTS(UID.BreastTomosynthesisImageStorage).asList()
-        );
+        assertEquals(Collections.emptyList(), list.getTS(UID.BreastTomosynthesisImageStorage).asList());
     }
 
     @Test
@@ -348,32 +319,20 @@ public class ServerSettingsTest {
         Collection<SOPClass> sopClasses = dcm.getSOPClasses();
         for (SOPClass sopClass : sopClasses) {
             Collection<String> tses = sopClass.getTransferSyntaxes();
-            
+
             switch (sopClass.getUID()) {
                 case UID.CTImageStorage:
                     assertEquals(Collections.emptyList(), tses);
                     break;
                 case UID.EnhancedXAImageStorage:
-                    assertEquals(
-                        Arrays.asList(
-                            "1.2.840.10008.1.2",
-                            "1.2.840.10008.1.2.1",
-                            "1.2.840.10008.1.2.5"
-                        ),
-                        tses
-                    );
+                    assertEquals(Arrays.asList("1.2.840.10008.1.2", "1.2.840.10008.1.2.1", "1.2.840.10008.1.2.5"),
+                            tses);
                     break;
                 case UID.EnhancedCTImageStorage:
-                // fallthrough (same settings)
+                    // fallthrough (same settings)
                 case UID.UltrasoundMultiFrameImageStorage:
-                    assertEquals(
-                        Arrays.asList(
-                            "1.2.840.10008.1.2",
-                            "1.2.840.10008.1.2.1",
-                            "1.2.840.10008.1.2.4.70",
-                            "1.2.840.10008.1.2.4.50"
-                        ),
-                        tses);
+                    assertEquals(Arrays.asList("1.2.840.10008.1.2", "1.2.840.10008.1.2.1", "1.2.840.10008.1.2.4.70",
+                            "1.2.840.10008.1.2.4.50"), tses);
                     break;
                 default:
                     break;
@@ -419,11 +378,9 @@ public class ServerSettingsTest {
         Logger logger = NOPLogger.NOP_LOGGER;
         // Filter (as in init)
         ds.setAdditionalTransferSyntaxes(ds.getAdditionalTransferSyntaxes().stream()
-                .filter(ats -> AdditionalTransferSyntax.isValid(ats, logger))
-                .collect(Collectors.toList()));
+                .filter(ats -> AdditionalTransferSyntax.isValid(ats, logger)).collect(Collectors.toList()));
         ds.setAdditionalSOPClasses(ds.getAdditionalSOPClasses().stream()
-                .filter(asc -> AdditionalSOPClass.isValid(asc, logger))
-                .collect(Collectors.toList()));
+                .filter(asc -> AdditionalSOPClass.isValid(asc, logger)).collect(Collectors.toList()));
 
         // assertions follow
 

--- a/dicoogle/src/test/java/pt/ua/dicoogle/webui/WebUIPluginTest.java
+++ b/dicoogle/src/test/java/pt/ua/dicoogle/webui/WebUIPluginTest.java
@@ -43,9 +43,8 @@ public class WebUIPluginTest {
     public void testLoadPlugin1() throws IOException, PluginFormatException {
         WebUIPluginManager webui = new WebUIPluginManager();
 
-        String test1Path = WebUIPluginTest.class.getClassLoader()
-            .getResource("pt/ua/dicoogle/webui/WebPlugins/test1")
-            .getFile();
+        String test1Path =
+                WebUIPluginTest.class.getClassLoader().getResource("pt/ua/dicoogle/webui/WebPlugins/test1").getFile();
         webui.load(new File(test1Path));
 
         WebUIPlugin plugin = webui.get("test1");

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.11.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -28,15 +28,22 @@
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <version>2.4</version>
+                <version>4.3</version>
                 <configuration>
-                    <header>short-license.txt</header>
-                    <includes>
-                        <include>**/*.java</include>
-                    </includes>
-                    <excludes>
-                        <exclude>**/package-info.java</exclude>
-                    </excludes>
+                    <mapping>
+                        <java>JAVADOC_STYLE</java>
+                    </mapping>
+                    <licenseSets>
+                        <licenseSet>
+                            <header>short-license.txt</header>
+                            <includes>
+                                <include>**/*.java</include>
+                            </includes>
+                            <excludes>
+                                <exclude>**/package-info.java</exclude>
+                            </excludes>
+                        </licenseSet>
+                    </licenseSets>
                 </configuration>
 
                 <executions>
@@ -51,7 +58,7 @@
             <plugin>
                 <groupId>net.revelc.code.formatter</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>
-                <version>2.11.0</version>
+                <version>2.12.2</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
                     <includes>

--- a/pom.xml
+++ b/pom.xml
@@ -58,9 +58,10 @@
             <plugin>
                 <groupId>net.revelc.code.formatter</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>
-                <version>2.12.2</version>
+                <version>2.16.0</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
+                    <lineEnding>KEEP</lineEnding>
                     <includes>
                         <include>**/*.java</include>
                     </includes>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -56,25 +56,25 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.5.1</version>
+                <configuration>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>**/*.SF</exclude>
+                                <exclude>**/*.DSA</exclude>
+                                <exclude>**/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                </configuration>
                 <executions>
                     <execution>
                         <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>
-                        <configuration>
-                            <filters>
-                                <filter>
-                                    <artifact>*:*</artifact>
-                                    <excludes>
-                                        <exclude>**/*.SF</exclude>
-                                        <exclude>**/*.DSA</exclude>
-                                        <exclude>**/*.RSA</exclude>
-                                    </excludes>
-                                </filter>
-                            </filters>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -82,7 +82,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.11.0</version>
                 <configuration>
                     <encoding>${project.build.sourceEncoding}</encoding>
                     <source>1.8</source>
@@ -93,7 +93,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>2.4.3</version>
+                <version>3.3.1</version>
                 <configuration>
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
@@ -102,17 +102,23 @@
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <version>2.4</version>
+                <version>4.3</version>
                 <configuration>
-                    <header>../short-license.txt</header>
-                    <includes>
-                        <include>**/*.java</include>
-                    </includes>
-                    <excludes>
-                        <exclude>**/package-info.java</exclude>
-                    </excludes>
+                    <mapping>
+                        <java>JAVADOC_STYLE</java>
+                    </mapping>
+                    <licenseSets>
+                        <licenseSet>
+                            <header>../short-license.txt</header>
+                            <includes>
+                                <include>**/*.java</include>
+                            </includes>
+                            <excludes>
+                                <exclude>**/package-info.java</exclude>
+                            </excludes>
+                        </licenseSet>
+                    </licenseSets>
                 </configuration>
-
                 <executions>
                     <execution>
                         <goals>
@@ -125,7 +131,7 @@
             <plugin>
                 <groupId>net.revelc.code.formatter</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>
-                <version>2.11.0</version>
+                <version>2.12.2</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
                     <includes>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -131,9 +131,10 @@
             <plugin>
                 <groupId>net.revelc.code.formatter</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>
-                <version>2.12.2</version>
+                <version>2.16.0</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
+                    <lineEnding>KEEP</lineEnding>
                     <includes>
                         <include>**/*.java</include>
                     </includes>

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/dim/DIMGeneric.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/dim/DIMGeneric.java
@@ -457,7 +457,7 @@ public class DIMGeneric {
                                     // not a number, do not include
                                 }
                             }
-    
+
                             instances.add(image);
                         }
                         seriesObj.put("images", instances);


### PR DESCRIPTION
This should be a safe maintenance update that does not affect functionality.

- [dicoogle][sdk] Update maven plugins
   - maven-compiler-plugin 3.11.0
   - maven-shade-plugin 3.5.1
   - maven-resources-plugin 3.3.1
   - frontend-maven-plugin 1.14.0
      - update nodeVersion to 18.17.1 and npmVersion to 9.6.7
   - license-maven-plugin 4.3
   - formatter-maven-plugin 2.16.0
      - This is the only plugin I could not update to the latest version, because we want to continue supporting Java 8
- Format Java code
- Reorganize .gitignore
   - Add `/target`, remove obsolete lines, rearrange lines
