### PR TITLE
Additional Methods for Index/Unindex Operations in Platform Interface

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/DicooglePlatformProxy.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/DicooglePlatformProxy.java
@@ -161,6 +161,12 @@ public class DicooglePlatformProxy implements DicooglePlatformInterface {
     }
 
     @Override
+    public List<Task<Report>> index(Collection<URI> paths) {
+        return pluginController.index(paths);
+    }
+
+
+    @Override
     public void unindex(URI path) {
         pluginController.unindex(path);
     }
@@ -176,6 +182,7 @@ public class DicooglePlatformProxy implements DicooglePlatformInterface {
     }
 
     @Override
+    @Deprecated
     public List<Report> indexBlocking(URI path) {
         return pluginController.indexBlocking(path);
     }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/DicooglePlatformProxy.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/DicooglePlatformProxy.java
@@ -21,6 +21,8 @@ package pt.ua.dicoogle.plugins;
 import java.net.URI;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Consumer;
+
 import pt.ua.dicoogle.core.settings.ServerSettingsManager;
 
 
@@ -31,6 +33,7 @@ import pt.ua.dicoogle.sdk.StorageInterface;
 import pt.ua.dicoogle.sdk.core.DicooglePlatformInterface;
 import pt.ua.dicoogle.sdk.datastructs.Report;
 import pt.ua.dicoogle.sdk.datastructs.SearchResult;
+import pt.ua.dicoogle.sdk.datastructs.UnindexReport;
 import pt.ua.dicoogle.sdk.datastructs.dim.DimLevel;
 import pt.ua.dicoogle.sdk.settings.server.ServerSettingsReader;
 import pt.ua.dicoogle.sdk.task.JointQueryTask;
@@ -155,6 +158,21 @@ public class DicooglePlatformProxy implements DicooglePlatformInterface {
     @Override
     public List<Task<Report>> index(URI path) {
         return pluginController.index(path);
+    }
+
+    @Override
+    public void unindex(URI path) {
+        pluginController.unindex(path);
+    }
+
+    @Override
+    public List<Task<UnindexReport>> unindex(Collection<URI> paths) {
+        return pluginController.unindex(paths, null);
+    }
+
+    @Override
+    public List<Task<UnindexReport>> unindex(Collection<URI> paths, Consumer<Collection<URI>> callbacks) {
+        return pluginController.unindex(paths, callbacks);
     }
 
     @Override

--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
@@ -733,13 +733,54 @@ public class PluginController {
         return rettasks;
     }
 
+    public List<Task<Report>> index(Collection<URI> paths) {
+        logger.info("Starting indexing procedure for {} items.", paths.size());
+
+        List<StorageInputStream> objectsToStore = new ArrayList<>();
+        ArrayList<Task<Report>> rettasks = new ArrayList<>();
+        Collection<IndexerInterface> indexers = getIndexingPlugins(true);
+
+        for (URI path : paths) {
+            StorageInterface store = getStorageForSchema(path);
+
+            if (store == null) {
+                logger.error("Could not get storage schema for {}", path);
+                continue;
+            }
+
+            store.at(path).forEach(objectsToStore::add);
+        }
+
+        for (IndexerInterface indexer : indexers) {
+            try {
+                Task<Report> task = indexer.index(objectsToStore);
+                if (task == null)
+                    continue;
+                final String taskUniqueID = UUID.randomUUID().toString();
+                task.setName(String.format("[%s]index %d items", indexer.getName(), objectsToStore.size()));
+                task.onCompletion(() -> {
+                    logger.info("Task [{}] complete on {} items", taskUniqueID, objectsToStore.size());
+                });
+
+                taskManager.dispatch(task);
+                rettasks.add(task);
+                RunningIndexTasks.getInstance().addTask(task);
+            } catch (RuntimeException ex) {
+                logger.warn("Indexer {} failed unexpectedly", indexer.getName(), ex);
+            }
+
+        }
+
+        return rettasks;
+    }
+
     public void unindex(URI path) {
         logger.info("Starting unindexing procedure for {}", path.toString());
         this.doUnindex(path, this.getIndexingPlugins(true));
     }
 
     /** Issue the removal of indexed entries in a path from the given indexers.
-     * 
+     *
      * @param path the URI of the directory or file to unindex
      * @param indexProviders a collection of providers
      */
@@ -759,7 +800,7 @@ public class PluginController {
 
     /** Issue the removal of indexed entries in bulk.
      *
-     * @param items a collections of item identifiers to unindex
+     * @param paths a collections of item identifiers to unindex
      * @param progressCallback an optional function (can be `null`),
      *        called for every batch of items successfully unindexed
      *        to indicate early progress
@@ -769,11 +810,10 @@ public class PluginController {
      *         a report containing which files were not unindexed,
      *         and whether some of them were not found in the database
      */
-    public List<Task<UnindexReport>> unindex(Collection<URI> items, Consumer<Collection<URI>> progressCallback) {
-
+    public List<Task<UnindexReport>> unindex(Collection<URI> paths, Consumer<Collection<URI>> progressCallback) {
         List<Task<UnindexReport>> tasks = new ArrayList<>();
         for (IndexerInterface indexer : this.getIndexingPlugins(true))
-            tasks.add(createUnindexTask(items, progressCallback, indexer));
+            tasks.add(createUnindexTask(paths, progressCallback, indexer));
 
         return tasks;
     }
@@ -781,7 +821,7 @@ public class PluginController {
     /** Issue the removal of indexed entries in bulk.
      *
      * @param indexProvider the name of the indexer
-     * @param items a collections of item identifiers to unindex
+     * @param paths a collections of item identifiers to unindex
      * @param progressCallback an optional function (can be `null`),
      *        called for every batch of items successfully unindexed
      *        to indicate early progress
@@ -791,7 +831,7 @@ public class PluginController {
      *         a report containing which files were not unindexed,
      *         and whether some of them were not found in the database
      */
-    public Task<UnindexReport> unindex(String indexProvider, Collection<URI> items,
+    public Task<UnindexReport> unindex(String indexProvider, Collection<URI> paths,
             Consumer<Collection<URI>> progressCallback) {
 
         IndexerInterface indexer = null;
@@ -801,11 +841,11 @@ public class PluginController {
         if (indexer == null) {
             indexer = this.getIndexingPlugins(true).iterator().next();
         }
-        return createUnindexTask(items, progressCallback, indexer);
+        return createUnindexTask(paths, progressCallback, indexer);
     }
 
     /** Issue an unindexing procedure to the given indexers.
-     * 
+     *
      * @param path the URI of the directory or file to unindex
      * @param indexers a collection of providers
      */
@@ -888,7 +928,7 @@ public class PluginController {
     // Methods for Web UI
 
     /** Retrieve all web UI plugin descriptors for the given slot id.
-     * 
+     *
      * @param ids the slot id's for the plugin ("query", "result", "menu", ...), empty or null for any slot
      * @return a collection of web UI plugins.
      */
@@ -911,7 +951,7 @@ public class PluginController {
     }
 
     /** Retrieve the web UI plugin descriptor of the plugin with the given name.
-     * 
+     *
      * @param name the unique name of the plugin
      * @return a web UI plugin descriptor object, or null if no such plugin exists or is inactive
      */
@@ -922,7 +962,7 @@ public class PluginController {
     }
 
     /** Retrieve the web UI plugin descriptor package.json.
-     * 
+     *
      * @param name the unique name of the plugin
      * @return the full contents of the package.json, null if the plugin is not available
      */
@@ -938,7 +978,7 @@ public class PluginController {
     }
 
     /** Retrieve the web UI plugin module code.
-     * 
+     *
      * @param name the unique name of the plugin
      * @return the full contents of the module file, null if the plugin is not available
      */

--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/PluginController.java
@@ -734,7 +734,7 @@ public class PluginController {
     }
 
     public List<Task<Report>> index(Collection<URI> paths) {
-        logger.info("Starting indexing procedure for {} items.", paths.size());
+        logger.info("Starting indexing procedure for {} items", paths.size());
 
         List<StorageInputStream> objectsToStore = new ArrayList<>();
         ArrayList<Task<Report>> rettasks = new ArrayList<>();

--- a/dicoogle/src/test/java/pt/ua/dicoogle/core/plugins/PlatformInterfaceMock.java
+++ b/dicoogle/src/test/java/pt/ua/dicoogle/core/plugins/PlatformInterfaceMock.java
@@ -123,6 +123,11 @@ public class PlatformInterfaceMock implements DicooglePlatformInterface {
     }
 
     @Override
+    public List<Task<Report>> index(Collection<URI> paths) {
+        return null;
+    }
+
+    @Override
     public void unindex(URI path) {}
 
     @Override

--- a/dicoogle/src/test/java/pt/ua/dicoogle/core/plugins/PlatformInterfaceMock.java
+++ b/dicoogle/src/test/java/pt/ua/dicoogle/core/plugins/PlatformInterfaceMock.java
@@ -25,6 +25,7 @@ import pt.ua.dicoogle.sdk.StorageInterface;
 import pt.ua.dicoogle.sdk.core.DicooglePlatformInterface;
 import pt.ua.dicoogle.sdk.datastructs.Report;
 import pt.ua.dicoogle.sdk.datastructs.SearchResult;
+import pt.ua.dicoogle.sdk.datastructs.UnindexReport;
 import pt.ua.dicoogle.sdk.datastructs.dim.DimLevel;
 import pt.ua.dicoogle.sdk.settings.server.ServerSettingsReader;
 import pt.ua.dicoogle.sdk.task.JointQueryTask;
@@ -33,6 +34,7 @@ import pt.ua.dicoogle.sdk.task.Task;
 import java.net.URI;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Consumer;
 
 public class PlatformInterfaceMock implements DicooglePlatformInterface {
 
@@ -117,6 +119,19 @@ public class PlatformInterfaceMock implements DicooglePlatformInterface {
 
     @Override
     public List<Task<Report>> index(URI path) {
+        return null;
+    }
+
+    @Override
+    public void unindex(URI path) {}
+
+    @Override
+    public List<Task<UnindexReport>> unindex(Collection<URI> paths) {
+        return null;
+    }
+
+    @Override
+    public List<Task<UnindexReport>> unindex(Collection<URI> paths, Consumer<Collection<URI>> progressCallback) {
         return null;
     }
 

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/IndexerInterface.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/IndexerInterface.java
@@ -111,7 +111,7 @@ public interface IndexerInterface extends DicooglePlugin {
      * one or more individual operations in batch,
      * thus becoming faster than unindexing each item individually.
      * 
-     * Like {@linkplain index},
+     * Like {@linkplain #index(Iterable, Object...)},
      * this operation is asynchronous.
      * One can keep track of the unindexing task's progress
      * by passing a callback function as the second parameter.

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/core/DicooglePlatformInterface.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/core/DicooglePlatformInterface.java
@@ -207,6 +207,15 @@ public interface DicooglePlatformInterface {
      */
     List<Task<Report>> index(URI path);
 
+
+    /** Easily performs indexation procedures over all active indexers. This operation is asynchronous
+     * and returns immediately.
+     *
+     * @param paths the paths to index
+     * @return a list of asynchronous tasks, one for each provider
+     */
+    List<Task<Report>> index(Collection<URI> paths);
+
     /** Easily performs an unindex procedure over all active indexers. This operation is synchronous.
      *
      * @param path the path to index
@@ -237,6 +246,7 @@ public interface DicooglePlatformInterface {
      * @param path the path to index
      * @return a list of reports, one for each provider
      */
+    @Deprecated
     List<Report> indexBlocking(URI path);
 
     /** Obtain access to the server's settings.

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/core/DicooglePlatformInterface.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/core/DicooglePlatformInterface.java
@@ -21,6 +21,7 @@ package pt.ua.dicoogle.sdk.core;
 import java.net.URI;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Consumer;
 
 import pt.ua.dicoogle.sdk.IndexerInterface;
 import pt.ua.dicoogle.sdk.QueryInterface;
@@ -28,6 +29,7 @@ import pt.ua.dicoogle.sdk.StorageInputStream;
 import pt.ua.dicoogle.sdk.StorageInterface;
 import pt.ua.dicoogle.sdk.datastructs.Report;
 import pt.ua.dicoogle.sdk.datastructs.SearchResult;
+import pt.ua.dicoogle.sdk.datastructs.UnindexReport;
 import pt.ua.dicoogle.sdk.datastructs.dim.DimLevel;
 import pt.ua.dicoogle.sdk.settings.server.ServerSettingsReader;
 import pt.ua.dicoogle.sdk.task.JointQueryTask;
@@ -53,26 +55,26 @@ public interface DicooglePlatformInterface {
      * @param name the name of the plugin 
      * @return the plugin that implements this interface
      */
-    public IndexerInterface requestIndexPlugin(String name);
+    IndexerInterface requestIndexPlugin(String name);
 
     /**
      * Gets an installed query plugin by name.
      * @param name the name of the plugin 
      * @return the plugin that implements this interface
      */
-    public QueryInterface requestQueryPlugin(String name);
+    QueryInterface requestQueryPlugin(String name);
 
     /**
      * Obtains a collection of all active index plugins.
      * @return an unmodifiable collection of active instances of {@link IndexerInterface}
      */
-    public Collection<IndexerInterface> getAllIndexPlugins();
+    Collection<IndexerInterface> getAllIndexPlugins();
 
     /**
      * Obtains a collection of all active query plugins.
      * @return an unmodifiable collection of active instances of {@link QueryInterface}
      */
-    public Collection<QueryInterface> getAllQueryPlugins();
+    Collection<QueryInterface> getAllQueryPlugins();
 
     /** Obtains the storage interface for handling storage of the given scheme.
      * 
@@ -80,7 +82,7 @@ public interface DicooglePlatformInterface {
      * @return the storage interface capable of handling that content, or {@code null} if no storage plugin
      * installed can.
      */
-    public StorageInterface getStoragePluginForSchema(String scheme);
+    StorageInterface getStoragePluginForSchema(String scheme);
 
     /** Obtains the storage interface for handling content in the given location.
      * 
@@ -88,7 +90,7 @@ public interface DicooglePlatformInterface {
      * @return the storage interface capable of handling that content, or {@code null} if no storage plugin
      * installed can
      */
-    public StorageInterface getStorageForSchema(URI location);
+    StorageInterface getStorageForSchema(URI location);
 
     /** Quickly obtains all storage elements at the given location.
      * 
@@ -96,14 +98,14 @@ public interface DicooglePlatformInterface {
      * @param args a variable list of extra parameters for the retrieve
      * @return an iterable of storage input streams
      */
-    public Iterable<StorageInputStream> resolveURI(URI location, Object... args);
+    Iterable<StorageInputStream> resolveURI(URI location, Object... args);
 
     /** Obtains all installed storage plugins.
      * 
      * @param onlyEnabled whether only enabled plugins should be retrieved (all are retrieved if {@code false})
      * @return a collection of storage plugin interfaces
      */
-    public Collection<StorageInterface> getStoragePlugins(boolean onlyEnabled);
+    Collection<StorageInterface> getStoragePlugins(boolean onlyEnabled);
 
     /** Obtains the storage interface for handling storage of the given scheme.
      * Same as {@link #getStoragePluginForSchema(java.lang.String)}.
@@ -112,21 +114,21 @@ public interface DicooglePlatformInterface {
      * @return the storage interface capable of handling that content, or {@code null} if no storage plugin
      * installed can
      */
-    public StorageInterface getStorageForSchema(String scheme);
+    StorageInterface getStorageForSchema(String scheme);
 
     /** Obtains all installed query plugins.
      * 
      * @param onlyEnabled whether only enabled plugins should be retrieved (all are retrieved if {@code false})
      * @return a collection of query plugin interfaces
      */
-    public Collection<QueryInterface> getQueryPlugins(boolean onlyEnabled);
+    Collection<QueryInterface> getQueryPlugins(boolean onlyEnabled);
 
     /** Gets the names of all query providers.
      * 
      * @param enabled whether only enabled plugins should be retrieved (all are retrieved if {@code false})
      * @return a collection of unique query provider names
      */
-    public List<String> getQueryProvidersName(boolean enabled);
+    List<String> getQueryProvidersName(boolean enabled);
 
     /** Gets the query provider with the given name.
      * 
@@ -134,7 +136,7 @@ public interface DicooglePlatformInterface {
      * @param onlyEnabled whether only enabled plugins should be retrieved (all are retrieved if {@code false})
      * @return a collection of unique query provider names
      */
-    public QueryInterface getQueryProviderByName(String name, boolean onlyEnabled);
+    QueryInterface getQueryProviderByName(String name, boolean onlyEnabled);
 
     /**
      * Easily performs a query over all query providers. This operation is asynchronous and returns immediately.
@@ -143,7 +145,7 @@ public interface DicooglePlatformInterface {
      * @param parameters a variable list of extra parameters for the query
      * @return a join query task
      */
-    public JointQueryTask queryAll(JointQueryTask holder, String query, Object... parameters);
+    JointQueryTask queryAll(JointQueryTask holder, String query, Object... parameters);
 
     /**
      * Easily performs a query over all query providers. This operation is asynchronous and returns immediately.
@@ -153,7 +155,7 @@ public interface DicooglePlatformInterface {
      * @param parameters a variable list of extra parameters for the query
      * @return a join query task
      */
-    public JointQueryTask queryAll(JointQueryTask holder, String query, DimLevel level, Object... parameters);
+    JointQueryTask queryAll(JointQueryTask holder, String query, DimLevel level, Object... parameters);
 
     /** Easily performs a query over a specific provider. This operation is asynchronous and returns immediately.
      * 
@@ -162,7 +164,7 @@ public interface DicooglePlatformInterface {
      * @param parameters a variable list of extra parameters for the query
      * @return an asynchronous task containing the results
      */
-    public Task<Iterable<SearchResult>> query(String querySource, String query, Object... parameters);
+    Task<Iterable<SearchResult>> query(String querySource, String query, Object... parameters);
 
     /** Easily performs a query over a specific provider. This operation is asynchronous and returns immediately.
      *
@@ -172,7 +174,7 @@ public interface DicooglePlatformInterface {
      * @param parameters a variable list of extra parameters for the query
      * @return an asynchronous task containing the results
      */
-    public Task<Iterable<SearchResult>> query(String querySource, DimLevel level, String query, Object... parameters);
+    Task<Iterable<SearchResult>> query(String querySource, DimLevel level, String query, Object... parameters);
 
     /** Easily performs a query over multiple providers. This operation is asynchronous and returns immediately.
      * 
@@ -182,7 +184,7 @@ public interface DicooglePlatformInterface {
      * @param parameters a variable list of extra parameters for the query
      * @return an asynchronous task containing the results
      */
-    public JointQueryTask query(JointQueryTask holder, List<String> querySources, String query, Object... parameters);
+    JointQueryTask query(JointQueryTask holder, List<String> querySources, String query, Object... parameters);
 
     /** Easily performs a query over multiple providers. This operation is asynchronous and returns immediately.
      *
@@ -193,17 +195,41 @@ public interface DicooglePlatformInterface {
      * @param parameters a variable list of extra parameters for the query
      * @return an asynchronous task containing the results
      */
-    public JointQueryTask query(JointQueryTask holder, List<String> querySources, DimLevel level, String query,
+    JointQueryTask query(JointQueryTask holder, List<String> querySources, DimLevel level, String query,
             Object... parameters);
 
 
     /** Easily performs an indexation procedure over all active indexers. This operation is asynchronous
      * and returns immediately.
-     * 
+     *
      * @param path the path to index
      * @return a list of asynchronous tasks, one for each provider
      */
-    public List<Task<Report>> index(URI path);
+    List<Task<Report>> index(URI path);
+
+    /** Easily performs an unindex procedure over all active indexers. This operation is synchronous.
+     *
+     * @param path the path to index
+     */
+    void unindex(URI path);
+
+
+    /** Easily performs an unindex procedure for several paths over all active indexers. This operation is asynchronous
+     * and returns immediately.
+     *
+     * @param paths the path to index
+     * @return a list of asynchronous tasks from each provider
+     */
+    List<Task<UnindexReport>> unindex(Collection<URI> paths);
+
+    /** Easily performs an unindex procedure for several paths over all active indexers. This operation is asynchronous
+     * and returns immediately.
+     *
+     * @param paths the path to index
+     * @return a list of asynchronous tasks from each provider
+     */
+    List<Task<UnindexReport>> unindex(Collection<URI> paths, Consumer<Collection<URI>> progressCallback);
+
 
     /** Easily performs an indexation procedure over all active indexers. This operation is synchronous
      * and will wait until all providers have finished indexing.
@@ -211,10 +237,10 @@ public interface DicooglePlatformInterface {
      * @param path the path to index
      * @return a list of reports, one for each provider
      */
-    public List<Report> indexBlocking(URI path);
+    List<Report> indexBlocking(URI path);
 
     /** Obtain access to the server's settings.
      * @return an object for read-only access to the settings
      */
-    public ServerSettingsReader getSettings();
+    ServerSettingsReader getSettings();
 }

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/core/DicooglePlatformInterface.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/core/DicooglePlatformInterface.java
@@ -208,7 +208,7 @@ public interface DicooglePlatformInterface {
     List<Task<Report>> index(URI path);
 
 
-    /** Easily performs indexation procedures over all active indexers. This operation is asynchronous
+    /** Easily performs indexing procedures over all active indexers. This operation is asynchronous
      * and returns immediately.
      *
      * @param paths the paths to index
@@ -245,6 +245,7 @@ public interface DicooglePlatformInterface {
      * 
      * @param path the path to index
      * @return a list of reports, one for each provider
+     * @deprecated Call {@linkplain #index} and get the result instead
      */
     @Deprecated
     List<Report> indexBlocking(URI path);


### PR DESCRIPTION
Implemented 1 index method for >1 URIs and several unindex methods for the platform interface.

We can now use the platform interface to dispatch unindex tasks for singular URIs or batches, which is performed and handled by `PluginController`. The new index method allows dispatching tasks for batches of URIs.

A minor code refactoring was performed in a few files, and `indexBlocking` was marked as deprecated, as requested by @Enet4 