### PR TITLE
Update Jetty to v9.4

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
@@ -266,6 +266,9 @@ public class PluginController {
 
         DicoogleWeb jettyServer = ControlServices.getInstance().getWebServicePlatform();
         for (JettyPluginInterface resource : jettyInterfaces) {
+            if (resource == null) {
+                continue;
+            }
             jettyServer.addContextHandlers(resource.getJettyHandlers());
         }
     }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/DicoogleWeb.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/DicoogleWeb.java
@@ -28,7 +28,6 @@ import pt.ua.dicoogle.server.web.servlets.ExportToCSVServlet;
 import pt.ua.dicoogle.server.web.servlets.SettingsServlet;
 import pt.ua.dicoogle.server.web.servlets.TagsServlet;
 import pt.ua.dicoogle.server.web.servlets.ExportCSVToFILEServlet;
-import pt.ua.dicoogle.server.web.servlets.SearchHolderServlet;
 import pt.ua.dicoogle.server.web.servlets.IndexerServlet;
 import pt.ua.dicoogle.server.web.servlets.ImageServlet;
 import pt.ua.dicoogle.server.web.servlets.plugins.PluginsServlet;
@@ -38,20 +37,6 @@ import pt.ua.dicoogle.server.web.servlets.search.ExportServlet.ExportType;
 import pt.ua.dicoogle.server.web.servlets.search.SearchServlet.SearchType;
 import pt.ua.dicoogle.server.web.servlets.accounts.LoginServlet;
 import pt.ua.dicoogle.server.web.servlets.accounts.UserServlet;
-
-//import pt.ua.dicoogle.core.ServerSettings;
-
-import pt.ua.dicoogle.server.web.servlets.management.AETitleServlet;
-import pt.ua.dicoogle.server.web.servlets.management.DicomQuerySettingsServlet;
-import pt.ua.dicoogle.server.web.servlets.management.ForceIndexing;
-import pt.ua.dicoogle.server.web.servlets.management.IndexerSettingsServlet;
-import pt.ua.dicoogle.server.web.servlets.management.LoggerServlet;
-import pt.ua.dicoogle.server.web.servlets.management.RemoveServlet;
-import pt.ua.dicoogle.server.web.servlets.management.RunningTasksServlet;
-import pt.ua.dicoogle.server.web.servlets.management.ServerStorageServlet;
-import pt.ua.dicoogle.server.web.servlets.management.ServicesServlet;
-import pt.ua.dicoogle.server.web.servlets.management.TransferOptionsServlet;
-
 
 import java.io.File;
 import java.net.URL;
@@ -64,18 +49,16 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
-import org.eclipse.jetty.webapp.WebAppContext;
+import org.restlet.Restlet;
 
 import javax.servlet.DispatcherType;
-import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 
 import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.HandlerWrapper;
-
+import org.eclipse.jetty.servlet.DefaultServlet;
 import org.eclipse.jetty.servlet.FilterHolder;
-import org.eclipse.jetty.servlets.GzipFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,8 +66,6 @@ import com.google.common.hash.Hashing;
 
 import pt.ua.dicoogle.server.LegacyRestletApplication;
 import pt.ua.dicoogle.server.web.servlets.accounts.LogoutServlet;
-import pt.ua.dicoogle.server.web.servlets.search.DumpServlet;
-import pt.ua.dicoogle.server.web.servlets.management.UnindexServlet;
 import pt.ua.dicoogle.server.web.servlets.webui.WebUIModuleServlet;
 import pt.ua.dicoogle.server.web.servlets.webui.WebUIServlet;
 import pt.ua.dicoogle.server.web.utils.LocalImageCache;
@@ -115,9 +96,9 @@ public class DicoogleWeb {
     private final int port;
 
     private final ContextHandlerCollection contextHandlers;
-    private ServletContextHandler pluginHandler = null;
+    private Handler pluginHandler;
     private PluginRestletApplication pluginApp = null;
-    private ServletContextHandler legacyHandler = null;
+    private Handler legacyHandler = null;
     private LegacyRestletApplication legacyApp = null;
 
     /**
@@ -128,107 +109,12 @@ public class DicoogleWeb {
     public DicoogleWeb(int port) throws Exception {
         logger.info("Starting Web Services in DicoogleWeb. Port: {}", port);
         System.setProperty("org.apache.jasper.compiler.disablejsr199", "true");
-        // System.setProperty("org.mortbay.jetty.webapp.parentLoaderPriority", "true");
-        // System.setProperty("production.mode", "true");
 
         this.port = port;
-
-        // "build" the input location, based on the www directory/.war chosen
-        final URL warUrl = Thread.currentThread().getContextClassLoader().getResource(WEBAPPDIR);
-        final String warUrlString = warUrl.toExternalForm();
-
-        // setup the DICOM to PNG image servlet, with a local cache
-        cache = new LocalImageCache("dic2png", 300, 900, new SimpleImageRetriever()); // pooling rate of 12/hr and max un-used cache age of 15 minutes
-        final ServletContextHandler dic2png = createServletHandler(new ImageServlet(cache), "/dic2png");
-        cache.start(); // start the caching system
-
-        // setup the DICOM to PNG image servlet
-        final ServletContextHandler dictags = createServletHandler(new TagsServlet(), "/dictags");
-
-        // setup the Export to CSV Servlet
-        final ServletContextHandler csvServletHolder = createServletHandler(new ExportToCSVServlet(), "/export");
-        File tempDir = Paths.get(System.getProperty("java.io.tmpdir")).toFile();
-        csvServletHolder.addServlet(new ServletHolder(new ExportCSVToFILEServlet(tempDir)), "/exportFile");
-
-        // setup the search (DIMSE-service-user C-FIND ?!?) servlet
-        // final ServletContextHandler search = new ServletContextHandler(ServletContextHandler.SESSIONS); // servlet with session support enabled
-        // search.setContextPath(CONTEXTPATH);
-        // search.addServlet(new ServletHolder(new SearchServlet()), "/search");
-
-        /*hooks = getRegisteredHookActions();
-         plugin.addServlet(new ServletHolder(new PluginsServlet(hooks)), "/plugin/*");
-         */
-
-        // setup the web pages/scripts app
-        final WebAppContext webpages = new WebAppContext(warUrlString, CONTEXTPATH);
-        webpages.setInitParameter("org.eclipse.jetty.servlet.Default.dirAllowed", "false"); // disables directory listing
-        webpages.setInitParameter("useFileMappedBuffer", "false");
-        webpages.setInitParameter("cacheControl", "public, max-age=2592000"); // cache for 30 days
-        webpages.setInitParameter("etags", "true"); // generate and handle weak entity validation tags
-        webpages.setDisplayName("webapp");
-        webpages.setWelcomeFiles(new String[] {"index.html"});
-        webpages.addServlet(new ServletHolder(new SearchHolderServlet()), "/search/holders");
-        webpages.addFilter(GzipFilter.class, "/*", EnumSet.of(DispatcherType.REQUEST));
-
-        this.pluginApp = new PluginRestletApplication();
-        this.pluginHandler = createServletHandler(new RestletHttpServlet(this.pluginApp), "/ext/*");
-
-        this.legacyApp = new LegacyRestletApplication();
-        this.legacyHandler = createServletHandler(new RestletHttpServlet(this.legacyApp), "/legacy/*");
-
-        // Add Static RESTlet Plugins
-        PluginRestletApplication.attachRestPlugin(new VersionResource());
-
-        // list the all the handlers mounted above
-        Handler[] handlers = new Handler[] {pluginHandler, legacyHandler, dic2png, dictags,
-                createServletHandler(new IndexerServlet(), "/indexer"), // DEPRECATED
-                createServletHandler(new SettingsServlet(), "/settings"), csvServletHolder,
-                createServletHandler(new LoginServlet(), "/login"),
-                createServletHandler(new LogoutServlet(), "/logout"),
-                createServletHandler(new UserServlet(), "/user/*"),
-                createServletHandler(new SearchServlet(), "/search"),
-                createServletHandler(new SearchServlet(SearchType.PATIENT), "/searchDIM"),
-                createServletHandler(new DumpServlet(), "/dump"),
-                createServletHandler(new IndexerSettingsServlet(IndexerSettingsServlet.SettingsType.path),
-                        "/management/settings/index/path"),
-                createServletHandler(new IndexerSettingsServlet(IndexerSettingsServlet.SettingsType.zip),
-                        "/management/settings/index/zip"),
-                createServletHandler(new IndexerSettingsServlet(IndexerSettingsServlet.SettingsType.effort),
-                        "/management/settings/index/effort"),
-                createServletHandler(new IndexerSettingsServlet(IndexerSettingsServlet.SettingsType.thumbnail),
-                        "/management/settings/index/thumbnail"),
-                createServletHandler(new IndexerSettingsServlet(IndexerSettingsServlet.SettingsType.watcher),
-                        "/management/settings/index/watcher"),
-                createServletHandler(new IndexerSettingsServlet(IndexerSettingsServlet.SettingsType.thumbnailSize),
-                        "/management/settings/index/thumbnail/size"),
-                createServletHandler(new IndexerSettingsServlet(IndexerSettingsServlet.SettingsType.all),
-                        "/management/settings/index"),
-                createServletHandler(new TransferOptionsServlet(), "/management/settings/transfer"),
-                createServletHandler(new WadoServlet(), "/wado"),
-                createServletHandler(new ProvidersServlet(), "/providers"),
-                createServletHandler(new DicomQuerySettingsServlet(), "/management/settings/dicom/query"),
-                createServletHandler(new DimTagsServlet(TagsStruct.getInstance()), "/management/settings/dicom/tags"),
-                createServletHandler(new ForceIndexing(), "/management/tasks/index"),
-                createServletHandler(new UnindexServlet(), "/management/tasks/unindex"),
-                createServletHandler(new RemoveServlet(), "/management/tasks/remove"),
-                createServletHandler(new ServicesServlet(ServicesServlet.STORAGE), "/management/dicom/storage"),
-                createServletHandler(new ServicesServlet(ServicesServlet.QUERY), "/management/dicom/query"),
-                createServletHandler(new ServicesServlet(ServicesServlet.PLUGIN), "/management/plugins/"),
-                createServletHandler(new AETitleServlet(), "/management/settings/dicom"),
-                createServletHandler(new PluginsServlet(), "/plugins/*"),
-                createServletHandler(new PresetsServlet(), "/presets/*"),
-                createServletHandler(new WebUIServlet(), "/webui"), createWebUIModuleServletHandler(),
-                createServletHandler(new LoggerServlet(), "/logger"),
-                createServletHandler(new RunningTasksServlet(), "/index/task"),
-                createServletHandler(new ExportServlet(ExportType.EXPORT_CVS), "/export/cvs"),
-                createServletHandler(new ExportServlet(ExportType.LIST), "/export/list"),
-                createServletHandler(new ServerStorageServlet(), "/management/settings/storage/dicom"), webpages};
+        this.contextHandlers = this.createHandlerCollection();
 
         // setup the server
         server = new Server(port);
-        // register the handlers on the server
-        this.contextHandlers = new ContextHandlerCollection();
-        this.contextHandlers.setHandlers(handlers);
         server.setHandler(this.contextHandlers);
 
         // Increase maxFormContentSize to avoid issues with big forms
@@ -238,13 +124,147 @@ public class DicoogleWeb {
         server.start();
     }
 
-    private ServletContextHandler createWebUIModuleServletHandler() {
-        ServletContextHandler handler = new ServletContextHandler(ServletContextHandler.SESSIONS); // servlet with session support enabled
-        handler.setContextPath(CONTEXTPATH);
+    /** Root context handler, contains the full tree of services. */
+    private ContextHandlerCollection createHandlerCollection() {
+        // setup the DICOM to PNG image servlet, with a local cache
+        cache = new LocalImageCache("dic2png", 300, 900, new SimpleImageRetriever()); // pooling rate of 12/hr and max un-used cache age of 15 minutes
+        cache.start(); // start the caching system
 
-        HttpServlet servletModule = new WebUIModuleServlet();
+        // temporary folder for export CSV files
+        File tempDir = Paths.get(System.getProperty("java.io.tmpdir")).toFile();
+
+        // set up plugin Restlet application for plugin services
+        this.pluginApp = new PluginRestletApplication();
+        this.pluginHandler = createRestletHandler("ext", this.pluginApp);
+
+        // set up plugin Restlet application for legacy services
+        this.legacyApp = new LegacyRestletApplication();
+        this.legacyHandler = createRestletHandler("legacy", this.legacyApp);
+
+        // Add Static RESTlet Plugins
+        PluginRestletApplication.attachRestPlugin(new VersionResource());
+
+        ServletContextHandler rootContextHandler = new ServletContextHandler(0);
+        rootContextHandler.setContextPath(CONTEXTPATH);
+
+        // list handlers for services mounted in the root context directly
+
+        // search
+        rootContextHandler.addServlet(new ServletHolder("search", new SearchServlet()), "/search");
+        // DICOM to PNG image servlet
+        rootContextHandler.addServlet(new ServletHolder("dic2png", new ImageServlet(cache)), "/dic2png");
+        // export to CSV servlets
+        rootContextHandler.addServlet(new ServletHolder("export", new ExportToCSVServlet()), "/export");
+        rootContextHandler.addServlet(new ServletHolder(new ExportCSVToFILEServlet(tempDir)), "/exportFile");
+        // dictags
+        rootContextHandler.addServlet(new ServletHolder(new TagsServlet()), "/dictags");
+        // User servlets: logging in and out, and fetching user information.
+        rootContextHandler.addServlet(new ServletHolder(new LoginServlet()), "/login");
+        rootContextHandler.addServlet(new ServletHolder(new LogoutServlet()), "/logout");
+        rootContextHandler.addServlet(new ServletHolder(new UserServlet()), "/user/*");
+        // DIM search servlet
+        rootContextHandler.addServlet(new ServletHolder(new SearchServlet(SearchType.PATIENT)), "/searchDIM");
+        // metadata dump servlet
+        rootContextHandler.addServlet(new ServletHolder(new DumpServlet()), "/dump");
+        // list query/index/storage providers
+        rootContextHandler.addServlet(new ServletHolder(new ProvidersServlet()), "/providers");
+        // service to retrieve plugin information
+        rootContextHandler.addServlet(new ServletHolder(new PluginsServlet()), "/plugins/*");
+        // service to retrieve export presets
+        rootContextHandler.addServlet(new ServletHolder(new PresetsServlet()), "/presets/*");
+        // retrieve logs
+        rootContextHandler.addServlet(new ServletHolder(new LoggerServlet()), "/logger");
+        // get running index tasks and do operations on them
+        rootContextHandler.addServlet(new ServletHolder(new RunningTasksServlet()), "/index/task");
+        // deprecated stuff
+        rootContextHandler.addServlet(new ServletHolder(new IndexerServlet()), "/indexer");
+        rootContextHandler.addServlet(new ServletHolder(new SettingsServlet()), "/settings");
+        rootContextHandler.addServlet(new ServletHolder(new WadoServlet()), "/wado");
+        rootContextHandler.addServlet(new ServletHolder(new ExportServlet(ExportType.EXPORT_CVS)), "/export/cvs");
+        rootContextHandler.addServlet(new ServletHolder(new ExportServlet(ExportType.LIST)), "/export/list");
+        // webapp
+        rootContextHandler.addServlet(createWebappServlet(), "/");
+
+        this.addCORSFilter(rootContextHandler);
+
+        // list ALL of the handlers mounted above
+        Handler[] handlers = new Handler[] {
+                // /management
+                createManagementHandler(),
+
+                // /webui
+                createWebUIServletHandler(),
+
+                // /ext (handler for Restlet resources from Dicoogle plugins)
+                pluginHandler,
+                // /legacy (legacy Restlet service handling)
+                legacyHandler,
+
+                // /
+                rootContextHandler};
+
+        ContextHandlerCollection col = new ContextHandlerCollection();
+        col.setHandlers(handlers);
+        return col;
+    }
+
+    private ServletHolder createWebappServlet() {
+        final URL warUrl = Thread.currentThread().getContextClassLoader().getResource(WEBAPPDIR);
+
+        // set up static serving of the webapp
+        ServletHolder webpages = new ServletHolder("webapp", DefaultServlet.class);
+        webpages.setInitParameter("resourceBase", warUrl.toExternalForm());
+        webpages.setInitParameter("welcomeFile", "index.html");
+        webpages.setInitParameter(AbstractCacheFilter.CACHE_CONTROL_PARAM, "public, max-age=2592000"); // cache for 30 days
+
+        return webpages;
+    }
+
+    /** Management services: create all servlets and respective handlers */
+    private ServletContextHandler createManagementHandler() {
+        ServletContextHandler handler = new ServletContextHandler(0);
+
+        handler.setContextPath(CONTEXTPATH + "management");
+
+        handler.addServlet(new ServletHolder(new IndexerSettingsServlet(IndexerSettingsServlet.SettingsType.path)),
+                "/settings/index/path");
+        handler.addServlet(new ServletHolder(new IndexerSettingsServlet(IndexerSettingsServlet.SettingsType.zip)),
+                "/settings/index/zip");
+        handler.addServlet(new ServletHolder(new IndexerSettingsServlet(IndexerSettingsServlet.SettingsType.effort)),
+                "/settings/index/effort");
+        handler.addServlet(new ServletHolder(new IndexerSettingsServlet(IndexerSettingsServlet.SettingsType.thumbnail)),
+                "/settings/index/thumbnail");
+        handler.addServlet(new ServletHolder(new IndexerSettingsServlet(IndexerSettingsServlet.SettingsType.watcher)),
+                "/settings/index/watcher");
+        handler.addServlet(
+                new ServletHolder(new IndexerSettingsServlet(IndexerSettingsServlet.SettingsType.thumbnailSize)),
+                "/settings/index/thumbnail/size");
+        handler.addServlet(new ServletHolder(new IndexerSettingsServlet(IndexerSettingsServlet.SettingsType.all)),
+                "/settings/index");
+        handler.addServlet(new ServletHolder(new TransferOptionsServlet()), "/settings/transfer");
+        handler.addServlet(new ServletHolder(new DicomQuerySettingsServlet()), "/settings/dicom/query");
+        handler.addServlet(new ServletHolder(new DimTagsServlet(TagsStruct.getInstance())), "/settings/dicom/tags");
+        handler.addServlet(new ServletHolder(new ForceIndexing()), "/tasks/index");
+        handler.addServlet(new ServletHolder(new UnindexServlet()), "/tasks/unindex");
+        handler.addServlet(new ServletHolder(new RemoveServlet()), "/tasks/remove");
+        handler.addServlet(new ServletHolder(new ServicesServlet(ServicesServlet.STORAGE)), "/dicom/storage");
+        handler.addServlet(new ServletHolder(new ServicesServlet(ServicesServlet.QUERY)), "/dicom/query");
+        handler.addServlet(new ServletHolder(new AETitleServlet()), "/settings/dicom");
+        handler.addServlet(new ServletHolder(new ServerStorageServlet()), "/settings/storage/dicom");
+
+        this.addCORSFilter(handler);
+
+        return handler;
+    }
+
+    /** Web UI functionality: create all servlets and respective handlers */
+    private ServletContextHandler createWebUIServletHandler() {
+        ServletContextHandler handler = new ServletContextHandler(0);
+        handler.setContextPath(CONTEXTPATH + "webui");
+
         // CORS support
         this.addCORSFilter(handler);
+
         // Caching!
         FilterHolder cacheHolder = new FilterHolder(new AbstractCacheFilter() {
             @Override
@@ -269,20 +289,24 @@ public class DicoogleWeb {
                 }
             }
         });
+
         cacheHolder.setInitParameter(AbstractCacheFilter.CACHE_CONTROL_PARAM, "private, max-age=2592000"); // cache for 30 days
-        handler.addFilter(cacheHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
-        handler.addServlet(new ServletHolder(servletModule), "/webui/module/*");
+
+        // servlet for web UI extension info retrieval
+        handler.addServlet(new ServletHolder("webui", new WebUIServlet()), "");
+        // servlet for web UI JavaScript retrieval (with Etag support)
+        handler.addFilter(cacheHolder, "/module/*", EnumSet.of(DispatcherType.REQUEST));
+        handler.addServlet(new ServletHolder("webui/module", new WebUIModuleServlet()), "/module/*");
         return handler;
     }
 
-    private ServletContextHandler createServletHandler(HttpServlet servlet, String path) {
-        ServletContextHandler handler = new ServletContextHandler(ServletContextHandler.SESSIONS); // servlet with session support enabled
-        handler.setContextPath(CONTEXTPATH);
+    private Handler createRestletHandler(String path, Restlet app) {
 
-        // CORS support
-        this.addCORSFilter(handler);
+        ServletContextHandler handler = new ServletContextHandler(0);
+        handler.setContextPath(CONTEXTPATH + path);
 
-        handler.addServlet(new ServletHolder(servlet), path);
+        handler.addServlet(new ServletHolder(path, new RestletHttpServlet(app)), "/*");
+
         return handler;
     }
 
@@ -353,7 +377,6 @@ public class DicoogleWeb {
         this.contextHandlers.addHandler(handler);
 
         this.addCORSFilter(handler);
-        // this.server.setHandler(this.contextHandlers);
     }
 
     public void stopPluginWebServices() {

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/auth/Session.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/auth/Session.java
@@ -235,9 +235,6 @@ public class Session {
                 return new LoggedInStatus(null, LoggedInStatus.S_UNAUTHORIZEDACCESS);
             }
 
-            // add the login information to the session
-            HttpSession session = request.getSession(true); // force the creation of a new session if there is none
-            session.setAttribute("login", login);
             return new LoggedInStatus(login, LoggedInStatus.S_VALIDLOGIN);
         }
 

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/SearchHolderServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/SearchHolderServlet.java
@@ -43,7 +43,9 @@ import pt.ua.dicoogle.server.web.utils.DIM2JSONConverter;
  * 
  * @author Tiago Godinho.
  *
+ * @deprecated See {@link pt.ua.dicoogle.server.web.servlets.search.SearchServlet} instead
  */
+@Deprecated
 public class SearchHolderServlet extends HttpServlet {
     private static final long serialVersionUID = 1L;
 

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/search/ExportServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/search/ExportServlet.java
@@ -35,6 +35,10 @@ import pt.ua.dicoogle.core.query.ExportToCSVQueryTask;
 import pt.ua.dicoogle.plugins.PluginController;
 import pt.ua.dicoogle.sdk.utils.DictionaryAccess;
 
+/**
+ * @deprecated Use {@link pt.ua.dicoogle.server.web.servlets.ExportCSVToFILEServlet} instead.
+ */
+@Deprecated
 public class ExportServlet extends HttpServlet {
     private static final Logger logger = LoggerFactory.getLogger(ExportServlet.class);
 

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/search/WadoServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/search/WadoServlet.java
@@ -38,7 +38,9 @@ import pt.ua.dicoogle.sdk.task.Task;
 /**
  * @author Frederico Silva <fredericosilva@ua.pt>
  * @todo
+ * @deprecated Incomplete implementation, to be removed in Dicoogle 4
  */
+@Deprecated
 public class WadoServlet extends HttpServlet {
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <name>dicoogle-all</name>
 
     <properties>
-        <jetty.version>9.4.52.v20230823</jetty.version>
+        <jetty.version>9.4.56.v20240826</jetty.version>
         <restlet.version>2.1.2</restlet.version>
         <dcm4che.version>2.0.29</dcm4che.version>
         <slf4j.version>1.7.36</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <name>dicoogle-all</name>
 
     <properties>
-        <jetty.version>9.0.3.v20130506</jetty.version>
+        <jetty.version>9.4.52.v20230823</jetty.version>
         <restlet.version>2.1.2</restlet.version>
         <dcm4che.version>2.0.29</dcm4che.version>
         <slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
### Summary

- Update some Maven plugins
- Format Java code
- Reorganize .gitignore
- Update Jetty from 9.0.3.v20130506 to ~~9.4.52.v20230823~~ 9.4.56.v20240826
   - rearrange and reorganize servlets and handlers
   - remover server session attribute
   - mark services known to be unused as deprecated
   - add plugin controller check to skip JettyPluginInterface resource if it is null