### PR TITLE
Fix application of task cleaning hook in RunningIndexTasks

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/taskManager/RunningIndexTasks.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/taskManager/RunningIndexTasks.java
@@ -74,7 +74,7 @@ public class RunningIndexTasks {
     }
 
     public void addTask(Task<Report> task) {
-        taskRunningList.put(task.getUid(), task);
+        this.addTask(task.getUid(), task);
     }
 
     public boolean removeTask(String taskUid) {


### PR DESCRIPTION
Pull request #441 was based on Dicoogle 2, but by the time we merged it in Dicoogle 3, we were already using another method overload for `addTask` which evaded our hook that cleans old tasks.

Should fix the situation reported in [this comment](https://github.com/bioinformatics-ua/dicoogle/issues/302#issuecomment-2058899263).