### PR TITLE
Include submitted query and provider in “result-selection-ready” event

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/search/SearchServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/search/SearchServlet.java
@@ -228,7 +228,6 @@ public class SearchServlet extends HttpServlet {
                     JSONObject obj = dimModel.getJSONObject(depth, offset, psize);
                     elapsedTime = System.currentTimeMillis() - elapsedTime;
                     obj.put("elapsedTime", elapsedTime);
-                    obj.put("query", query);
                     response.getWriter().write(obj.toString());
                 } catch (Exception e) {
                     logger.warn("Failed to get DIM", e);

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/search/SearchServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/search/SearchServlet.java
@@ -228,6 +228,7 @@ public class SearchServlet extends HttpServlet {
                     JSONObject obj = dimModel.getJSONObject(depth, offset, psize);
                     elapsedTime = System.currentTimeMillis() - elapsedTime;
                     obj.put("elapsedTime", elapsedTime);
+                    obj.put("query", query);
                     response.getWriter().write(obj.toString());
                 } catch (Exception e) {
                     logger.warn("Failed to get DIM", e);

--- a/dicoogle/src/main/resources/webapp/js/actions/requestActions.js
+++ b/dicoogle/src/main/resources/webapp/js/actions/requestActions.js
@@ -1,0 +1,5 @@
+import Reflux from "reflux";
+const RequestActions = {
+  query: Reflux.createAction(),
+};
+export { RequestActions };

--- a/dicoogle/src/main/resources/webapp/js/components/plugin/pluginForm.jsx
+++ b/dicoogle/src/main/resources/webapp/js/components/plugin/pluginForm.jsx
@@ -44,7 +44,7 @@ export default class PluginForm extends React.Component {
           node,
           "result-selection-ready",
           {
-            "query": RequestStore.get(),
+            "request": RequestStore.get(),
             "selected": ResultsSelected.get(),
             "search": SearchStore.get()
           }

--- a/dicoogle/src/main/resources/webapp/js/components/plugin/pluginForm.jsx
+++ b/dicoogle/src/main/resources/webapp/js/components/plugin/pluginForm.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import * as PropTypes from "prop-types";
 import { ResultsSelected } from "../../stores/resultSelected";
+import { RequestStore } from "../../stores/requestStore";
 import { SearchStore } from "../../stores/searchStore";
 import Webcore from "dicoogle-webcore";
 
@@ -43,6 +44,7 @@ export default class PluginForm extends React.Component {
           node,
           "result-selection-ready",
           {
+            "query": RequestStore.get(),
             "selected": ResultsSelected.get(),
             "search": SearchStore.get()
           }

--- a/dicoogle/src/main/resources/webapp/js/stores/requestStore.js
+++ b/dicoogle/src/main/resources/webapp/js/stores/requestStore.js
@@ -11,9 +11,6 @@ const RequestStore = Reflux.createStore({
 
   onQuery: function(data) {
     this._contents = data
-    self.trigger({
-      contents: this._contents
-    });
   },
 
   get: function() {
@@ -24,5 +21,3 @@ const RequestStore = Reflux.createStore({
 });
 
 export { RequestStore };
-
-window.store = RequestStore;

--- a/dicoogle/src/main/resources/webapp/js/stores/requestStore.js
+++ b/dicoogle/src/main/resources/webapp/js/stores/requestStore.js
@@ -1,0 +1,28 @@
+import Reflux from "reflux";
+
+import { RequestActions } from "../actions/requestActions";
+
+const RequestStore = Reflux.createStore({
+  listenables: RequestActions,
+
+  init: function() {
+    this._contents = "";
+  },
+
+  onQuery: function(data) {
+    this._contents = data
+    self.trigger({
+      contents: this._contents
+    });
+  },
+
+  get: function() {
+    return {
+      contents: this._contents
+    };
+  }
+});
+
+export { RequestStore };
+
+window.store = RequestStore;

--- a/dicoogle/src/main/resources/webapp/js/stores/requestStore.js
+++ b/dicoogle/src/main/resources/webapp/js/stores/requestStore.js
@@ -6,16 +6,19 @@ const RequestStore = Reflux.createStore({
   listenables: RequestActions,
 
   init: function() {
-    this._contents = "";
+    this._query = "";
+    this._provider = "";
   },
 
-  onQuery: function(data) {
-    this._contents = data
+  onQuery: function(query, provider) {
+    this._query = query
+    this._provider = provider
   },
 
   get: function() {
     return {
-      contents: this._contents
+      query: this._query,
+      provider: this._provider
     };
   }
 });

--- a/dicoogle/src/main/resources/webapp/js/stores/searchStore.js
+++ b/dicoogle/src/main/resources/webapp/js/stores/searchStore.js
@@ -6,6 +6,8 @@ import { getPatients } from "../handlers/requestHandler";
 import { unindex } from "../handlers/requestHandler";
 import { remove } from "../handlers/requestHandler";
 
+import { RequestActions } from "../actions/requestActions";
+
 const SearchStore = Reflux.createStore({
   listenables: ActionCreators,
   init: function() {
@@ -20,6 +22,9 @@ const SearchStore = Reflux.createStore({
 
   onSearch: function(data) {
     var self = this;
+
+    RequestActions.query(data.text)
+
     getPatients(
       data.text,
       undefined,

--- a/dicoogle/src/main/resources/webapp/js/stores/searchStore.js
+++ b/dicoogle/src/main/resources/webapp/js/stores/searchStore.js
@@ -23,7 +23,7 @@ const SearchStore = Reflux.createStore({
   onSearch: function(data) {
     var self = this;
 
-    RequestActions.query(data.text)
+    RequestActions.query(data.text, data.provider)
 
     getPatients(
       data.text,


### PR DESCRIPTION
This PR adds the submitted query and provider to the `result-selection-ready` event as a new `request` field.

This further enriched the data that `result-batch` web plugins have access to.