### PR TITLE
Adjust WebUIPluginManager and WebUIPluginTest for test reliability

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/plugins/webui/WebUIPluginManager.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/plugins/webui/WebUIPluginManager.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
@@ -133,8 +134,10 @@ public class WebUIPluginManager {
     }
 
     public WebUIPlugin load(File directory) throws IOException, PluginFormatException {
-        assert directory != null;
-        assert directory.isDirectory();
+        Objects.requireNonNull(directory);
+        if (!directory.isDirectory()) {
+            throw new IllegalArgumentException("Web UI plugin base `" + directory + "` is not a directory");
+        }
         final String dirname = directory.getCanonicalPath();
         Path packageJSON = directory.toPath().resolve("package.json");
         String packageJSONTxt = IOUtils.toString(Files.newInputStream(packageJSON), StandardCharsets.UTF_8);

--- a/dicoogle/src/test/java/pt/ua/dicoogle/webui/WebUIPluginTest.java
+++ b/dicoogle/src/test/java/pt/ua/dicoogle/webui/WebUIPluginTest.java
@@ -43,9 +43,19 @@ public class WebUIPluginTest {
     public void testLoadPlugin1() throws IOException, PluginFormatException {
         WebUIPluginManager webui = new WebUIPluginManager();
 
+        // try to resolve the path to the test1 plugin directory
+        // in two different ways
         String test1Path =
                 WebUIPluginTest.class.getClassLoader().getResource("pt/ua/dicoogle/webui/WebPlugins/test1").getFile();
-        webui.load(new File(test1Path));
+        File test1Dir = new File(test1Path);
+        if (!test1Dir.isDirectory()) {
+            test1Dir = new File("./src/test/resources/pt/ua/dicoogle/webui/WebPlugins/test1");
+            if (!test1Dir.exists()) {
+                fail("Failed pre-condition: test plugin directory not found in " + test1Path);
+            }
+        }
+
+        webui.load(test1Dir);
 
         WebUIPlugin plugin = webui.get("test1");
         assertNotNull(plugin);


### PR DESCRIPTION
We have encountered an odd scenario where the JDK would try to retrieve the web UI plugin directory incorrectly in the tests, resulting in false positives. This form should be more resilient.

### Summary

- Replace `assert`s with hard checks which throw exceptions in `WebUIPluginManager#load`
- Tweak test1 dir resource retrieval in `WebUIPluginTest#loadTest1`, adding a fallback to webui plugin path resolution
