### PR TITLE
Typo fix in CSV export code & docs

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/DicoogleWeb.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/DicoogleWeb.java
@@ -220,7 +220,7 @@ public class DicoogleWeb {
                 createServletHandler(new WebUIServlet(), "/webui"), createWebUIModuleServletHandler(),
                 createServletHandler(new LoggerServlet(), "/logger"),
                 createServletHandler(new RunningTasksServlet(), "/index/task"),
-                createServletHandler(new ExportServlet(ExportType.EXPORT_CVS), "/export/cvs"),
+                createServletHandler(new ExportServlet(ExportType.EXPORT_CSV), "/export/csv"),
                 createServletHandler(new ExportServlet(ExportType.LIST), "/export/list"),
                 createServletHandler(new ServerStorageServlet(), "/management/settings/storage/dicom"), webpages};
 

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/search/ExportServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/search/ExportServlet.java
@@ -39,7 +39,7 @@ public class ExportServlet extends HttpServlet {
     private static final Logger logger = LoggerFactory.getLogger(ExportServlet.class);
 
     public enum ExportType {
-        LIST, EXPORT_CVS;
+        LIST, EXPORT_CSV;
     }
 
     private ExportType type;
@@ -54,8 +54,8 @@ public class ExportServlet extends HttpServlet {
             case LIST:
                 doGetTagList(req, resp);
                 break;
-            case EXPORT_CVS:
-                doGetExportCvs(req, resp);
+            case EXPORT_CSV:
+                doGetExportCsv(req, resp);
                 break;
         }
     }
@@ -79,7 +79,7 @@ public class ExportServlet extends HttpServlet {
         resp.getWriter().write(array.toString());
     }
 
-    private void doGetExportCvs(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    private void doGetExportCsv(HttpServletRequest req, HttpServletResponse resp) throws IOException {
         resp.setHeader("Content-disposition", "attachment; filename=QueryResultsExport.csv");
         String queryString = req.getParameter("query");
         String[] fields = req.getParameterValues("fields");

--- a/dicoogle_web_api.yaml
+++ b/dicoogle_web_api.yaml
@@ -906,7 +906,7 @@ paths:
           description: Successful operation
         "400":
           description: Invalid supplied parameters
-  /export/cvs:
+  /export/csv:
     get:
       tags:
         - Misc


### PR DESCRIPTION
This quick PR fixes a typo present in Dicoogle's REST API pertaining to CSV exporting:

* The endpoint `/export/cvs` was changed to `/export/csv`;
* Related methods/code were refactored;
* The API docs were updated accordingly. 