### PR TITLE
Provide baseline access control to web services

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/core/settings/LegacyServerSettings.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/core/settings/LegacyServerSettings.java
@@ -430,6 +430,16 @@ public class LegacyServerSettings implements ServerSettings {
             this.accessControlAllowOrigins = origins;
         }
 
+        @Override
+        public void setAllowUnauthorized(boolean allowUnauthorized) {
+            // no-op, not supported by legacy settings
+        }
+
+        @Override
+        public boolean isAllowUnauthorized() {
+            return true;
+        }
+
         @Deprecated
         public void setWebServices(boolean webServices) {
             this.webServices = webServices;

--- a/dicoogle/src/main/java/pt/ua/dicoogle/core/settings/part/WebServerImpl.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/core/settings/part/WebServerImpl.java
@@ -53,6 +53,9 @@ public class WebServerImpl implements ServerSettings.WebServer {
     @JsonProperty("allowed-origins")
     private String allowedOrigins;
 
+    @JsonProperty("allow-unauthorized")
+    private boolean allowUnauthorized = false;
+
     @Override
     public boolean isAutostart() {
         return autostart;
@@ -91,6 +94,16 @@ public class WebServerImpl implements ServerSettings.WebServer {
     @Override
     public String getAllowedOrigins() {
         return this.allowedOrigins;
+    }
+
+    @Override
+    public boolean isAllowUnauthorized() {
+        return allowUnauthorized;
+    }
+
+    @Override
+    public void setAllowUnauthorized(boolean allowUnauthorized) {
+        this.allowUnauthorized = allowUnauthorized;
     }
 
     @Override

--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/DicooglePlatformProxy.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/DicooglePlatformProxy.java
@@ -23,6 +23,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
 
+import org.eclipse.jetty.server.Request;
+
 import pt.ua.dicoogle.core.settings.ServerSettingsManager;
 
 
@@ -31,6 +33,7 @@ import pt.ua.dicoogle.sdk.QueryInterface;
 import pt.ua.dicoogle.sdk.StorageInputStream;
 import pt.ua.dicoogle.sdk.StorageInterface;
 import pt.ua.dicoogle.sdk.core.DicooglePlatformInterface;
+import pt.ua.dicoogle.sdk.datastructs.DicoogleUser;
 import pt.ua.dicoogle.sdk.datastructs.Report;
 import pt.ua.dicoogle.sdk.datastructs.SearchResult;
 import pt.ua.dicoogle.sdk.datastructs.UnindexReport;
@@ -38,6 +41,8 @@ import pt.ua.dicoogle.sdk.datastructs.dim.DimLevel;
 import pt.ua.dicoogle.sdk.settings.server.ServerSettingsReader;
 import pt.ua.dicoogle.sdk.task.JointQueryTask;
 import pt.ua.dicoogle.sdk.task.Task;
+import pt.ua.dicoogle.server.users.User;
+import pt.ua.dicoogle.server.web.auth.Authentication;
 
 /**
  * A proxy to the implementations of Plugin Controller.
@@ -192,4 +197,23 @@ public class DicooglePlatformProxy implements DicooglePlatformInterface {
         return ServerSettingsManager.getSettings();
     }
 
+    @Override
+    public DicoogleUser getUser(String token) {
+        User user = Authentication.getInstance().getUsername(token);
+        if (user == null) {
+            return null;
+        }
+
+        return user.toDicoogleUser();
+    }
+
+    @Override
+    public DicoogleUser getUser(Request request) {
+        User user = Authentication.getInstance().getAuthenticatedUser(request);
+        if (user == null) {
+            return null;
+        }
+        
+        return user.toDicoogleUser();
+    }
 }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/users/User.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/users/User.java
@@ -23,6 +23,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import pt.ua.dicoogle.sdk.datastructs.DicoogleUser;
+
 /**
  * Class that saves information about one user
  *
@@ -167,5 +169,16 @@ public class User implements UserRoleManager {
 
     public List<Role> getRoles() {
         return roles;
+    }
+
+    /** Create a simple user record for sharing through the SDK */
+    public DicoogleUser toDicoogleUser() {
+        return new DicoogleUser(
+            this.username,
+            this.admin,
+            this.roles.stream()
+                .map(Role::getName)
+                .collect(java.util.stream.Collectors.toSet())
+        );
     }
 }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/AuthenticatedFilter.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/AuthenticatedFilter.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (C) 2014  Universidade de Aveiro, DETI/IEETA, Bioinformatics Group - http://bioinformatics.ua.pt/
+ *
+ * This file is part of Dicoogle/dicoogle.
+ *
+ * Dicoogle/dicoogle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Dicoogle/dicoogle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Dicoogle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ */
+
+package pt.ua.dicoogle.server.web;
+
+import java.io.IOException;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import pt.ua.dicoogle.server.users.Role;
+import pt.ua.dicoogle.server.users.User;
+import pt.ua.dicoogle.server.web.auth.Authentication;
+
+/** Servlet filter to ensure that the user is logged in
+ * (has a valid session token in `Authorization`).
+ */
+public class AuthenticatedFilter implements Filter {
+
+    public static final String NEEDS_ADMIN_PARAM = "needsAdmin";
+    public static final String NEEDS_ROLE_PARAM = "needsRole";
+
+    /** Whether the user needs to be an admin */
+    private boolean needsAdmin = false;
+    /** Whether the user needs to have this specific role (or be admin) */
+    private Role needsRole = null;
+
+    @Override
+    public void init(FilterConfig fc) throws ServletException {
+        try {
+            String needsAdminStr = fc.getInitParameter(NEEDS_ADMIN_PARAM);
+            if (needsAdminStr != null && !needsAdminStr.isEmpty()) {
+                needsAdmin = Boolean.parseBoolean(needsAdminStr);
+            }
+        } catch (IllegalArgumentException ex) {
+            throw new ServletException("Invalid needsAdmin value for AuthenticatedFilter", ex);
+        }
+
+        try {
+            String needsRoleStr = fc.getInitParameter(NEEDS_ROLE_PARAM);
+            if (needsRoleStr != null && !needsRoleStr.isEmpty()) {
+                needsRole = new Role(needsRoleStr);
+            }
+        } catch (IllegalArgumentException ex) {
+            throw new ServletException("Invalid role for AuthenticatedFilter", ex);
+        }
+    }
+
+    @Override
+    public void doFilter(ServletRequest sreq, ServletResponse sresp, FilterChain fc)
+            throws IOException, ServletException {
+
+        if (sreq instanceof HttpServletRequest) {
+            HttpServletRequest req = (HttpServletRequest) sreq;
+            String token = req.getHeader("Authorization");
+
+            // Authorization header must have a Dicoogle session token
+            if (token == null) {
+                unauthorized(sresp);
+                return;
+            }
+
+            // user has to exist
+            User user = Authentication.getInstance().getUsername(token);
+            if (user == null) {
+                forbidden(sresp);
+                return;
+            }
+
+            // user must be admin if required by this endpoint
+            if (needsAdmin && !user.isAdmin()) {
+                forbidden(sresp);
+                return;
+            }
+
+            // if a role is required by this endpoint,
+            // the user must either have that role or be admin
+            if (!user.isAdmin() && needsRole != null && !user.hasRole(needsRole)) {
+                forbidden(sresp);
+                return;
+            }
+
+            // OK
+        }
+        fc.doFilter(sreq, sresp);
+    }
+
+    private static void unauthorized(ServletResponse resp) throws IOException {
+        if (resp instanceof HttpServletResponse) {
+            HttpServletResponse httpResp = (HttpServletResponse) resp;
+            httpResp.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+        }
+    }
+
+    private static void forbidden(ServletResponse resp) throws IOException {
+        if (resp instanceof HttpServletResponse) {
+            HttpServletResponse httpResp = (HttpServletResponse) resp;
+            httpResp.sendError(HttpServletResponse.SC_FORBIDDEN);
+        }
+    }
+
+    @Override
+    public void destroy() {}
+
+}

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/DicoogleWeb.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/DicoogleWeb.java
@@ -293,8 +293,12 @@ public class DicoogleWeb {
         HttpServlet servletModule = new WebUIModuleServlet();
         // CORS support
         this.addCORSFilter(handler);
+
         // require being logged in
-        this.addAuthFilter(handler, false, null);
+        if (this.authorizationEnabled) {
+            this.addAuthFilter(handler, false, null);
+        }
+
         // Caching!
         FilterHolder cacheHolder = new FilterHolder(new AbstractCacheFilter() {
             @Override

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/DicoogleWeb.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/DicoogleWeb.java
@@ -29,7 +29,6 @@ import pt.ua.dicoogle.server.web.servlets.management.*;
 import pt.ua.dicoogle.server.web.servlets.search.*;
 import pt.ua.dicoogle.server.web.servlets.search.ExportServlet.ExportType;
 import pt.ua.dicoogle.server.web.servlets.search.SearchServlet.SearchType;
-import pt.ua.dicoogle.server.web.servlets.WelcomeServlet;
 import pt.ua.dicoogle.server.web.servlets.accounts.LoginServlet;
 import pt.ua.dicoogle.server.web.servlets.accounts.UserServlet;
 
@@ -110,6 +109,10 @@ public class DicoogleWeb {
     public static final String CONTEXTPATH = "/";
     private LocalImageCache cache = null;
     private Server server = null;
+    /** Whether access to services is protected with authorization:
+     * There has to be a valid Dicoogle session token in the `Authorization` header.
+     */
+    private boolean authorizationEnabled = true;
 
     private final ContextHandlerCollection contextHandlers;
     private ServletContextHandler pluginHandler = null;
@@ -127,110 +130,116 @@ public class DicoogleWeb {
         // System.setProperty("org.mortbay.jetty.webapp.parentLoaderPriority", "true");
         // System.setProperty("production.mode", "true");
 
+        // initialize the authorization flag
+        this.authorizationEnabled = !ServerSettingsManager.getSettings().getWebServerSettings().isAllowUnauthorized();
+
         // "build" the input location, based on the www directory/.war chosen
         final URL warUrl = Thread.currentThread().getContextClassLoader().getResource(WEBAPPDIR);
         final String warUrlString = warUrl.toExternalForm();
 
-        // setup the DICOM to PNG image servlet, with a local cache
-        cache = new LocalImageCache("dic2png", 300, 900, new SimpleImageRetriever()); // pooling rate of 12/hr and max un-used cache age of 15 minutes
-        final ServletContextHandler dic2png = createServletHandler(new ImageServlet(cache), "/dic2png");
+        // setup the DICOM to PNG image servlet, with a local cache.
+        // pooling rate of 12/hr and max un-used cache age of 15 minutes
+        cache = new LocalImageCache("dic2png", 300, 900, new SimpleImageRetriever());
+        final ServletContextHandler dic2png = createServletHandler(new ImageServlet(cache), "/dic2png",
+                Needs.authenticated());
         cache.start(); // start the caching system
 
         // setup the ROI extractor
-        final ServletContextHandler roiExtractor = createServletHandler(new ROIServlet(), "/roi");
+        final ServletContextHandler roiExtractor = createServletHandler(new ROIServlet(), "/roi",
+                Needs.authenticated());
 
         // setup the DICOM to PNG image servlet
-        final ServletContextHandler dictags = createServletHandler(new TagsServlet(), "/dictags");
+        final ServletContextHandler dictags = createServletHandler(new TagsServlet(), "/dictags",
+                Needs.authenticated());
 
         // setup the Export to CSV Servlet
-        final ServletContextHandler csvServletHolder = createServletHandler(new ExportToCSVServlet(), "/export");
+        final ServletContextHandler csvServletHolder = createServletHandler(new ExportToCSVServlet(), "/export",
+                Needs.authenticated());
         File tempDir = Paths.get(System.getProperty("java.io.tmpdir")).toFile();
         csvServletHolder.addServlet(new ServletHolder(new ExportCSVToFILEServlet(tempDir)), "/exportFile");
 
-        // setup the search (DIMSE-service-user C-FIND ?!?) servlet
-        // final ServletContextHandler search = new ServletContextHandler(ServletContextHandler.SESSIONS); // servlet with session support enabled
-        // search.setContextPath(CONTEXTPATH);
-        // search.addServlet(new ServletHolder(new SearchServlet()), "/search");
-
-        /*hooks = getRegisteredHookActions();
-         plugin.addServlet(new ServletHolder(new PluginsServlet(hooks)), "/plugin/*");
-         */
-
         // setup the web pages/scripts app
         final WebAppContext webpages = new WebAppContext(warUrlString, CONTEXTPATH);
-        webpages.setInitParameter("org.eclipse.jetty.servlet.Default.dirAllowed", "false"); // disables directory listing
+        // disables directory listing
+        webpages.setInitParameter("org.eclipse.jetty.servlet.Default.dirAllowed", "false");
         webpages.setInitParameter("useFileMappedBuffer", "false");
         webpages.setInitParameter("cacheControl", "public, max-age=2592000"); // cache for 30 days
         webpages.setInitParameter("etags", "true"); // generate and handle weak entity validation tags
         webpages.setDisplayName("webapp");
-        webpages.setWelcomeFiles(new String[] {"index.html"});
+        webpages.setWelcomeFiles(new String[] { "index.html" });
         webpages.addServlet(new ServletHolder(new SearchHolderServlet()), "/search/holders");
         webpages.addFilter(GzipFilter.class, "/*", EnumSet.of(DispatcherType.REQUEST));
 
         this.pluginApp = new PluginRestletApplication();
-        this.pluginHandler = createServletHandler(new RestletHttpServlet(this.pluginApp), "/ext/*");
+        this.pluginHandler = createServletHandler(new RestletHttpServlet(this.pluginApp), "/ext/*", null);
 
         this.legacyApp = new LegacyRestletApplication();
-        this.legacyHandler = createServletHandler(new RestletHttpServlet(this.legacyApp), "/legacy/*");
+        this.legacyHandler = createServletHandler(new RestletHttpServlet(this.legacyApp), "/legacy/*",
+                Needs.authenticated());
 
         // Add Static RESTlet Plugins
         PluginRestletApplication.attachRestPlugin(new VersionResource());
 
         // list the all the handlers mounted above
         Handler[] handlers = new Handler[] {pluginHandler, legacyHandler, dic2png, roiExtractor, dictags,
-                createServletHandler(new WelcomeServlet(), "/welcome"),
-                createServletHandler(new IndexerServlet(), "/indexer"), // DEPRECATED
-                createServletHandler(new SettingsServlet(), "/settings"), csvServletHolder,
-                createServletHandler(new LoginServlet(), "/login"),
-                createServletHandler(new LogoutServlet(), "/logout"),
-                createServletHandler(new UserServlet(), "/user/*"),
-                createServletHandler(new SearchServlet(), "/search"),
-                createServletHandler(new SearchServlet(SearchType.PATIENT), "/searchDIM"),
-                createServletHandler(new DumpServlet(), "/dump"),
+                createServletHandler(new WelcomeServlet(), "/welcome", null),
+                createServletHandler(new IndexerServlet(), "/indexer", Needs.authenticated()), // DEPRECATED
+                createServletHandler(new SettingsServlet(), "/settings", Needs.authenticated()), csvServletHolder,
+                createServletHandler(new LoginServlet(), "/login", null),
+                createServletHandler(new LogoutServlet(), "/logout", null),
+                createServletHandler(new UserServlet(), "/user/*", Needs.admin()),
+                createServletHandler(new SearchServlet(), "/search", Needs.authenticated()),
+                createServletHandler(new SearchServlet(SearchType.PATIENT), "/searchDIM", Needs.authenticated()),
+                createServletHandler(new DumpServlet(), "/dump", Needs.authenticated()),
                 createServletHandler(new IndexerSettingsServlet(IndexerSettingsServlet.SettingsType.path),
-                        "/management/settings/index/path"),
+                        "/management/settings/index/path", Needs.admin()),
                 createServletHandler(new IndexerSettingsServlet(IndexerSettingsServlet.SettingsType.zip),
-                        "/management/settings/index/zip"),
+                        "/management/settings/index/zip", Needs.admin()),
                 createServletHandler(new IndexerSettingsServlet(IndexerSettingsServlet.SettingsType.effort),
-                        "/management/settings/index/effort"),
+                        "/management/settings/index/effort", Needs.admin()),
                 createServletHandler(new IndexerSettingsServlet(IndexerSettingsServlet.SettingsType.thumbnail),
-                        "/management/settings/index/thumbnail"),
+                        "/management/settings/index/thumbnail", Needs.admin()),
                 createServletHandler(new IndexerSettingsServlet(IndexerSettingsServlet.SettingsType.watcher),
-                        "/management/settings/index/watcher"),
+                        "/management/settings/index/watcher", Needs.admin()),
                 createServletHandler(new IndexerSettingsServlet(IndexerSettingsServlet.SettingsType.thumbnailSize),
-                        "/management/settings/index/thumbnail/size"),
+                        "/management/settings/index/thumbnail/size", Needs.admin()),
                 createServletHandler(new IndexerSettingsServlet(IndexerSettingsServlet.SettingsType.all),
-                        "/management/settings/index"),
-                createServletHandler(new TransferOptionsServlet(), "/management/settings/transfer"),
-                createServletHandler(new WadoServlet(), "/wado"),
-                createServletHandler(new ProvidersServlet(), "/providers"),
-                createServletHandler(new DicomQuerySettingsServlet(), "/management/settings/dicom/query"),
-                createServletHandler(new DimTagsServlet(TagsStruct.getInstance()), "/management/settings/dicom/tags"),
-                createServletHandler(new ForceIndexing(), "/management/tasks/index"),
-                createServletHandler(new UnindexServlet(), "/management/tasks/unindex"),
-                createServletHandler(new RemoveServlet(), "/management/tasks/remove"),
+                        "/management/settings/index", Needs.admin()),
+                createServletHandler(new TransferOptionsServlet(), "/management/settings/transfer", Needs.admin()),
+                createServletHandler(new WadoServlet(), "/wado", Needs.authenticated()),
+                createServletHandler(new ProvidersServlet(), "/providers", Needs.authenticated()),
+                createServletHandler(new DicomQuerySettingsServlet(), "/management/settings/dicom/query",
+                        Needs.admin()),
+                createServletHandler(new DimTagsServlet(TagsStruct.getInstance()), "/management/settings/dicom/tags",
+                        Needs.admin()),
+                createServletHandler(new ForceIndexing(), "/management/tasks/index", Needs.admin()),
+                createServletHandler(new UnindexServlet(), "/management/tasks/unindex", Needs.admin()),
+                createServletHandler(new RemoveServlet(), "/management/tasks/remove", Needs.admin()),
                 createServletHandler(new ServicesServlet(ServicesServlet.ServiceType.STORAGE),
-                        "/management/dicom/storage"),
-                createServletHandler(new ServicesServlet(ServicesServlet.ServiceType.QUERY), "/management/dicom/query"),
-                createServletHandler(new AETitleServlet(), "/management/settings/dicom"),
-                createServletHandler(new PluginsServlet(), "/plugins/*"),
-                createServletHandler(new PresetsServlet(), "/presets/*"),
-                createServletHandler(new WebUIServlet(), "/webui"), createWebUIModuleServletHandler(),
-                createServletHandler(new LoggerServlet(), "/logger"),
-                createServletHandler(new RunningTasksServlet(), "/index/task"),
-                createServletHandler(new ExportServlet(ExportType.EXPORT_CVS), "/export/cvs"),
-                createServletHandler(new ExportServlet(ExportType.LIST), "/export/list"),
-                createServletHandler(new ServerStorageServlet(), "/management/settings/storage/dicom"),
+                        "/management/dicom/storage", Needs.admin()),
+                createServletHandler(new ServicesServlet(ServicesServlet.ServiceType.QUERY), "/management/dicom/query",
+                        Needs.admin()),
+                createServletHandler(new AETitleServlet(), "/management/settings/dicom", Needs.admin()),
+                createServletHandler(new PluginsServlet(), "/plugins/*", Needs.admin()),
+                createServletHandler(new PresetsServlet(), "/presets/*", Needs.authenticated()),
+                createServletHandler(new WebUIServlet(), "/webui", Needs.authenticated()),
+                createWebUIModuleServletHandler(),
+                createServletHandler(new LoggerServlet(), "/logger", Needs.admin()),
+                createServletHandler(new RunningTasksServlet(), "/index/task", Needs.admin()),
+                createServletHandler(new ExportServlet(ExportType.EXPORT_CVS), "/export/cvs", Needs.authenticated()),
+                createServletHandler(new ExportServlet(ExportType.LIST), "/export/list", Needs.authenticated()),
+                createServletHandler(new ServerStorageServlet(), "/management/settings/storage/dicom", Needs.admin()),
 
                 // ml provider servlets
-                createServletHandler(new DatastoreServlet(), "/ml/datastore"),
-                createServletHandler(new InferServlet(), "/ml/infer/single"),
-                createServletHandler(new BulkInferServlet(), "/ml/infer/bulk"),
-                createServletHandler(new TrainServlet(), "/ml/train"),
-                createServletHandler(new ListAllModelsServlet(), "/ml/model/list"),
-                createServletHandler(new ModelinfoServlet(), "/ml/model/info"),
-                createServletHandler(new CacheServlet(), "/ml/cache"),
-                createServletHandler(new ImplementedMethodsServlet(), "/ml/provider/methods"), webpages};
+                createServletHandler(new DatastoreServlet(), "/ml/datastore", Needs.authenticated()),
+                createServletHandler(new InferServlet(), "/ml/infer/single", Needs.authenticated()),
+                createServletHandler(new BulkInferServlet(), "/ml/infer/bulk", Needs.authenticated()),
+                createServletHandler(new TrainServlet(), "/ml/train", Needs.authenticated()),
+                createServletHandler(new ListAllModelsServlet(), "/ml/model/list", Needs.authenticated()),
+                createServletHandler(new ModelinfoServlet(), "/ml/model/info", Needs.authenticated()),
+                createServletHandler(new CacheServlet(), "/ml/cache", Needs.authenticated()),
+                createServletHandler(new ImplementedMethodsServlet(), "/ml/provider/methods", Needs.authenticated()),
+                webpages };
 
         // setup the server
         server = new Server(socketAddr);
@@ -277,12 +286,15 @@ public class DicoogleWeb {
     }
 
     private ServletContextHandler createWebUIModuleServletHandler() {
-        ServletContextHandler handler = new ServletContextHandler(ServletContextHandler.SESSIONS); // servlet with session support enabled
+        // servlet with session support enabled
+        ServletContextHandler handler = new ServletContextHandler(ServletContextHandler.SESSIONS);
         handler.setContextPath(CONTEXTPATH);
 
         HttpServlet servletModule = new WebUIModuleServlet();
         // CORS support
         this.addCORSFilter(handler);
+        // require being logged in
+        this.addAuthFilter(handler, false, null);
         // Caching!
         FilterHolder cacheHolder = new FilterHolder(new AbstractCacheFilter() {
             @Override
@@ -307,18 +319,46 @@ public class DicoogleWeb {
                 }
             }
         });
-        cacheHolder.setInitParameter(AbstractCacheFilter.CACHE_CONTROL_PARAM, "private, max-age=2592000"); // cache for 30 days
+        // cache for 30 days
+        cacheHolder.setInitParameter(AbstractCacheFilter.CACHE_CONTROL_PARAM, "private, max-age=2592000");
         handler.addFilter(cacheHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
         handler.addServlet(new ServletHolder(servletModule), "/webui/module/*");
         return handler;
     }
 
-    private ServletContextHandler createServletHandler(HttpServlet servlet, String path) {
-        ServletContextHandler handler = new ServletContextHandler(ServletContextHandler.SESSIONS); // servlet with session support enabled
+    static class Needs {
+        final boolean admin;
+        final String role;
+
+        Needs(boolean admin, String role) {
+            this.admin = admin;
+            this.role = role;
+        }
+
+        public static Needs admin() {
+            return new Needs(true, null);
+        }
+
+        public static Needs role(String role) {
+            return new Needs(false, role);
+        }
+
+        public static Needs authenticated() {
+            return new Needs(false, null);
+        }
+    }
+
+    private ServletContextHandler createServletHandler(HttpServlet servlet, String path, Needs needs) {
+        // servlet with session support enabled
+        ServletContextHandler handler = new ServletContextHandler(ServletContextHandler.SESSIONS);
         handler.setContextPath(CONTEXTPATH);
 
         // CORS support
         this.addCORSFilter(handler);
+
+        if (this.authorizationEnabled && needs != null) {
+            this.addAuthFilter(handler, needs.admin, needs.role);
+        }
 
         handler.addServlet(new ServletHolder(servlet), path);
         return handler;
@@ -357,6 +397,15 @@ public class DicoogleWeb {
                 addCORSFilter(h);
             }
         }
+    }
+
+    private void addAuthFilter(ServletContextHandler handler, boolean needsAdmin, String needsRole) {
+        FilterHolder authHolder = new FilterHolder(AuthenticatedFilter.class);
+        authHolder.setInitParameter(AuthenticatedFilter.NEEDS_ADMIN_PARAM, Boolean.toString(needsAdmin));
+        if (needsRole != null) {
+            authHolder.setInitParameter(AuthenticatedFilter.NEEDS_ROLE_PARAM, needsRole);
+        }
+        handler.addFilter(authHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
     }
 
     /**

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/DicoogleWeb.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/DicoogleWeb.java
@@ -22,6 +22,7 @@ import pt.ua.dicoogle.core.settings.ServerSettingsManager;
 import pt.ua.dicoogle.plugins.PluginController;
 import pt.ua.dicoogle.plugins.webui.WebUIPlugin;
 import pt.ua.dicoogle.sdk.utils.TagsStruct;
+import pt.ua.dicoogle.server.web.auth.AuthenticatedFilter;
 import pt.ua.dicoogle.server.web.rest.VersionResource;
 import pt.ua.dicoogle.server.web.servlets.*;
 import pt.ua.dicoogle.server.web.servlets.plugins.PluginsServlet;
@@ -109,8 +110,11 @@ public class DicoogleWeb {
     public static final String CONTEXTPATH = "/";
     private LocalImageCache cache = null;
     private Server server = null;
-    /** Whether access to services is protected with authorization:
-     * There has to be a valid Dicoogle session token in the `Authorization` header.
+    /**
+     * Whether access to services is protected with authorization:
+     * There has to be a valid Dicoogle session token in the request.
+     * @see {@link pt.ua.dicoogle.server.web.auth.Authentication}
+     * @see {@link pa.ua.dicoogle.server.web.auth.AuthenticatedFilter}
      */
     private boolean authorizationEnabled = true;
 
@@ -122,6 +126,7 @@ public class DicoogleWeb {
 
     /**
      * Initializes and starts the Dicoogle Web service.
+     *
      * @param socketAddr the server binding socket address
      * @throws java.lang.Exception
      */

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/auth/AuthenticatedFilter.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/auth/AuthenticatedFilter.java
@@ -16,10 +16,8 @@
  * You should have received a copy of the GNU General Public License
  * along with Dicoogle.  If not, see <http://www.gnu.org/licenses/>.
  */
-/**
- */
 
-package pt.ua.dicoogle.server.web;
+package pt.ua.dicoogle.server.web.auth;
 
 import java.io.IOException;
 import javax.servlet.Filter;
@@ -28,20 +26,59 @@ import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import pt.ua.dicoogle.server.users.Role;
 import pt.ua.dicoogle.server.users.User;
-import pt.ua.dicoogle.server.web.auth.Authentication;
 
-/** Servlet filter to ensure that the user is logged in
- * (has a valid session token in `Authorization`).
+/**
+ * Servlet filter to ensure that the user is logged in
+ * (has a valid session token).
+ *
+ * <p>
+ * Authentication tokens are created upon login.
+ * A Dicoogle user can provide an authentication token
+ * through one of these mechanisms:
+ * </p>
+ *
+ * <ul>
+ * <li><code>Authorization</code> header with the token as the value,
+ * optionally prefixed with "Dicoogle " or "Bearer ";
+ * <li>Or a cookie named <code>DICOOGLE_SESSION</code>
+ * with the token as the value.
+ * </ul>
+ *
+ * <p>
+ * Before Dicoogle 3.6.0, only the <code>Authorization</code> header
+ * with the token as the value was supported.
+ * </p>
  */
 public class AuthenticatedFilter implements Filter {
 
+    /**
+     * Name of the filter configuration parameter for
+     * whether the user needs to be admin
+     */
     public static final String NEEDS_ADMIN_PARAM = "needsAdmin";
+    /**
+     * Name of the filter configuration parameter for
+     * whether the user needs to have a specific role
+     */
     public static final String NEEDS_ROLE_PARAM = "needsRole";
+
+    /** Name of the servlet request parameter
+     * containing the authenticated user object,
+     * if the request is successfully authenticated.
+     */
+    public static final String USER_ATTRIBUTE = "dicoogleUser";
+
+    /**
+     * The name of the Dicoogle session cookie,
+     * where the authentication token can be stored.
+     */
+    public static final String DICOOGLE_SESSION_COOKIE_NAME = "DICOOGLE_SESSION";
 
     /** Whether the user needs to be an admin */
     private boolean needsAdmin = false;
@@ -75,7 +112,7 @@ public class AuthenticatedFilter implements Filter {
 
         if (sreq instanceof HttpServletRequest) {
             HttpServletRequest req = (HttpServletRequest) sreq;
-            String token = req.getHeader("Authorization");
+            String token = getTokenFromRequest(req);
 
             // Authorization header must have a Dicoogle session token
             if (token == null) {
@@ -103,9 +140,71 @@ public class AuthenticatedFilter implements Filter {
                 return;
             }
 
-            // OK
+            // OK, inject user attribute and continue
+            sreq.setAttribute(USER_ATTRIBUTE, user);
         }
         fc.doFilter(sreq, sresp);
+    }
+
+    /**
+     * Helper function to retrieve the Dicoogle user authentication token.
+     *
+     * Servlets can call {@link Authentication#getAuthenticatedUser}
+     * to retrieve the authenticated user when this filter is installed as a middleware,
+     * as requests that pass the filter will already have the authenticated user object
+     * injected as a request attribute.
+     * When not using this filter,
+     * prefer using this method over inspecting the request directly,
+     * as it supports more ways in which
+     * the token is sent by the client (see also #223).
+     *
+     * @param req the HTTP request to retrieve the token from
+     * @return the token string, or null if no token is present
+     */
+    public static String getTokenFromRequest(HttpServletRequest req) {
+        // prefer the Authorization header
+        String token = req.getHeader("Authorization");
+        if (token != null) {
+            if (token.startsWith("Dicoogle ") || token.startsWith("dicoogle ")) {
+                token = token.substring("dicoogle ".length());
+            } else if (token.startsWith("Bearer ") || token.startsWith("bearer ")) {
+                token = token.substring("bearer ".length());
+            }
+            if (!token.isEmpty()) {
+                return token;
+            }
+        }
+
+        // if not found, look for the DICOOGLE_SESSION cookie
+        if (req.getCookies() != null) {
+            for (Cookie cookie : req.getCookies()) {
+                if (DICOOGLE_SESSION_COOKIE_NAME.equals(cookie.getName())) {
+                    String cookieValue = cookie.getValue();
+                    if (!cookieValue.isEmpty()) {
+                        return cookieValue;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Helper function to retrieve the Dicoogle user authentication token.
+     *
+     * Prefer using this over inspecting the request directly,
+     * as it supports more ways in which
+     * the token is sent by the client (see also #223).
+     *
+     * @param req the HTTP request to retrieve the token from
+     * @return the token string, or null if no token is present
+     */
+    public static String getTokenFromRequest(ServletRequest req) {
+        if (req instanceof HttpServletRequest) {
+            return getTokenFromRequest((HttpServletRequest) req);
+        }
+        return null;
     }
 
     private static void unauthorized(ServletResponse resp) throws IOException {
@@ -123,6 +222,7 @@ public class AuthenticatedFilter implements Filter {
     }
 
     @Override
-    public void destroy() {}
+    public void destroy() {
+    }
 
 }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/auth/AuthenticatedFilter.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/auth/AuthenticatedFilter.java
@@ -114,7 +114,7 @@ public class AuthenticatedFilter implements Filter {
             HttpServletRequest req = (HttpServletRequest) sreq;
             String token = getTokenFromRequest(req);
 
-            // Authorization header must have a Dicoogle session token
+            // A Dicoogle session token must be found in order to continue
             if (token == null) {
                 unauthorized(sresp);
                 return;
@@ -149,12 +149,14 @@ public class AuthenticatedFilter implements Filter {
     /**
      * Helper function to retrieve the Dicoogle user authentication token.
      *
-     * Servlets can call {@link Authentication#getAuthenticatedUser}
-     * to retrieve the authenticated user when this filter is installed as a middleware,
-     * as requests that pass the filter will already have the authenticated user object
-     * injected as a request attribute.
-     * When not using this filter,
-     * prefer using this method over inspecting the request directly,
+     * Note that servlets can call {@link Authentication#getAuthenticatedUser}
+     * to retrieve the authenticated user.
+     * This filter will ensure that the user object
+     * is injected as an attribute in the servlet request in advance,
+     * so that subsequent calls will not repeat the process.
+     *
+     * This method is only necessary if retrieving the token itself is important.
+     * In such cases, prefer using this method over inspecting the request directly,
      * as it supports more ways in which
      * the token is sent by the client (see also #223).
      *

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/auth/Authentication.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/auth/Authentication.java
@@ -59,9 +59,32 @@ public class Authentication {
         return instance;
     }
 
-    /** Obtain the user object of the user logged in */
+    /** Obtain the user object of the user logged in according to the given request.
+     *
+     * If the servlet request object already contains the user in attribute `USER_ATTRIBUTE`,
+     * the same object is returned.
+     *
+     * Otherwise, the user is obtained from the session token provided in the request.
+     */
     public User getAuthenticatedUser(ServletRequest request) {
-        return (User) request.getAttribute(AuthenticatedFilter.USER_ATTRIBUTE);
+        User user = (User) request.getAttribute(AuthenticatedFilter.USER_ATTRIBUTE);
+        if (user != null) {
+            return user;
+        }
+
+        String token = AuthenticatedFilter.getTokenFromRequest(request);
+        if (token == null) {
+            return null;
+        }
+
+        user = Authentication.getInstance().getUsername(token);
+
+        // save the user for future use
+        if (user != null) {
+            request.setAttribute(AuthenticatedFilter.USER_ATTRIBUTE, user);
+        }
+
+        return user;
     }
 
     /** Obtain the user object of the user associated with

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/auth/Authentication.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/auth/Authentication.java
@@ -24,6 +24,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import javax.servlet.ServletRequest;
+
 /**
  * Provides login routines for users.
  *
@@ -57,7 +59,14 @@ public class Authentication {
         return instance;
     }
 
+    /** Obtain the user object of the user logged in */
+    public User getAuthenticatedUser(ServletRequest request) {
+        return (User) request.getAttribute(AuthenticatedFilter.USER_ATTRIBUTE);
+    }
 
+    /** Obtain the user object of the user associated with
+     * the given session token
+     */
     public User getUsername(String token) {
         String user = tokenUsers.get(token);
         if (user == null)

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/accounts/LoginServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/accounts/LoginServlet.java
@@ -22,6 +22,7 @@ package pt.ua.dicoogle.server.web.servlets.accounts;
 import java.io.IOException;
 
 import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -31,6 +32,7 @@ import net.sf.json.JSONObject;
 import pt.ua.dicoogle.server.users.Role;
 import pt.ua.dicoogle.server.users.User;
 import pt.ua.dicoogle.server.users.UsersStruct;
+import pt.ua.dicoogle.server.web.auth.AuthenticatedFilter;
 import pt.ua.dicoogle.server.web.auth.Authentication;
 import pt.ua.dicoogle.server.web.auth.LoggedIn;
 import pt.ua.dicoogle.server.web.auth.LoggedInStatus;
@@ -68,6 +70,10 @@ public class LoginServlet extends HttpServlet {
         }
         json_resp.put("token", mLoggedIn.getToken());
 
+        // Add session cookie
+        Cookie cookie = new Cookie(AuthenticatedFilter.DICOOGLE_SESSION_COOKIE_NAME, mLoggedIn.getToken());
+        resp.addCookie(cookie);
+
         // Set response content type
         resp.setContentType("application/json");
 
@@ -78,9 +84,7 @@ public class LoginServlet extends HttpServlet {
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
 
-        String token = req.getHeader("Authorization");
-        User user = Authentication.getInstance().getUsername(token);
-
+        User user = Authentication.getInstance().getAuthenticatedUser(req);
         if (user == null) {
             resp.sendError(401);
             return;

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/accounts/LoginServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/accounts/LoginServlet.java
@@ -84,7 +84,15 @@ public class LoginServlet extends HttpServlet {
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
 
-        User user = Authentication.getInstance().getAuthenticatedUser(req);
+        // Find authenticated user
+        User user = null;
+        // Fetch token from request,
+        // as this servlet is not filtered by AuthenticatedFilter
+        String token = AuthenticatedFilter.getTokenFromRequest(req);
+        if (token != null) {
+            user = Authentication.getInstance().getUsername(token);
+        }
+
         if (user == null) {
             resp.sendError(401);
             return;

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/accounts/LoginServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/accounts/LoginServlet.java
@@ -72,6 +72,7 @@ public class LoginServlet extends HttpServlet {
 
         // Add session cookie
         Cookie cookie = new Cookie(AuthenticatedFilter.DICOOGLE_SESSION_COOKIE_NAME, mLoggedIn.getToken());
+        cookie.setHttpOnly(true);
         resp.addCookie(cookie);
 
         // Set response content type
@@ -85,13 +86,7 @@ public class LoginServlet extends HttpServlet {
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
 
         // Find authenticated user
-        User user = null;
-        // Fetch token from request,
-        // as this servlet is not filtered by AuthenticatedFilter
-        String token = AuthenticatedFilter.getTokenFromRequest(req);
-        if (token != null) {
-            user = Authentication.getInstance().getUsername(token);
-        }
+        User user = Authentication.getInstance().getAuthenticatedUser(req);
 
         if (user == null) {
             resp.sendError(401);

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/accounts/LogoutServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/accounts/LogoutServlet.java
@@ -21,9 +21,12 @@ package pt.ua.dicoogle.server.web.servlets.accounts;
 
 import java.io.IOException;
 import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import pt.ua.dicoogle.server.web.auth.AuthenticatedFilter;
 import pt.ua.dicoogle.server.web.auth.Authentication;
 import pt.ua.dicoogle.server.web.auth.Session;
 import pt.ua.dicoogle.server.web.utils.ResponseUtil;
@@ -34,8 +37,6 @@ import pt.ua.dicoogle.server.web.utils.ResponseUtil;
  */
 public class LogoutServlet extends HttpServlet {
 
-    private static final String TOKEN_HEADERNAME = "Authorization";
-
     @Deprecated
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
@@ -45,11 +46,15 @@ public class LogoutServlet extends HttpServlet {
     @Override
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
         boolean logout = Session.logout(req);
-        String token = req.getHeader(TOKEN_HEADERNAME);
-        if (token != null && !token.equals("")) {
+        String token = AuthenticatedFilter.getTokenFromRequest(req);
+        if (token != null && !token.isEmpty()) {
             Authentication.getInstance().logout(token);
         }
+        // delete existing session cookie
+        Cookie cookie = new Cookie(AuthenticatedFilter.DICOOGLE_SESSION_COOKIE_NAME, "");
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+        resp.addCookie(cookie);
         ResponseUtil.simpleResponse(resp, "success", logout);
     }
-
 }

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/accounts/LogoutServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/accounts/LogoutServlet.java
@@ -52,7 +52,7 @@ public class LogoutServlet extends HttpServlet {
         }
         // delete existing session cookie
         Cookie cookie = new Cookie(AuthenticatedFilter.DICOOGLE_SESSION_COOKIE_NAME, "");
-        cookie.setPath("/");
+        cookie.setHttpOnly(true);
         cookie.setMaxAge(0);
         resp.addCookie(cookie);
         ResponseUtil.simpleResponse(resp, "success", logout);

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/search/PresetsServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/search/PresetsServlet.java
@@ -46,8 +46,7 @@ public class PresetsServlet extends HttpServlet {
 
     @Override
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        String token = req.getHeader("Authorization");
-        User user = Authentication.getInstance().getUsername(token);
+        User user = Authentication.getInstance().getAuthenticatedUser(req);
         if (user == null) {
             ResponseUtil.sendError(resp, 401, "Unauthorized access to this user.");
             return;
@@ -81,8 +80,7 @@ public class PresetsServlet extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        String token = req.getHeader("Authorization");
-        User user = Authentication.getInstance().getUsername(token);
+        User user = Authentication.getInstance().getAuthenticatedUser(req);
         if (user == null) {
             ResponseUtil.sendError(resp, 401, "Unauthorized access to this user.");
             return;

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/webui/WebUIServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/webui/WebUIServlet.java
@@ -82,8 +82,7 @@ public class WebUIServlet extends HttpServlet {
 
     /** Retrieve plugins. */
     private String getPluginsBySlot(HttpServletRequest req, String... slotIds) throws IOException {
-        String token = req.getHeader("Authorization");
-        User user = Authentication.getInstance().getUsername(token);
+        User user = Authentication.getInstance().getAuthenticatedUser(req);
 
         Collection<WebUIPlugin> plugins = PluginController.getInstance().getWebUIPlugins(slotIds);
         List<String> pkgList = new ArrayList<>(plugins.size());

--- a/dicoogle/src/test/java/pt/ua/dicoogle/core/plugins/PlatformInterfaceMock.java
+++ b/dicoogle/src/test/java/pt/ua/dicoogle/core/plugins/PlatformInterfaceMock.java
@@ -164,4 +164,14 @@ public class PlatformInterfaceMock implements DicooglePlatformInterface {
     public StorageInterface getStorageForSchema(String scheme) {
         return null;
     }
+
+    @Override
+    public pt.ua.dicoogle.sdk.datastructs.DicoogleUser getUser(String token) {
+        return null;
+    }
+
+    @Override
+    public pt.ua.dicoogle.sdk.datastructs.DicoogleUser getUser(org.eclipse.jetty.server.Request request) {
+        return null;
+    }
 }

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/core/DicooglePlatformInterface.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/core/DicooglePlatformInterface.java
@@ -27,6 +27,7 @@ import pt.ua.dicoogle.sdk.IndexerInterface;
 import pt.ua.dicoogle.sdk.QueryInterface;
 import pt.ua.dicoogle.sdk.StorageInputStream;
 import pt.ua.dicoogle.sdk.StorageInterface;
+import pt.ua.dicoogle.sdk.datastructs.DicoogleUser;
 import pt.ua.dicoogle.sdk.datastructs.Report;
 import pt.ua.dicoogle.sdk.datastructs.SearchResult;
 import pt.ua.dicoogle.sdk.datastructs.UnindexReport;
@@ -254,4 +255,18 @@ public interface DicooglePlatformInterface {
      * @return an object for read-only access to the settings
      */
     ServerSettingsReader getSettings();
+
+    /** Retrieve the user authenticated in the given request.
+     *
+     * @param token a dicoogle user session token
+     * @return a user descriptor, or {@code null} if the request is not authenticated
+     */
+    DicoogleUser getUser(String token);
+
+    /** Retrieve the user authenticated in the given request.
+     *
+     * @param request a servlet request
+     * @return a user descriptor, or {@code null} if the request is not authenticated
+     */
+    DicoogleUser getUser(org.eclipse.jetty.server.Request request);
 }

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/DicoogleUser.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/datastructs/DicoogleUser.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (C) 2014  Universidade de Aveiro, DETI/IEETA, Bioinformatics Group - http://bioinformatics.ua.pt/
+ *
+ * This file is part of Dicoogle/dicoogle-sdk.
+ *
+ * Dicoogle/dicoogle-sdk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Dicoogle/dicoogle-sdk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Dicoogle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package pt.ua.dicoogle.sdk.datastructs;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Simple descriptor for a Dicoogle user,
+ * agnostic from authentication method and source.
+ */
+public final class DicoogleUser {
+    private final String username;
+    private final boolean admin;
+    private final Set<String> roles;
+
+    /** Constructs a Dicoogle user record from its parts. */
+    public DicoogleUser(String username, boolean admin, Set<String> roles) {
+        this.username = username;
+        this.admin = admin;
+        this.roles = roles != null ? Collections.unmodifiableSet(roles) : Collections.emptySet();
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public boolean isAdmin() {
+        return admin;
+    }
+
+    public Set<String> getRoles() {
+        return roles;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(username, admin, roles);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        DicoogleUser other = (DicoogleUser) obj;
+        return Objects.equals(username, other.username) && admin == other.admin && Objects.equals(roles, other.roles);
+    }
+
+    @Override
+    public String toString() {
+        return "DicoogleUser [username=" + username + ", admin=" + admin + ", roles=" + roles + "]";
+    }
+}

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/settings/server/ServerSettings.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/settings/server/ServerSettings.java
@@ -49,6 +49,9 @@ public interface ServerSettings extends ServerSettingsReader {
     interface WebServer extends ServiceBase, ServerSettingsReader.WebServer {
         @JsonProperty("allowed-origins")
         void setAllowedOrigins(String allowedOrigins);
+
+        @JsonProperty("allow-unauthorized")
+        void setAllowUnauthorized(boolean allowUnauthorized);
     }
 
     @Override

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/settings/server/ServerSettingsReader.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/settings/server/ServerSettingsReader.java
@@ -21,6 +21,7 @@ package pt.ua.dicoogle.sdk.settings.server;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import pt.ua.dicoogle.sdk.datastructs.AdditionalSOPClass;
@@ -62,6 +63,14 @@ public interface ServerSettingsReader {
 
         @JsonGetter("allowed-origins")
         String getAllowedOrigins();
+
+        /** If true, authorization in the Dicoogle web API is disabled,
+         * which allows access to all services without logging in to Dicoogle.
+         *
+         * Use with caution, as this effectively disables all safeguards.
+         */
+        @JsonProperty("allow-unauthorized")
+        boolean isAllowUnauthorized();
     }
 
     @JsonGetter("web-server")


### PR DESCRIPTION
Should resolve #98 for Dicoogle core services. Security of services in extensions still needs to be upheld by each plugin.

### Summary

- Add another mechanism to stay logged in using a cookie
   - `DICOOGLE_SESSION` is automatically provided on login and is looked up when the `Authorization` header is not found.
- Require to be logged in for most core Dicoogle services
   - Web service extensions via plugins are not included here
   - Require user logged in to be an admin in management related operations
- Add server setting "allow-unauthorized"
   - If `true`, access control is disabled like in dicoogle<=3.5.0
   - A warning is displayed when starting the web server with this flag enabled
- Extend Dicoogle platform interface so that plugins can know that a user is authenticated

### Pending issues

- [x] Requests to `webui/module` and `/dic2png` (for the thumbnails) in the webapp do not have the authentication token at the moment, so they will always fail.
   - Resolved by setting a session cookie.
- [x] Errors in user presets, likely a regression in another PR.
   - Fixed in #738
