### PR TITLE
Optimize task management page

### DIFF
--- a/dicoogle/src/main/resources/webapp/js/components/indexer/TaskStatus.jsx
+++ b/dicoogle/src/main/resources/webapp/js/components/indexer/TaskStatus.jsx
@@ -56,7 +56,7 @@ class TaskStatus extends React.Component {
     }
 
     return (
-      <div key={item.taskUid} className="well well-sm">
+      <div key={item.taskUid} className="well well-sm task-status">
         <div className="row">
           <div className="col-sm-10">
             <div className="progress indexstatusprogress">
@@ -77,34 +77,34 @@ class TaskStatus extends React.Component {
             </button>
           </div>
         </div>
-        <div>
-          <p>
+        <ul>
+          <li>
             <b>Uid: </b> {item.taskUid}
-          </p>
-          <p>
+          </li>
+          <li>
             <b>Name: </b> {item.taskName}
-          </p>
-          <p>
+          </li>
+          <li>
             <b>Time created: </b> {dateTimeToHumanReadable(timeCreated)}
-          </p>
-          <div style={{ visibility: item.complete ? "" : "hidden" }}>
+          </li>
+          <li className="task-status-complete" style={{ visibility: item.complete ? "" : "hidden" }}>
             {typeof item.elapsedTime === "number" && (
-              <p>
+              <span>
                 <b>Elapsed Time: </b> {toHumanReadable(item.elapsedTime)}
-              </p>
+              </span>
             )}
             {typeof item.nIndexed === "number" && (
-              <p>
-                <b>Indexed: </b> {item.nIndexed}{" "}
-              </p>
+              <span>
+                <b>Indexed: </b> {item.nIndexed}
+              </span>
             )}
             {typeof item.nErrors === "number" && (
-              <p>
-                <b>Errors: </b> {item.nErrors}{" "}
-              </p>
+              <span>
+                <b>Errors: </b> {item.nErrors}
+              </span>
             )}
-          </div>
-        </div>
+          </li>
+        </ul>
       </div>
     );
   }

--- a/dicoogle/src/main/resources/webapp/sass/modules/_management.scss
+++ b/dicoogle/src/main/resources/webapp/sass/modules/_management.scss
@@ -40,6 +40,20 @@
   background: $main_color;
 }
 
+.task-status {
+  ul,li {
+    list-style-type: none;
+    padding-left: 0;
+    margin-bottom: 0.4em;
+  }
+}
+
+.task-status-complete {
+  display: flex;
+  flex-direction: row;
+  gap: 3em;
+}
+
 .list-group-item-management {
   border-color: $hover_color;
   border-right-color: white;


### PR DESCRIPTION
### Summary

- Restrain task status view to showing the 200 most recent tasks, so that the page can still open fine on long-running Dicoogle instances without saturating the browser.
- Show how many tasks are presented and the number of tasks not shown in the header above the task list.
- Update task status style so that each task is more compact.

See screenshot.

![Screenshot 2024-10-24 095303](https://github.com/user-attachments/assets/98e263dd-4d79-438b-a216-3fe94068f8b7)
