### PR TITLE
Add robustness to DIMGeneric against BodyPartThickness

### DIFF
--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/dim/DIMGeneric.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/dim/DIMGeneric.java
@@ -158,8 +158,7 @@ public class DIMGeneric {
          * Get data to Series
          */
         String serieUID = toTrimmedString(extra.get("SeriesInstanceUID"), false);
-        String BodyPartThickness = (String) extra.get("BodyPartThickness");
-        // System.out.println("serieUID"+serieUID);
+        String BodyPartThickness = toTrimmedString(extra.get("BodyPartThickness"), true);
         String serieNumber = toTrimmedString(extra.get("SeriesNumber"), true);
         String serieDescription = toTrimmedString(extra.get("SeriesDescription"), false);
         String modality = toTrimmedString(extra.get("Modality"), false);
@@ -192,8 +191,6 @@ public class DIMGeneric {
         /**
          * Get data to Image
          */
-        // TODO:Error checking here... but according to standard, all images
-        // must have one of these...
         String sopInstUID = toTrimmedString(extra.get("SOPInstanceUID"), true);
 
         if (sopInstUID == null) {


### PR DESCRIPTION
This fixes a situation found in the wild, where the matching of certain search results via C-FIND would lead to a server error.

### Summary

At `DIMGeneric#fillDim`, do not assume that `BodyPartThickness` is a string, because some index sources might save it as a double.
