### PR TITLE
Fix Web UI Plugin Settings Files Not Handled Properly

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/webui/WebUIServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/webui/WebUIServlet.java
@@ -89,7 +89,11 @@ public class WebUIServlet extends HttpServlet {
         List<String> pkgList = new ArrayList<>(plugins.size());
         for (WebUIPlugin plugin : plugins) {
 
-            String pkg = PluginController.getInstance().getWebUIPackageJSON(plugin.getName());
+            JSONObject pkgObject =
+                    JSONObject.fromObject(PluginController.getInstance().getWebUIPackageJSON(plugin.getName()));
+            pkgObject.put("settings", plugin.getSettings());
+
+            String pkg = pkgObject.toString();
             if (pkg == null) {
                 logger.warn("Ignoring web plugin {}", plugin.getName());
                 continue;

--- a/webcore/src/dicoogle-webcore.js
+++ b/webcore/src/dicoogle-webcore.js
@@ -328,13 +328,14 @@ export const fetchModules = m.fetchModules;
     pluginInstance.Name = name;
     pluginInstance.SlotId = slotId;
     pluginInstance.Caption = thisPackage.dicoogle.caption || name;
+    pluginInstance.Settings = thisPackage.settings;
     plugins[name] = pluginInstance;
     if (slots[slotId]) {
       for (let slot of slots[slotId]) {
         slot.attachPlugin(pluginInstance);
       }
     }
-    const eventData = {name, slotId, caption: pluginInstance.Caption};
+    const eventData = {name, slotId, caption: pluginInstance.Caption, settings: pluginInstance.Settings};
     event_hub.emit('load', eventData);
   };
 export const onRegister = m.onRegister;


### PR DESCRIPTION
This PR fixes a broken feature of the web UI plugins' config files. Settings files are now properly loaded and provided to the respective web UI plugins. 

## Description
Configurations for a web UI plugin have always been properly handled, so long as the files 
 (which must be named `[WebUIPluginName].json`, see `package.json`'s `name` attribute) are stored in `Plugins/settings`. However, neither the Web UI servlet nor `dicoogle-webcore.js` do any effort to provide or handle the settings so that web UI plugins can access these.

This PR modifies the web UI servlet to include a new `settings` parameter, having the contents of the settings file, should it exist. Furthermore, the webcore was updated to include a new `Settings` field in registered plugins. This allows default webplugin classes to access this field by simply referring to their own attributes (i.e.: `this.Settings`) during the `render(...)` method.


