### PR TITLE
[sdk] Undeprecate StorageInterface#handles

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/DefaultFileStoragePlugin.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/DefaultFileStoragePlugin.java
@@ -75,13 +75,6 @@ public class DefaultFileStoragePlugin extends PluginBase implements StorageInter
         return defaultScheme;
     }
 
-    @Override
-    public boolean handles(URI location) {
-        if (location.getScheme() == null)
-            return true;
-        return location.getScheme().equals(defaultScheme);
-    }
-
     private Iterator<StorageInputStream> createIterator(URI location) {
         if (!handles(location)) {
             logger.error("Cannot Handle: " + location.toString());
@@ -122,7 +115,7 @@ public class DefaultFileStoragePlugin extends PluginBase implements StorageInter
 
     @Override
     public void remove(URI location) {
-        if (!location.getScheme().equals(defaultScheme)) {
+        if (!handles(location)) {
             return;
         }
 
@@ -135,7 +128,7 @@ public class DefaultFileStoragePlugin extends PluginBase implements StorageInter
 
     @Override
     public Stream<URI> list(URI location) throws IOException {
-        if (!location.getScheme().equals(defaultScheme)) {
+        if (!handles(location)) {
             return Stream.empty();
         }
 

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/StorageInterface.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/StorageInterface.java
@@ -47,10 +47,12 @@ public interface StorageInterface extends DicooglePlugin {
     /**
      * Checks whether the file in the given path can be handled by this storage plugin.
      *
+     * The default implementation checks that the given location URI
+     * has the exact same scheme as the scheme returned by {@link #getScheme()}.
+     *
      * @param location a URI containing a scheme to be verified
      * @return true if this storage plugin is in charge of URIs in the given form 
      */
-    @Deprecated
     public default boolean handles(URI location) {
         return Objects.equals(this.getScheme(), location.getScheme());
     }


### PR DESCRIPTION
Resolves #692. Starting from either version 3.4.0 or 4.0.0, we will allow plugin developers to adjust how the URI is checked to know whether it can be handled by their plugins.

I am sending in the corresponding change in the learning pack soon.