### PR TITLE
Add data store failure detection in DICOM storage service

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/DicomStorage.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/DicomStorage.java
@@ -278,13 +278,30 @@ public class DicomStorage extends StorageService {
 
             Iterable<StorageInterface> plugins = PluginController.getInstance().getStoragePlugins(true);
 
+            int success = 0;
+            int failures = 0;
             for (StorageInterface storage : plugins) {
-                URI uri = storage.store(d);
-                if (uri != null) {
-                    // enqueue to index
-                    ImageElement element = new ImageElement(uri, as.getCallingAET(), seqNum.getAndIncrement());
-                    IndexQueueWorker.getInstance().addElement(element);
+                try {
+                    URI uri = storage.store(d);
+                    if (uri != null) {
+                        // enqueue to index
+                        ImageElement element = new ImageElement(uri, as.getCallingAET(), seqNum.getAndIncrement());
+                        IndexQueueWorker.getInstance().addElement(element);
+                        success += 1;
+                    } else {
+                        LOG.error("Failed to store DICOM object {} onto {}: null URI", iuid, storage.getName());
+                        failures += 1;
+                    }
+                } catch (IOException ex) {
+                    LOG.error("Failed to store DICOM object {} onto {}", iuid, storage.getName(), ex);
+                    failures += 1;
                 }
+            }
+
+            if (success == 0 && failures == 0) {
+                throw new DicomServiceException(rq, Status.ProcessingFailure, "No storage provider available");
+            } else if (success == 0) {
+                throw new DicomServiceException(rq, Status.ProcessingFailure, "Failed to store DICOM object");
             }
 
         } catch (Exception e) {

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/StorageInterface.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/StorageInterface.java
@@ -121,7 +121,7 @@ public interface StorageInterface extends DicooglePlugin {
      * @param parameters a variable list of extra parameters for the retrieve
      * @return The URI of the previously stored Object.
      */
-    public URI store(DicomObject dicomObject, Object... parameters);
+    public URI store(DicomObject dicomObject, Object... parameters) throws IOException;
 
     /**
      * Stores a new element into the storage.

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/StorageInterface.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/StorageInterface.java
@@ -117,29 +117,30 @@ public interface StorageInterface extends DicooglePlugin {
     /**
      * Stores a DICOM object into the storage.
      *
-     * @param dicomObject Object to be Stored
+     * @param dicomObject DICOM object to be stored
      * @param parameters a variable list of extra parameters for the retrieve
-     * @return The URI of the previously stored Object.
+     * @return The URI of the object just stored
+     * @throws IOException if an I/O error occurs during the store operation
      */
     public URI store(DicomObject dicomObject, Object... parameters) throws IOException;
 
     /**
-     * Stores a new element into the storage.
+     * Stores a new item into the storage.
      *
      * @param inputStream an input stream with the contents to be stored
      * @param parameters a variable list of extra parameters for the retrieve
-     * @return the URI of the stored data
-     * @throws IOException if an I/O error occurs
+     * @return The URI of the DICOM data just stored
+     * @throws IOException if an I/O error occurs while fetching or storing DICOM data
      */
     public URI store(DicomInputStream inputStream, Object... parameters) throws IOException;
 
-    /** Removes an element at the given URI.
+    /** Removes an item at the given URI.
      * 
      * @param location the URI of the stored data
      */
     public void remove(URI location);
 
-    /** Lists the elements at the given location in the storage's file tree.
+    /** Lists the items at the given location in the storage's file tree.
      * Unlike {@link StorageInterface#at}, this method is not recursive and
      * can yield intermediate URIs representing other directories rather than
      * objects.


### PR DESCRIPTION
Should resolve #721.

Caveats:
- it's an SDK breaking change
- reports success whenever at least one storage provider succeeds, meaning that others could have failed when there is more than one. The scenario of having multiple storage providers at once is not that well supported anyway.

### Summary

- [sdk] Change signature of `StorageInterface#store(DicomObject,Object...)` so it `throws IOException`
- [sdk] Adjust documentation of `StorageInterface` a bit
- Detect data storage failure in `DicomStorage`
