### PR TITLE
Make ControlServices comply with autostart server settings

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/management/ServicesServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/management/ServicesServlet.java
@@ -160,32 +160,45 @@ public class ServicesServlet extends HttpServlet {
 
         // update running
         if (updateRunning) {
-            switch (mType) {
-                case STORAGE:
-                    if (running) {
-                        controlServices.startStorage();
-                        obj.element("running", true);
-                    } else {
-                        controlServices.stopStorage();
-                        obj.element("running", false);
-                    }
-                    break;
+            try {
+                switch (mType) {
+                    case STORAGE:
+                        if (running) {
+                            boolean out = controlServices.startStorage();
+                            if (!out) {
+                                resp.addHeader("Warning", "Service was already running");
+                                obj.element("warning", "Service was already running");
+                            }
+                            obj.element("running", true);
+                        } else {
+                            controlServices.stopStorage();
+                            obj.element("running", false);
+                        }
+                        break;
 
-                case QUERY:
-                    if (running) {
-                        controlServices.startQueryRetrieve();
-                        obj.element("running", true);
+                    case QUERY:
+                        if (running) {
+                            controlServices.startQueryRetrieve();
+                            obj.element("running", true);
 
-                    } else {
-                        controlServices.stopQueryRetrieve();
-                        obj.element("running", false);
-                    }
-                    break;
+                        } else {
+                            controlServices.stopQueryRetrieve();
+                            obj.element("running", false);
+                        }
+                        break;
 
-                default:
-                    break;
+                    default:
+                        break;
+                }
+            } catch (Exception ex) {
+                obj.element("success", false);
+                obj.element("error", ex.getMessage());
+                reply(resp, 500, obj);
+                return;
             }
         }
+
+        // finalize
         ServerSettingsManager.saveSettings();
         obj.element("success", true);
         reply(resp, 200, obj);


### PR DESCRIPTION
- do not start the service(s) if their respective autostart setting is set to false, a regression probably existing since Dicoogle 3.0.0
- remove unused variable `webServicesRunning` in `ControlServices`
- remove use of raw types in `startStorage()`
- remove outdated TODO note
- refactor `ControlServices#startStorage()` to return whether the service started (`true`) or was already running (`false`) and raise an exception on error
- adjust `ServicesServlet` according to changes to `ControlServices`, and for the output to be more precise and informative
