### PR TITLE
Update Bcrypt dependency and password hash service

### DIFF
--- a/dicoogle/pom.xml
+++ b/dicoogle/pom.xml
@@ -329,7 +329,7 @@
         <dependency>
             <groupId>at.favre.lib</groupId>
             <artifactId>bcrypt</artifactId>
-            <version>0.9.0</version>
+            <version>0.10.2</version>
         </dependency>
 
         <dependency>

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/users/HashService.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/users/HashService.java
@@ -18,6 +18,8 @@
  */
 package pt.ua.dicoogle.server.users;
 
+import org.slf4j.LoggerFactory;
+
 import at.favre.lib.crypto.bcrypt.BCrypt;
 import at.favre.lib.crypto.bcrypt.LongPasswordStrategies;
 
@@ -27,9 +29,24 @@ import at.favre.lib.crypto.bcrypt.LongPasswordStrategies;
 public class HashService {
 
     /**
-     * Hardcoded cost for the password hashing algorithm.
+     * The cost for the password hashing algorithm.
+     * 
+     * Can be configured via JVM variable `dicoogle.user.hashStrength`.
+     * Default is 10.
      */
-    private static final int HASH_STRENGTH = 10;
+    private static final int HASH_STRENGTH;
+
+    static {
+        int strength;
+        try {
+            strength = Integer.parseInt(System.getProperty("dicoogle.user.hashStrength", "10"));
+        } catch (NumberFormatException e) {
+            LoggerFactory.getLogger(HashService.class)
+                    .warn("Invalid value for dicoogle.user.hashStrength, using default value");
+            strength = 10;
+        }
+        HASH_STRENGTH = strength;
+    }
 
     /**
      * Hash a password.

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/users/HashService.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/users/HashService.java
@@ -22,6 +22,8 @@ import org.slf4j.LoggerFactory;
 
 import at.favre.lib.crypto.bcrypt.BCrypt;
 import at.favre.lib.crypto.bcrypt.LongPasswordStrategies;
+import at.favre.lib.crypto.bcrypt.LongPasswordStrategy;
+import at.favre.lib.crypto.bcrypt.BCrypt.Version;
 
 /**
  * This class provides a password hashing service.
@@ -48,6 +50,9 @@ public class HashService {
         HASH_STRENGTH = strength;
     }
 
+    private static final LongPasswordStrategy LONG_PASSWORD_STRATEGY =
+            LongPasswordStrategies.hashSha512(BCrypt.Version.VERSION_2B);
+
     /**
      * Hash a password.
      *
@@ -67,8 +72,7 @@ public class HashService {
      */
     public static String hashPassword(char[] password) {
         try {
-            return BCrypt.with(LongPasswordStrategies.hashSha512(BCrypt.Version.VERSION_2B)).hashToString(HASH_STRENGTH,
-                    password);
+            return BCrypt.with(Version.VERSION_2B, LONG_PASSWORD_STRATEGY).hashToString(HASH_STRENGTH, password);
         } finally {
             for (int i = 0; i < password.length; i++) {
                 password[i] = '\0';
@@ -97,7 +101,7 @@ public class HashService {
      */
     public static boolean verifyPassword(String hash, char[] password) {
         try {
-            BCrypt.Result result = BCrypt.verifyer().verify(password, hash);
+            BCrypt.Result result = BCrypt.verifyer(Version.VERSION_2B, LONG_PASSWORD_STRATEGY).verify(password, hash);
             return result.verified;
         } finally {
             for (int i = 0; i < password.length; i++) {
@@ -105,5 +109,4 @@ public class HashService {
             }
         }
     }
-
 }

--- a/dicoogle/src/test/java/pt/ua/dicoogle/server/users/HashServiceTest.java
+++ b/dicoogle/src/test/java/pt/ua/dicoogle/server/users/HashServiceTest.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2014  Universidade de Aveiro, DETI/IEETA, Bioinformatics Group - http://bioinformatics.ua.pt/
+ *
+ * This file is part of Dicoogle/dicoogle.
+ *
+ * Dicoogle/dicoogle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Dicoogle/dicoogle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Dicoogle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pt.ua.dicoogle.server.users;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class HashServiceTest {
+
+    /** Hash service reliably accepts the same password,
+     * while rejecting different passwords.
+     */
+    @Test
+    public void canValidatePasswords() {
+
+        String[] passwords = new String[] {"dicoogledicoogle", "IAmTest123456789", "áÀéìóÙãõçüºª",
+                "very long password here very long password here very long password here"};
+
+        for (String password : passwords) {
+            String hash = HashService.hashPassword(password);
+            assertTrue(HashService.verifyPassword(hash, password));
+
+            assertFalse(HashService.verifyPassword(hash, "wrongpasswordgoeshere123"));
+        }
+    }
+}


### PR DESCRIPTION
### Summary

- Update bcrypt and password hashing
   - bcrypt 0.10.2
   - Make password hashing strength configurable via JVM variable (default stays at 10)
- Fix `HashService` for very large passwords
   - Set BCrypt version to 2B
   - Apply existing long password strategy in verification
   - Add `HashServiceTest`
