### PR TITLE
Integrate dicoogle-next UI 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "dicoogle/src/main/resources/dicoogle-next"]
+	path = dicoogle/src/main/resources/dicoogle-next
+	url = git@github.com:dicoogle/dicoogle-next.git
+	branch = main

--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ Brief Documentation
 
       After running a query, the result browser shows up, giving the user an intuitive hierarchical view of the results. On this page, there is also an Export button, which is used in order to export the query results into a CSV file. When the export button is clicked, the user has to select which tags (s)he wants to export in the CSV file. This selection is heavily assisted by the interface, on which the user may type an incomplete tag and have presented the available candidates that match the inserted term. Moreover, the text box allows users to copy a list of tags directly from another CSV file, enabling an easier generation of reports.
 
+    - Using dicoogle-next interface
+
+      Dicoogle now features **dicoogle-next**, a web application that runs alongside the current gebapp. This interface offers a refreshed design and updated workflows.
+      You can access this interface by navigating to the `/experimental` path on your server (e.g., `http://localhost:8080/experimental`).
+
 #### Using the Web Services
 
   Let us assume that the Web Services for our instance of Dicoogle are running in https://demo.dicoogle.com/
@@ -150,6 +155,19 @@ Before building, please make sure that your system contains the following tools:
  - Maven 3;
 
  1. Retrieve the full source code from this repository: `git clone https://github.com/bioinformatics-ua/dicoogle.git`
+
+- Note
+  - Initialize the dicoogle-next submodule:
+
+```bash
+    git submodule update --init
+```
+
+- Update the submodule to fetch the latest version of the dicoogle-next web application:
+
+```bash
+    git submodule update --remote --recursive
+```
  2. Navigate to the project's base directory, and build the parent Maven project by calling `mvn install`.
     - Note: this will build the web application using an embedded version of Node.js and npm. To skip building the webapp: `mvn install -Dskip.installnodenpm -Dskip.npm`
  3. The resulting jar file can be found in "./dicoogle/target".

--- a/README.md
+++ b/README.md
@@ -85,8 +85,52 @@ Brief Documentation
 
     - Using dicoogle-next interface
 
-      Dicoogle now features **dicoogle-next**, a web application that runs alongside the current gebapp. This interface offers a refreshed design and updated workflows.
+      Dicoogle now features **dicoogle-next**, a web application that runs alongside the current webapp. This interface offers a refreshed design and updated workflows.
       You can access this interface by navigating to the `/experimental` path on your server (e.g., `http://localhost:8080/experimental`).
+
+      The integrated Filesystem Manager is optional and disabled by default. Use `--fs` (or `--filesystem`, `-fs`) to enable it.
+      You may optionally provide a config file path in either of these forms:
+
+      - `-fs=<file>`
+
+      Examples:
+
+      ```bash
+      java -jar dicoogle.jar -fs # starts the filesystem manager with default /home and C: allowed roots
+      java -jar dicoogle.jar -fs=/opt/dicoogle/paths.txt 
+      java -jar dicoogle.jar -fs=/opt/dicoogle/filesystem.config.json
+      java -jar dicoogle.jar -fs=/opt/dicoogle/filesystem.config.json
+      ```
+
+      The config file can be either JSON (recommended) or a plain text path list.
+
+      JSON example (`filesystem.config.json`):
+
+      ```json
+      {
+        "allowedRoots": [
+          "/home",
+          "~/Documents",
+          "~/Downloads",
+          "C:\\",
+          "D:\\"
+        ]
+      }
+      ```
+
+      Plain text example (`paths.txt`, one path per line):
+
+      ```text
+      /home
+      ~/Documents
+      ~/Downloads
+      /mnt/dicom
+      ```
+
+      Notes:
+      - JSON files are passed to the filesystem server through `FILESYSTEM_CONFIG_PATH`.
+      - Plain text files are converted into `FILESYSTEM_ALLOWED_ROOTS`.
+      - Non-existent paths are ignored and logged by the filesystem server.
 
 #### Using the Web Services
 
@@ -218,4 +262,3 @@ Project leaders
 
 * Carlos Costa and José Luis Oliveira (UA.PT Bioinformatics, scientific advisors)
 * Luís Bastião (BMD software - development)
-

--- a/README.md
+++ b/README.md
@@ -85,52 +85,8 @@ Brief Documentation
 
     - Using dicoogle-next interface
 
-      Dicoogle now features **dicoogle-next**, a web application that runs alongside the current webapp. This interface offers a refreshed design and updated workflows.
+      Dicoogle now features **dicoogle-next**, a web application that runs alongside the current gebapp. This interface offers a refreshed design and updated workflows.
       You can access this interface by navigating to the `/experimental` path on your server (e.g., `http://localhost:8080/experimental`).
-
-      The integrated Filesystem Manager is optional and disabled by default. Use `--fs` (or `--filesystem`, `-fs`) to enable it.
-      You may optionally provide a config file path in either of these forms:
-
-      - `-fs=<file>`
-
-      Examples:
-
-      ```bash
-      java -jar dicoogle.jar -fs # starts the filesystem manager with default /home and C: allowed roots
-      java -jar dicoogle.jar -fs=/opt/dicoogle/paths.txt 
-      java -jar dicoogle.jar -fs=/opt/dicoogle/filesystem.config.json
-      java -jar dicoogle.jar -fs=/opt/dicoogle/filesystem.config.json
-      ```
-
-      The config file can be either JSON (recommended) or a plain text path list.
-
-      JSON example (`filesystem.config.json`):
-
-      ```json
-      {
-        "allowedRoots": [
-          "/home",
-          "~/Documents",
-          "~/Downloads",
-          "C:\\",
-          "D:\\"
-        ]
-      }
-      ```
-
-      Plain text example (`paths.txt`, one path per line):
-
-      ```text
-      /home
-      ~/Documents
-      ~/Downloads
-      /mnt/dicom
-      ```
-
-      Notes:
-      - JSON files are passed to the filesystem server through `FILESYSTEM_CONFIG_PATH`.
-      - Plain text files are converted into `FILESYSTEM_ALLOWED_ROOTS`.
-      - Non-existent paths are ignored and logged by the filesystem server.
 
 #### Using the Web Services
 
@@ -262,3 +218,4 @@ Project leaders
 
 * Carlos Costa and José Luis Oliveira (UA.PT Bioinformatics, scientific advisors)
 * Luís Bastião (BMD software - development)
+

--- a/dicoogle/pom.xml
+++ b/dicoogle/pom.xml
@@ -327,21 +327,27 @@
                 <artifactId>frontend-maven-plugin</artifactId>
                 <version>1.15.0</version>
                 <executions>
+                    <!-- Install Node and NPM -->
                     <execution>
                         <id>install node and npm experimental</id>
-                        <goals><goal>install-node-and-npm</goal></goals>
+                        <goals>
+                            <goal>install-node-and-npm</goal>
+                        </goals>
                         <phase>generate-resources</phase>
                         <configuration>
-                            <nodeVersion>v24.14.1</nodeVersion> 
+                            <nodeVersion>v24.14.1</nodeVersion>
                             <npmVersion>11.11.0</npmVersion>
                             <installDirectory>target</installDirectory>
                             <workingDirectory>src/main/resources/dicoogle-next/webapp</workingDirectory>
                         </configuration>
                     </execution>
                     
+                    <!-- Install dependencies -->
                     <execution>
                         <id>npm install experimental</id>
-                        <goals><goal>npm</goal></goals>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
                         <phase>generate-resources</phase>
                         <configuration>
                             <workingDirectory>src/main/resources/dicoogle-next/webapp</workingDirectory>
@@ -349,23 +355,16 @@
                         </configuration>
                     </execution>
                     
+                    <!-- Build webapp -->
                     <execution>
                         <id>npm run build experimental</id>
-                        <goals><goal>npm</goal></goals>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
                         <phase>generate-resources</phase>
                         <configuration>
                             <workingDirectory>src/main/resources/dicoogle-next/webapp</workingDirectory>
                             <arguments>run build</arguments>
-                        </configuration>
-                    </execution>
-
-                    <execution>
-                        <id>build filesystem binary</id>
-                        <goals><goal>npm</goal></goals>
-                        <phase>generate-resources</phase>
-                        <configuration>
-                            <workingDirectory>src/main/resources/dicoogle-next/webapp</workingDirectory>
-                            <arguments>run build:fs</arguments>
                         </configuration>
                     </execution>
                 </executions>

--- a/dicoogle/pom.xml
+++ b/dicoogle/pom.xml
@@ -86,19 +86,19 @@
                     <include>webapp/dist/**</include>
                     <include>webapp/index.html</include>
                     <!-- dicoogle-next -->
-                    <include>dicoogle-next/dist/**</include>
+                    <include>dicoogle-next/webapp/dist/**</include>
                 </includes>
                 <excludes>
                     <exclude>META-INF/*.SF</exclude>
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>
                 <!-- Exclude dicoogle-next source files (only include dist) -->
-                    <exclude>dicoogle-next/src/**</exclude>
-                    <exclude>dicoogle-next/node_modules/**</exclude>
-                    <exclude>dicoogle-next/vite-plugins/**</exclude>
-                    <exclude>dicoogle-next/docs/**</exclude>
-                    <exclude>dicoogle-next/*.json</exclude>
-                    <exclude>dicoogle-next/*.ts</exclude>
+                    <exclude>dicoogle-next/webapp/src/**</exclude>
+                    <exclude>dicoogle-next/webapp/node_modules/**</exclude>
+                    <exclude>dicoogle-next/webapp/vite-plugins/**</exclude>
+                    <exclude>dicoogle-next/webapp/docs/**</exclude>
+                    <exclude>dicoogle-next/webapp/*.json</exclude>
+                    <exclude>dicoogle-next/webapp/*.ts</exclude>
                 </excludes>
             </resource>
 
@@ -338,7 +338,7 @@
                             <nodeVersion>v20.11.0</nodeVersion>
                             <npmVersion>10.2.4</npmVersion>
                             <installDirectory>target</installDirectory>
-                            <workingDirectory>src/main/resources/dicoogle-next</workingDirectory>
+                            <workingDirectory>src/main/resources/dicoogle-next/webapp</workingDirectory>
                         </configuration>
                     </execution>
                     
@@ -350,7 +350,7 @@
                         </goals>
                         <phase>generate-resources</phase>
                         <configuration>
-                            <workingDirectory>src/main/resources/dicoogle-next</workingDirectory>
+                            <workingDirectory>src/main/resources/dicoogle-next/webapp</workingDirectory>
                             <arguments>install --no-audit</arguments>
                         </configuration>
                     </execution>
@@ -363,7 +363,7 @@
                         </goals>
                         <phase>generate-resources</phase>
                         <configuration>
-                            <workingDirectory>src/main/resources/dicoogle-next</workingDirectory>
+                            <workingDirectory>src/main/resources/dicoogle-next/webapp</workingDirectory>
                             <arguments>run build</arguments>
                         </configuration>
                     </execution>

--- a/dicoogle/pom.xml
+++ b/dicoogle/pom.xml
@@ -85,11 +85,20 @@
                     <include>webapp/css/**</include>
                     <include>webapp/dist/**</include>
                     <include>webapp/index.html</include>
+                    <!-- dicoogle-next -->
+                    <include>dicoogle-next/dist/**</include>
                 </includes>
                 <excludes>
                     <exclude>META-INF/*.SF</exclude>
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>
+                <!-- Exclude dicoogle-next source files (only include dist) -->
+                    <exclude>dicoogle-next/src/**</exclude>
+                    <exclude>dicoogle-next/node_modules/**</exclude>
+                    <exclude>dicoogle-next/vite-plugins/**</exclude>
+                    <exclude>dicoogle-next/docs/**</exclude>
+                    <exclude>dicoogle-next/*.json</exclude>
+                    <exclude>dicoogle-next/*.ts</exclude>
                 </excludes>
             </resource>
 
@@ -310,6 +319,55 @@
                     <!-- Defining webapp directory -->
                     <workingDirectory>src/main/resources/webapp</workingDirectory>
                 </configuration>
+            </plugin>
+
+            <!-- Experimental Webapp (dicoogle-next) -->
+            <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <version>1.15.0</version>
+                <executions>
+                    <!-- Install Node and NPM -->
+                    <execution>
+                        <id>install node and npm experimental</id>
+                        <goals>
+                            <goal>install-node-and-npm</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <nodeVersion>v20.11.0</nodeVersion>
+                            <npmVersion>10.2.4</npmVersion>
+                            <installDirectory>target</installDirectory>
+                            <workingDirectory>src/main/resources/dicoogle-next</workingDirectory>
+                        </configuration>
+                    </execution>
+                    
+                    <!-- Install dependencies -->
+                    <execution>
+                        <id>npm install experimental</id>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <workingDirectory>src/main/resources/dicoogle-next</workingDirectory>
+                            <arguments>install --no-audit</arguments>
+                        </configuration>
+                    </execution>
+                    
+                    <!-- Build webapp -->
+                    <execution>
+                        <id>npm run build experimental</id>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <workingDirectory>src/main/resources/dicoogle-next</workingDirectory>
+                            <arguments>run build</arguments>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/dicoogle/pom.xml
+++ b/dicoogle/pom.xml
@@ -313,8 +313,8 @@
 
                 </executions>
                 <configuration>
-                    <nodeVersion>v18.17.1</nodeVersion>
-                    <npmVersion>9.6.7</npmVersion>
+                    <nodeVersion>v24.14.1</nodeVersion>
+                    <npmVersion>11.11.0</npmVersion>
                     <installDirectory>target</installDirectory>
                     <!-- Defining webapp directory -->
                     <workingDirectory>src/main/resources/webapp</workingDirectory>
@@ -335,8 +335,8 @@
                         </goals>
                         <phase>generate-resources</phase>
                         <configuration>
-                            <nodeVersion>v20.11.0</nodeVersion>
-                            <npmVersion>10.2.4</npmVersion>
+                            <nodeVersion>v24.14.1</nodeVersion>
+                            <npmVersion>11.11.0</npmVersion>
                             <installDirectory>target</installDirectory>
                             <workingDirectory>src/main/resources/dicoogle-next/webapp</workingDirectory>
                         </configuration>

--- a/dicoogle/pom.xml
+++ b/dicoogle/pom.xml
@@ -327,27 +327,21 @@
                 <artifactId>frontend-maven-plugin</artifactId>
                 <version>1.15.0</version>
                 <executions>
-                    <!-- Install Node and NPM -->
                     <execution>
                         <id>install node and npm experimental</id>
-                        <goals>
-                            <goal>install-node-and-npm</goal>
-                        </goals>
+                        <goals><goal>install-node-and-npm</goal></goals>
                         <phase>generate-resources</phase>
                         <configuration>
-                            <nodeVersion>v24.14.1</nodeVersion>
+                            <nodeVersion>v24.14.1</nodeVersion> 
                             <npmVersion>11.11.0</npmVersion>
                             <installDirectory>target</installDirectory>
                             <workingDirectory>src/main/resources/dicoogle-next/webapp</workingDirectory>
                         </configuration>
                     </execution>
                     
-                    <!-- Install dependencies -->
                     <execution>
                         <id>npm install experimental</id>
-                        <goals>
-                            <goal>npm</goal>
-                        </goals>
+                        <goals><goal>npm</goal></goals>
                         <phase>generate-resources</phase>
                         <configuration>
                             <workingDirectory>src/main/resources/dicoogle-next/webapp</workingDirectory>
@@ -355,16 +349,23 @@
                         </configuration>
                     </execution>
                     
-                    <!-- Build webapp -->
                     <execution>
                         <id>npm run build experimental</id>
-                        <goals>
-                            <goal>npm</goal>
-                        </goals>
+                        <goals><goal>npm</goal></goals>
                         <phase>generate-resources</phase>
                         <configuration>
                             <workingDirectory>src/main/resources/dicoogle-next/webapp</workingDirectory>
                             <arguments>run build</arguments>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>build filesystem binary</id>
+                        <goals><goal>npm</goal></goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <workingDirectory>src/main/resources/dicoogle-next/webapp</workingDirectory>
+                            <arguments>run build:fs</arguments>
                         </configuration>
                     </execution>
                 </executions>

--- a/dicoogle/src/main/java/pt/ua/dicoogle/Main.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/Main.java
@@ -41,6 +41,12 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
+import java.io.InputStream;
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.util.Map;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.Files;
 
 /**
  * Main class for Dicoogle
@@ -51,6 +57,8 @@ import java.net.UnknownHostException;
  */
 public class Main {
     private static final Logger logger = LoggerFactory.getLogger(Main.class);
+    private static Process fsServerProcess = null;
+
 
     /**
      * Starts the graphical user interface for Dicoogle
@@ -87,14 +95,17 @@ public class Main {
                 System.out.println();
                 System.out.println(" -s : Start the server");
                 System.out.println(" -w : Start the server and load web application in default browser (default)");
+                System.out.println(" --fs[=<file>] : Enable filesystem manager (optional config file path)");
             } else {
                 System.out.println("Wrong arguments!");
                 System.out.println();
                 System.out.println("Dicoogle PACS");
                 System.out.println("-s : Start the server");
                 System.out.println("-w : Start the server and load web application in default browser (default)");
+                System.out.println("--fs[=<file>] : Enable filesystem manager (optional config file path)");
             }
         }
+        startFileSystemManager(args);
         // Register System Exceptions Hook
         ExceptionHandler.registerExceptionHandler();
     }
@@ -201,4 +212,154 @@ public class Main {
             }
         }));
     }
+
+    private static void startFileSystemManager(String[] args) {
+        boolean enabled = false;
+        String configPath = null;
+
+        for (int i = 0; i < args.length; i++) {
+            String arg = args[i];
+
+            if ("--fs".equals(arg) || "--filesystem".equals(arg) || "-fs".equals(arg)) {
+                enabled = true;
+                if (i + 1 < args.length && !args[i + 1].startsWith("-")) {
+                    configPath = args[++i];
+                }
+                continue;
+            }
+
+            if (arg.startsWith("--fs=") || arg.startsWith("--filesystem=") || arg.startsWith("-fs=")) {
+                enabled = true;
+                configPath = arg.substring(arg.indexOf('=') + 1).trim();
+                continue;
+            }
+        }
+
+        if (!enabled) {
+            logger.info("Filesystem Manager disabled. Use --fs to enable it.");
+            return;
+        }
+
+        try {
+            String os = System.getProperty("os.name").toLowerCase();
+            String binaryName;
+            String extension = "";
+
+            if (os.contains("win")) {
+                binaryName = "fs-server-bundle-win.exe";
+                extension = ".exe";
+            } else if (os.contains("mac")) {
+                binaryName = "fs-server-bundle-macos";
+            } else {
+                binaryName = "fs-server-bundle-linux";
+            }
+
+            // 1. Read binary from the JAR
+            InputStream in = Main.class.getResourceAsStream("/dicoogle-next/webapp/dist/bin/" + binaryName);
+            if (in == null) {
+                logger.error("Could not find filesystem server binary in JAR: {}", binaryName);
+                return;
+            }
+
+            File tempBin = File.createTempFile("fs-server-", extension);
+            tempBin.deleteOnExit(); // Ensure it cleans up when Java exits
+            Files.copy(in, tempBin.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            tempBin.setExecutable(true);
+
+            // 3. Start the process
+            logger.info("Starting Next Filesystem Manager from {}", tempBin.getAbsolutePath());
+            ProcessBuilder pb = new ProcessBuilder(tempBin.getAbsolutePath());
+
+            // Pass the port environment variable
+            Map<String, String> env = pb.environment();
+            env.put("FILESYSTEM_SERVER_PORT", "3333");
+            env.put("NODE_ENV", "production");
+            applyFsConfigToEnvironment(env, configPath);
+
+            // Inherit IO so you can see console.log outputs from the JS file in your Java console!
+            pb.inheritIO();
+
+            fsServerProcess = pb.start();
+
+            // 4. Add a shutdown hook to kill the Node.js process when Dicoogle is closed
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                if (fsServerProcess != null && fsServerProcess.isAlive()) {
+                    logger.info("Stopping Filesystem Manager Server...");
+                    fsServerProcess.destroy();
+                }
+            }));
+
+        } catch (Exception e) {
+            logger.error("Failed to start embedded FileSystem Manager", e);
+        }
+    }
+
+    private static void applyFsConfigToEnvironment(Map<String, String> env, String fsConfigPath) {
+        if (fsConfigPath == null || fsConfigPath.trim().isEmpty()) {
+            return;
+        }
+
+        File configFile = new File(fsConfigPath.trim());
+
+        if (!configFile.exists() || !configFile.isFile()) {
+            logger.warn("Filesystem config file not found: {}", configFile.getAbsolutePath());
+            return;
+        }
+
+        String fileName = configFile.getName().toLowerCase();
+        if (fileName.endsWith(".json") || fileName.contains(".json.") || looksLikeJsonConfig(configFile)) {
+            env.put("FILESYSTEM_CONFIG_PATH", configFile.getAbsolutePath());
+            logger.info("Using filesystem JSON config: {}", configFile.getAbsolutePath());
+            return;
+        }
+
+        String allowedRoots = readAllowedRootsList(configFile);
+        if (!allowedRoots.isEmpty()) {
+            env.put("FILESYSTEM_ALLOWED_ROOTS", allowedRoots);
+            logger.info("Using filesystem roots list from {}", configFile.getAbsolutePath());
+        } else {
+            logger.warn("Filesystem roots file is empty: {}", configFile.getAbsolutePath());
+        }
+    }
+
+    private static String readAllowedRootsList(File file) {
+        StringBuilder roots = new StringBuilder();
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                String value = line.trim();
+                if (value.isEmpty()) {
+                    continue;
+                }
+
+                if (roots.length() > 0) {
+                    roots.append(';');
+                }
+                roots.append(value);
+            }
+        } catch (IOException ex) {
+            logger.warn("Failed to read filesystem roots file {}: {}", file.getAbsolutePath(), ex.getMessage());
+            return "";
+        }
+
+        return roots.toString();
+    }
+
+    private static boolean looksLikeJsonConfig(File file) {
+        try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                String value = line.trim();
+                if (value.isEmpty()) {
+                    continue;
+                }
+                return value.startsWith("{") || value.startsWith("[");
+            }
+        } catch (IOException ex) {
+            logger.warn("Failed to inspect filesystem config file {}: {}", file.getAbsolutePath(), ex.getMessage());
+        }
+        return false;
+    }
 }
+

--- a/dicoogle/src/main/java/pt/ua/dicoogle/Main.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/Main.java
@@ -41,12 +41,6 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
-import java.io.InputStream;
-import java.io.BufferedReader;
-import java.io.FileReader;
-import java.util.Map;
-import java.nio.file.StandardCopyOption;
-import java.nio.file.Files;
 
 /**
  * Main class for Dicoogle
@@ -57,8 +51,6 @@ import java.nio.file.Files;
  */
 public class Main {
     private static final Logger logger = LoggerFactory.getLogger(Main.class);
-    private static Process fsServerProcess = null;
-
 
     /**
      * Starts the graphical user interface for Dicoogle
@@ -95,17 +87,14 @@ public class Main {
                 System.out.println();
                 System.out.println(" -s : Start the server");
                 System.out.println(" -w : Start the server and load web application in default browser (default)");
-                System.out.println(" --fs[=<file>] : Enable filesystem manager (optional config file path)");
             } else {
                 System.out.println("Wrong arguments!");
                 System.out.println();
                 System.out.println("Dicoogle PACS");
                 System.out.println("-s : Start the server");
                 System.out.println("-w : Start the server and load web application in default browser (default)");
-                System.out.println("--fs[=<file>] : Enable filesystem manager (optional config file path)");
             }
         }
-        startFileSystemManager(args);
         // Register System Exceptions Hook
         ExceptionHandler.registerExceptionHandler();
     }
@@ -212,154 +201,4 @@ public class Main {
             }
         }));
     }
-
-    private static void startFileSystemManager(String[] args) {
-        boolean enabled = false;
-        String configPath = null;
-
-        for (int i = 0; i < args.length; i++) {
-            String arg = args[i];
-
-            if ("--fs".equals(arg) || "--filesystem".equals(arg) || "-fs".equals(arg)) {
-                enabled = true;
-                if (i + 1 < args.length && !args[i + 1].startsWith("-")) {
-                    configPath = args[++i];
-                }
-                continue;
-            }
-
-            if (arg.startsWith("--fs=") || arg.startsWith("--filesystem=") || arg.startsWith("-fs=")) {
-                enabled = true;
-                configPath = arg.substring(arg.indexOf('=') + 1).trim();
-                continue;
-            }
-        }
-
-        if (!enabled) {
-            logger.info("Filesystem Manager disabled. Use --fs to enable it.");
-            return;
-        }
-
-        try {
-            String os = System.getProperty("os.name").toLowerCase();
-            String binaryName;
-            String extension = "";
-
-            if (os.contains("win")) {
-                binaryName = "fs-server-bundle-win.exe";
-                extension = ".exe";
-            } else if (os.contains("mac")) {
-                binaryName = "fs-server-bundle-macos";
-            } else {
-                binaryName = "fs-server-bundle-linux";
-            }
-
-            // 1. Read binary from the JAR
-            InputStream in = Main.class.getResourceAsStream("/dicoogle-next/webapp/dist/bin/" + binaryName);
-            if (in == null) {
-                logger.error("Could not find filesystem server binary in JAR: {}", binaryName);
-                return;
-            }
-
-            File tempBin = File.createTempFile("fs-server-", extension);
-            tempBin.deleteOnExit(); // Ensure it cleans up when Java exits
-            Files.copy(in, tempBin.toPath(), StandardCopyOption.REPLACE_EXISTING);
-            tempBin.setExecutable(true);
-
-            // 3. Start the process
-            logger.info("Starting Next Filesystem Manager from {}", tempBin.getAbsolutePath());
-            ProcessBuilder pb = new ProcessBuilder(tempBin.getAbsolutePath());
-
-            // Pass the port environment variable
-            Map<String, String> env = pb.environment();
-            env.put("FILESYSTEM_SERVER_PORT", "3333");
-            env.put("NODE_ENV", "production");
-            applyFsConfigToEnvironment(env, configPath);
-
-            // Inherit IO so you can see console.log outputs from the JS file in your Java console!
-            pb.inheritIO();
-
-            fsServerProcess = pb.start();
-
-            // 4. Add a shutdown hook to kill the Node.js process when Dicoogle is closed
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-                if (fsServerProcess != null && fsServerProcess.isAlive()) {
-                    logger.info("Stopping Filesystem Manager Server...");
-                    fsServerProcess.destroy();
-                }
-            }));
-
-        } catch (Exception e) {
-            logger.error("Failed to start embedded FileSystem Manager", e);
-        }
-    }
-
-    private static void applyFsConfigToEnvironment(Map<String, String> env, String fsConfigPath) {
-        if (fsConfigPath == null || fsConfigPath.trim().isEmpty()) {
-            return;
-        }
-
-        File configFile = new File(fsConfigPath.trim());
-
-        if (!configFile.exists() || !configFile.isFile()) {
-            logger.warn("Filesystem config file not found: {}", configFile.getAbsolutePath());
-            return;
-        }
-
-        String fileName = configFile.getName().toLowerCase();
-        if (fileName.endsWith(".json") || fileName.contains(".json.") || looksLikeJsonConfig(configFile)) {
-            env.put("FILESYSTEM_CONFIG_PATH", configFile.getAbsolutePath());
-            logger.info("Using filesystem JSON config: {}", configFile.getAbsolutePath());
-            return;
-        }
-
-        String allowedRoots = readAllowedRootsList(configFile);
-        if (!allowedRoots.isEmpty()) {
-            env.put("FILESYSTEM_ALLOWED_ROOTS", allowedRoots);
-            logger.info("Using filesystem roots list from {}", configFile.getAbsolutePath());
-        } else {
-            logger.warn("Filesystem roots file is empty: {}", configFile.getAbsolutePath());
-        }
-    }
-
-    private static String readAllowedRootsList(File file) {
-        StringBuilder roots = new StringBuilder();
-
-        try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
-            String line;
-            while ((line = reader.readLine()) != null) {
-                String value = line.trim();
-                if (value.isEmpty()) {
-                    continue;
-                }
-
-                if (roots.length() > 0) {
-                    roots.append(';');
-                }
-                roots.append(value);
-            }
-        } catch (IOException ex) {
-            logger.warn("Failed to read filesystem roots file {}: {}", file.getAbsolutePath(), ex.getMessage());
-            return "";
-        }
-
-        return roots.toString();
-    }
-
-    private static boolean looksLikeJsonConfig(File file) {
-        try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
-            String line;
-            while ((line = reader.readLine()) != null) {
-                String value = line.trim();
-                if (value.isEmpty()) {
-                    continue;
-                }
-                return value.startsWith("{") || value.startsWith("[");
-            }
-        } catch (IOException ex) {
-            logger.warn("Failed to inspect filesystem config file {}: {}", file.getAbsolutePath(), ex.getMessage());
-        }
-        return false;
-    }
 }
-

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/DicoogleWeb.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/DicoogleWeb.java
@@ -88,6 +88,7 @@ import pt.ua.dicoogle.server.web.servlets.webui.WebUIServlet;
 import pt.ua.dicoogle.server.web.utils.LocalImageCache;
 import pt.ua.dicoogle.server.PluginRestletApplication;
 import pt.ua.dicoogle.server.web.utils.SimpleImageRetriever;
+import pt.ua.dicoogle.server.web.servlets.DicoogleNextWebAppServlet;
 
 /**
  * @author António Novo <antonio.novo@ua.pt>
@@ -216,6 +217,7 @@ public class DicoogleWeb {
                 createServletHandler(new PluginsServlet(), "/plugins/*"),
                 createServletHandler(new PresetsServlet(), "/presets/*"),
                 createServletHandler(new WebUIServlet(), "/webui"), createWebUIModuleServletHandler(),
+                createServletHandler(new DicoogleNextWebAppServlet(), "/experimental/*"),
                 createServletHandler(new LoggerServlet(), "/logger"),
                 createServletHandler(new RunningTasksServlet(), "/index/task"),
                 createServletHandler(new ExportServlet(ExportType.EXPORT_CVS), "/export/cvs"),

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/DicoogleNextWebAppServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/DicoogleNextWebAppServlet.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (C) 2014  Universidade de Aveiro, DETI/IEETA, Bioinformatics Group - http://bioinformatics.ua.pt/
+ *
+ * This file is part of Dicoogle/dicoogle.
+ *
+ * Dicoogle/dicoogle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Dicoogle/dicoogle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Dicoogle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pt.ua.dicoogle.server.web.servlets;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * Servlet to serve the experimental dicoogle-next webapp
+ */
+public class DicoogleNextWebAppServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+
+        String path = req.getPathInfo();
+
+        // Default to index.html for root and client-side routing
+        if (path == null || path.equals("/")) {
+            path = "/index.html";
+        }
+
+        // Try to serve from /dicoogle-next/dist/ first
+        String resourcePath = "/dicoogle-next/dist" + path;
+        InputStream is = getClass().getResourceAsStream(resourcePath);
+
+        // If it's a file request (has extension) and not found, it's a 404
+        // If it's a route (no extension), fallback to index.html for SPA routing
+        if (is == null) {
+            if (path.contains(".")) {
+                // File not found
+                resp.sendError(HttpServletResponse.SC_NOT_FOUND);
+                return;
+            } else {
+                // Fallback to index.html for client-side routing
+                resourcePath = "/dicoogle-next/dist/index.html";
+                is = getClass().getResourceAsStream(resourcePath);
+            }
+        }
+
+        if (is == null) {
+            resp.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+
+        // Set content type
+        String contentType = getServletContext().getMimeType(path);
+        if (contentType == null) {
+            if (path.endsWith(".js")) {
+                contentType = "application/javascript";
+            } else if (path.endsWith(".css")) {
+                contentType = "text/css";
+            } else if (path.endsWith(".html")) {
+                contentType = "text/html";
+            } else if (path.endsWith(".json")) {
+                contentType = "application/json";
+            } else if (path.endsWith(".svg")) {
+                contentType = "image/svg+xml";
+            } else if (path.endsWith(".png")) {
+                contentType = "image/png";
+            } else if (path.endsWith(".jpg") || path.endsWith(".jpeg")) {
+                contentType = "image/jpeg";
+            } else if (path.endsWith(".ico")) {
+                contentType = "image/x-icon";
+            } else if (path.endsWith(".woff") || path.endsWith(".woff2")) {
+                contentType = "font/woff2";
+            }
+        }
+
+        if (contentType != null) {
+            resp.setContentType(contentType);
+        }
+
+        // Cache assets
+        if (path.contains("/assets/") || path.endsWith(".png") || path.endsWith(".jpg") || path.endsWith(".svg")
+                || path.endsWith(".ico")) {
+            resp.setHeader("Cache-Control", "public, max-age=31536000, immutable");
+        }
+
+        // Stream response
+        try (InputStream in = is; OutputStream out = resp.getOutputStream()) {
+            byte[] buffer = new byte[8192];
+            int bytesRead;
+            while ((bytesRead = in.read(buffer)) != -1) {
+                out.write(buffer, 0, bytesRead);
+            }
+        }
+    }
+}

--- a/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/DicoogleNextWebAppServlet.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/server/web/servlets/DicoogleNextWebAppServlet.java
@@ -19,13 +19,16 @@
 
 package pt.ua.dicoogle.server.web.servlets;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+
+import org.apache.commons.io.IOUtils;
 
 /**
  * Servlet to serve the experimental dicoogle-next webapp
@@ -42,8 +45,8 @@ public class DicoogleNextWebAppServlet extends HttpServlet {
             path = "/index.html";
         }
 
-        // Try to serve from /dicoogle-next/dist/ first
-        String resourcePath = "/dicoogle-next/dist" + path;
+        // Try to serve from /dicoogle-next/webapp/dist/ first
+        String resourcePath = "/dicoogle-next/webapp/dist" + path;
         InputStream is = getClass().getResourceAsStream(resourcePath);
 
         // If it's a file request (has extension) and not found, it's a 404
@@ -55,7 +58,7 @@ public class DicoogleNextWebAppServlet extends HttpServlet {
                 return;
             } else {
                 // Fallback to index.html for client-side routing
-                resourcePath = "/dicoogle-next/dist/index.html";
+                resourcePath = "/dicoogle-next/webapp/dist/index.html";
                 is = getClass().getResourceAsStream(resourcePath);
             }
         }
@@ -69,7 +72,7 @@ public class DicoogleNextWebAppServlet extends HttpServlet {
         String contentType = getServletContext().getMimeType(path);
         if (contentType == null) {
             if (path.endsWith(".js")) {
-                contentType = "application/javascript";
+                contentType = "text/javascript";
             } else if (path.endsWith(".css")) {
                 contentType = "text/css";
             } else if (path.endsWith(".html")) {
@@ -101,11 +104,7 @@ public class DicoogleNextWebAppServlet extends HttpServlet {
 
         // Stream response
         try (InputStream in = is; OutputStream out = resp.getOutputStream()) {
-            byte[] buffer = new byte[8192];
-            int bytesRead;
-            while ((bytesRead = in.read(buffer)) != -1) {
-                out.write(buffer, 0, bytesRead);
-            }
+            IOUtils.copy(in, out);
         }
     }
 }


### PR DESCRIPTION
## Description
This PR integrates the new **dicoogle-next web application** accessible via a dedicated Servlet under the `/experimental` path. 

## Summary
* Added a new `DicoogleNextWebAppServlet.java` servlet mapped to `/experimental/*` to serve the new UI.
* Included the [dicoogle-next](https://github.com/dicoogle/dicoogle-next) repository as a submodule.
* Modified `pom.xml` and `DicoogleWeb.java` to accomodate the build and routing of the new UI alongside the current one.